### PR TITLE
feat: bump limit of events pulled by nodes from to 2 to 20

### DIFF
--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -94,7 +94,7 @@ class Pull_Endpoint {
 				'id_greater_than'  => $last_processed_id,
 				'action_name_in'   => $actions,
 			],
-			20
+			defined( 'NEWSPACK_NETWORK_EVENTS_PULL_LIMIT' ) && is_numeric( NEWSPACK_NETWORK_EVENTS_PULL_LIMIT ) ? NEWSPACK_NETWORK_EVENTS_PULL_LIMIT : 20
 		);
 
 		Debugger::log( count( $events ) . ' events found' );

--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -94,7 +94,7 @@ class Pull_Endpoint {
 				'id_greater_than'  => $last_processed_id,
 				'action_name_in'   => $actions,
 			],
-			2
+			20
 		);
 
 		Debugger::log( count( $events ) . ' events found' );


### PR DESCRIPTION
Currently, each node runs a `newspack_network_pull_from_hub` cron job that pulls events from the Hub's log every 5 minutes. This job pulls a max of 2 events at a time, but this means that if there are more than 2 events accruing on the Hub's end every 5 minutes, this will create a delay and backlog in events to be pulled. Bumping this limit to 20 seems more reasonable in a production environment. But since this value might need to be tweaked up or down to accommodate different traffic or performance scenarios, this PR also allows for the limit to be set via a `NEWSPACK_NETWORK_EVENTS_PULL_LIMIT` constant so we can tweak it without updating code.