### PR TITLE
fix: failing CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,35 @@ version: 2.1
 orbs:
   newspack: newspack/newspack@1.4.4
 
+commands:
+  checkout_code:
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/
+
+jobs:
+  build:
+    docker:
+      - image: cimg/node:16.11.1
+    steps:
+      - checkout_code
+      - run:
+          name: Install dependencies
+          command: npm start
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project
+
 workflows:
   version: 2
   all:
     jobs:
-      - newspack/build
-      - newspack/build-distributable:
-          requires:
-            - newspack/build
-          archive-name: 'newspack-network'
-          filters:
-            branches:
-              only:
-                - master
+      - build
       - newspack/release:
           requires:
-            - newspack/build
+            - build
           filters:
             branches:
               only:

--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
 	"scripts": {
 		"cm": "git-cz",
 		"semantic-release": "newspack-scripts release --files=newspack-network.php",
-		"build": "newspack-scripts build",
-		"start": "npm ci && newspack-scripts watch",
-		"watch": "newspack-scripts watch",
-		"test": "newspack-scripts test",
+		"start": "composer install && npm ci",
 		"lint:php": "./vendor/bin/phpcs .",
 		"format:php": "./vendor/bin/phpcbf .",
 		"lint:php:staged": "./vendor/bin/phpcs",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"scripts": {
 		"cm": "git-cz",
 		"semantic-release": "newspack-scripts release --files=newspack-network.php",
-		"start": "composer install && npm ci",
+		"start": "npm ci",
 		"lint:php": "./vendor/bin/phpcs .",
 		"format:php": "./vendor/bin/phpcbf .",
 		"lint:php:staged": "./vendor/bin/phpcs",


### PR DESCRIPTION
Removes several JS-related NPM scripts and CI jobs that were failing because this repo contains no JS. To test, confirm that all jobs below complete.