### PR TITLE
Adjust node_id check logic

### DIFF
--- a/includes/hub/admin/class-woo.php
+++ b/includes/hub/admin/class-woo.php
@@ -158,7 +158,7 @@ abstract class Woo {
 			return null;
 		}
 		
-		if ( empty( $_GET['node_id'] ) && '0' !== $_GET['node_id'] ) { // zero is a valid value.
+		if ( ! isset( $_GET['node_id'] ) || ! is_numeric( $_GET['node_id'] ) ) { // zero is a valid value.
 			return null;
 		}
 		$query->query_vars['meta_query'][] = [


### PR DESCRIPTION
I think I've fixed this in a way that preserves the logic it was meant to have. 

Currently this line is throwing an undefined index error because if `$_GET['node_id']` is empty, then it will get the value of `$_GET['node_id']`, but of course `$_GET['node_id']` could be empty because it doesn't exist. :)