### PR TITLE
Feat/distributor settings

### DIFF
--- a/includes/class-distributor-customizations.php
+++ b/includes/class-distributor-customizations.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Newspack Network Distributor Customizations.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+/**
+ * Class to initialize the customizations we do to the Distributor plugin
+ */
+class Distributor_Customizations {
+
+	/**
+	 * Initializes the customizations.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		Distributor_Customizations\Canonical_Url::init();
+	}
+
+
+}

--- a/includes/class-distributor-customizations.php
+++ b/includes/class-distributor-customizations.php
@@ -18,6 +18,7 @@ class Distributor_Customizations {
 	 * @return void
 	 */
 	public static function init() {
+		require_once NEWSPACK_NETWORK_PLUGIN_DIR . '/includes/distributor-customizations/global.php';
 		Distributor_Customizations\Canonical_Url::init();
 	}
 

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -33,13 +33,13 @@ class Initializer {
 			if ( Node\Settings::get_hub_url() ) {
 				Node\Webhook::init();
 				Node\Pulling::init();
-				Node\Canonical_Url::init();
 				Rest_Authenticaton::init_node_filters();
 			}
 		}
-		
+
 		Data_Listeners::init();
 		Reader_Roles_Filter::init();
+		Distributor_Customizations::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/distributor-customizations/README.md
+++ b/includes/distributor-customizations/README.md
@@ -1,3 +1,9 @@
 This folder holds the tweaks we do to the Distributor plugin.
 
 They are active in the Hub and in all Nodes of the network, either by default, or dependning on some option that is set on the Hub and propagated to the Nodes.
+
+# Global tweaks
+
+These are the changes we apply to Distributor in all sites:
+
+* Post publication date: When you push or pull a post, the publication date is kept in the target site, instead of updating it to the distribution date.

--- a/includes/distributor-customizations/README.md
+++ b/includes/distributor-customizations/README.md
@@ -1,0 +1,3 @@
+This folder holds the tweaks we do to the Distributor plugin.
+
+They are active in the Hub and in all Nodes of the network, either by default, or dependning on some option that is set on the Hub and propagated to the Nodes.

--- a/includes/distributor-customizations/class-canonical-url.php
+++ b/includes/distributor-customizations/class-canonical-url.php
@@ -5,7 +5,7 @@
  * @package Newspack
  */
 
-namespace Newspack_Network\Node;
+namespace Newspack_Network\Distributor_Customizations;
 
 use Newspack\Data_Events;
 
@@ -13,7 +13,7 @@ use Newspack\Data_Events;
  * Class to filter the Distributor Canonical URLs based on information received from the Hub.
  */
 class Canonical_Url {
-	
+
 	const OPTION_NAME = 'newspack_network_canonical_url';
 
 	/**

--- a/includes/distributor-customizations/global.php
+++ b/includes/distributor-customizations/global.php
@@ -16,8 +16,8 @@
 add_filter(
 	'dt_push_post_args',
 	function( $post_body, $post ) {
-		$post_body['post_date'] = $post->post_date;
-
+		$post_body['date']     = $post->post_date;
+		$post_body['date_gmt'] = $post->post_date_gmt;
 		return $post_body;
 	},
 	10,
@@ -31,9 +31,9 @@ add_filter(
 add_filter(
 	'dt_pull_post_args',
 	function( $post_array, $remote_id, $post ) {
-		$post_array['post_date'] = $post->post_date;
-
-		return $post_body;
+		$post_array['post_date']     = $post->post_date;
+		$post_array['post_date_gmt'] = $post->post_date_gmt;
+		return $post_array;
 	},
 	10,
 	3

--- a/includes/distributor-customizations/global.php
+++ b/includes/distributor-customizations/global.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This files contains the global tweaks that are loaded by default in every site in the Network (bot Hub and Nodes)
+ *
+ * @package newspack-network
+ */
+
+/**
+ * =========================================
+ * ======== Post publication date ==========
+ * =========================================
+ * Keep the publication date on the new pushed post.
+ *
+ * This filter is used to filter the arguments sent to the remote server during a push. The below code snippet passes the original published date to the new pushed post and sets the same published date instead of setting it as per the current time.
+ */
+add_filter(
+	'dt_push_post_args',
+	function( $post_body, $post ) {
+		$post_body['post_date'] = $post->post_date;
+
+		return $post_body;
+	},
+	10,
+	2
+);
+/**
+ * Keep the publication date on the new pulled post.
+ *
+ * This filter is used to filter the arguments sent to the remote server during a pull.
+ */
+add_filter(
+	'dt_pull_post_args',
+	function( $post_array, $remote_id, $post ) {
+		$post_array['post_date'] = $post->post_date;
+
+		return $post_body;
+	},
+	10,
+	3
+);
+/**
+ * =========================================
+ * ===== End of Post publication date ======
+ * =========================================
+ */

--- a/includes/hub/class-distributor-settings.php
+++ b/includes/hub/class-distributor-settings.php
@@ -20,7 +20,7 @@ class Distributor_Settings {
 	 * The setting section constant
 	 */
 	const SETTINGS_SECTION = 'newspack_hub_distributor_settings';
-	
+
 	/**
 	 * The admin page slug
 	 */
@@ -141,7 +141,7 @@ class Distributor_Settings {
 		$current = self::get_canonical_node();
 
 		Nodes::nodes_dropdown( $current, self::CANONICAL_NODE_OPTION_NAME, __( 'Default', 'newspack-network' ) );
-		
+
 		echo sprintf(
 			'<br/><small>%1$s</small>',
 			esc_html__( 'By default, canonical URLs will point to the site where the post was created. Modify this setting if you want them to point to one of the nodes.', 'newspack-network' )
@@ -162,7 +162,7 @@ class Distributor_Settings {
 		<div class='wrap'>
 			<?php settings_errors(); ?>
 			<form method='post' action='options.php'>
-			<?php 
+			<?php
 				do_settings_sections( self::PAGE_SLUG );
 				settings_fields( self::SETTINGS_SECTION );
 			?>
@@ -183,6 +183,11 @@ class Distributor_Settings {
 	 * @return array
 	 */
 	public static function dispatch_canonical_url_updated_event( $old_value, $value, $option ) {
+		if ( '0' === (string) $value ) {
+			return [
+				'url' => get_bloginfo( 'url' ),
+			];
+		}
 		$node     = new Node( $value );
 		$node_url = $node->get_url();
 		if ( ! $node_url ) {

--- a/includes/incoming-events/class-canonical-url-updated.php
+++ b/includes/incoming-events/class-canonical-url-updated.php
@@ -7,14 +7,14 @@
 
 namespace Newspack_Network\Incoming_Events;
 
-use Newspack_Network\Node\Canonical_Url;
+use Newspack_Network\Distributor_Customizations\Canonical_Url;
 
 /**
  * Class to handle the Canonical Url Updated Event
  *
  * This event is always sent from the Hub and received by Nodes.
  */
-class Canonical_Url_Updated extends Abstract_Incoming_Event {   
+class Canonical_Url_Updated extends Abstract_Incoming_Event {
 
 	/**
 	 * Process event in Node
@@ -22,9 +22,7 @@ class Canonical_Url_Updated extends Abstract_Incoming_Event {
 	 * @return void
 	 */
 	public function process_in_node() {
-		if ( ! empty( $this->get_data()->url ) ) {
-			update_option( Canonical_Url::OPTION_NAME, $this->get_data()->url );
-		}
+		update_option( Canonical_Url::OPTION_NAME, $this->get_data()->url );
 	}
 
 }


### PR DESCRIPTION
This PR does two things

* Changes where the Distributor customizations live

When we first implemented the "Canonical URL" option, we were only considering posts distributed from the Hub to the Nodes, so the filter was only being applied to the Nodes. With this change, this filter is also applied to the Hub.

No really need to test this, but if you want to give it a go, see the testing instructions in original pr ->  https://github.com/Automattic/newspack-network/pull/1 (add to the instructions pulling a post from the Nodes to the hub and confirming the change in the canonical url is also applied to the hub

I also fixed an issue that would prevent the selection of Hub or Default as the option for the canonical urls

* The main change of this PR -> Keep post published date

This was added as a global option, so it's on by default and there's no UI to remove the behavior.

Push a post from a site to another and confirm that the post publication date is kept from the original site (the default behavior of Distributor is to set the post publication date as the distribution date.

Do the same with a Pull.