### PR TITLE
feat(ads): support network targeting key-val

### DIFF
--- a/includes/class-gam.php
+++ b/includes/class-gam.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Newspack Ads GAM Integration.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+use Newspack_Ads\Providers\GAM\Api as GAM_API;
+use Newspack_Ads\Providers\GAM_Model;
+
+/**
+ * Integration class for Newspack Ads' GAM support.
+ */
+final class GAM {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'newspack_ads_setup_gam', [ __CLASS__, 'create_targeting_keys' ] );
+		add_action( 'save_post_' . Hub\Nodes::POST_TYPE_SLUG, [ __CLASS__, 'create_targeting_keys' ] );
+		add_filter( 'newspack_ads_ad_targeting', [ __CLASS__, 'add_targeting' ], 10, 2 );
+	}
+
+	/**
+	 * Create targeting keys.
+	 */
+	public static function create_targeting_keys() {
+		if ( ! Site_Role::is_hub() ) {
+			return;
+		}
+		if ( ! class_exists( 'Newspack_Ads\Providers\GAM_Model' ) ) {
+			return;
+		}
+		$api = GAM_Model::get_api();
+		if ( ! $api || is_wp_error( $api ) ) {
+			Debugger::log( 'Error adding GAM targeting keys: GAM API is not available.' );
+			return;
+		}
+		$nodes     = Hub\Nodes::get_all_nodes();
+		$node_urls = array_map(
+			function( $node ) {
+				return $node->get_url();
+			},
+			$nodes
+		);
+		$urls      = array_merge( [ \get_site_url() ], $node_urls );
+		$api->targeting_keys->create_targeting_key( 'site', $urls, 'PREDEFINED', 'CUSTOM_DIMENSION' );
+		Debugger::log( 'Updated GAM targeting keys.' );
+	}
+
+	/**
+	 * Add targeting.
+	 *
+	 * @param array $targeting Targeting.
+	 * @param array $ad_unit   Ad unit.
+	 *
+	 * @return array
+	 */
+	public static function add_targeting( $targeting, $ad_unit ) {
+		$targeting['site'] = \get_site_url();
+		return $targeting;
+	}
+}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -37,9 +37,10 @@ class Initializer {
 				Rest_Authenticaton::init_node_filters();
 			}
 		}
-		
+
 		Data_Listeners::init();
 		Reader_Roles_Filter::init();
+		GAM::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}


### PR DESCRIPTION
Implement support for custom targeting key-values integration with Newspack Ads.

The key-value is registered as type "pre-defined" and reportable type set to "custom dimension". The available values should be updated when saving a node or when GAM executes its setup.

### How to test

1. Check out this branch and https://github.com/Automattic/newspack-ads/pull/766
2. Set up Newspack Ads with GAM connection for the hub and their nodes
3. Visit your GAM dashboard, navigate to "Inventory -> Key Values" and confirm "site" was added and the values are set to the available nodes in the network (depending on the account used, you might also find other URLs from my own local testing)
4. Confirm the "Type" is set to "Predefined" and the "Reportable" is set to "Custom dimension"
5. Configure placements with ads and visit the front-end with GAM's debug tool by adding `?googfc` to the URL
6. Open targeting info and confirm you see the site URL as follows:
<img width="652" alt="image" src="https://github.com/Automattic/newspack-network/assets/820752/aaa3e6a0-f577-41da-84f5-1b60094a0036">
