### PR TITLE
feat: sync author bio and meta

### DIFF
--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -32,6 +32,7 @@ class Accepted_Actions {
 		'newspack_node_order_changed'        => 'Order_Changed',
 		'newspack_node_subscription_changed' => 'Subscription_Changed',
 		'canonical_url_updated'              => 'Canonical_Url_Updated',
+		'network_author_updated'             => 'Author_Updated',
 	];
 
 	/**
@@ -44,5 +45,6 @@ class Accepted_Actions {
 	const ACTIONS_THAT_NODES_PULL = [
 		'reader_registered',
 		'canonical_url_updated',
+		'network_author_updated',
 	];
 }

--- a/includes/class-author-update-watcher.php
+++ b/includes/class-author-update-watcher.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Newspack Network watcher for updates on authors' information
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+/**
+ * Class to handle the plugin admin pages
+ */
+class Author_Update_Watcher {
+
+	/**
+	 * Flag to indicate if the processing of the author updated event is in progress.
+	 * If true, this class won't fire any events to avoid an infinite loop in author updates.
+	 *
+	 * @var boolean
+	 */
+	public static $processing_author_updated_event = false;
+
+	/**
+	 * Holds information about the authors that were updated in this request, if any.
+	 *
+	 * @var array
+	 */
+	public static $updated_authors = [];
+
+	/**
+	 * The metadata we're watching and syncing.
+	 *
+	 * @var array
+	 */
+	public static $watched_meta = [
+		// Social Links.
+		'facebook',
+		'instagram',
+		'linkedin',
+		'myspace',
+		'pinterest',
+		'soundcloud',
+		'tumblr',
+		'twitter',
+		'youtube',
+		'wikipedia',
+
+		// Core bio.
+		'description',
+
+		// Newspack.
+		'newspack_job_title',
+		'newspack_role',
+		'newspack_employer',
+		'newspack_phone_number',
+
+		// Yoast SEO.
+		'wpseo_title',
+		'wpseo_metadesc',
+		'wpseo_noindex_author',
+		'wpseo_content_analysis_disable',
+		'wpseo_keyword_analysis_disable',
+		'wpseo_inclusive_language_analysis_disable',
+	];
+
+	/**
+	 * The user properties we're watching and syncing.
+	 *
+	 * @var array
+	 */
+	public static $user_props = [
+		'display_name',
+		'user_email',
+		'ID',
+		'user_url',
+	];
+
+	/**
+	 * Runs the initialization.
+	 */
+	public static function init() {
+		add_action( 'update_user_meta', [ __CLASS__, 'update_user_meta' ], 10, 4 );
+		add_action( 'profile_update', [ __CLASS__, 'profile_update' ], 10, 3 );
+		add_action( 'shutdown', [ __CLASS__, 'maybe_trigger_event' ] );
+	}
+
+	/**
+	 * Adds a change to the list of changes in the current request
+	 *
+	 * @param int    $user_id The updated user ID.
+	 * @param string $type The change type: meta or prop.
+	 * @param string $key The key of the changed meta or prop.
+	 * @param string $value The new value of the changed meta or prop.
+	 * @return void
+	 */
+	private static function add_change( $user_id, $type, $key, $value ) {
+		if ( ! isset( self::$updated_authors[ $user_id ] ) ) {
+			$user = get_userdata( $user_id );
+			if ( $user ) {
+				self::$updated_authors[ $user_id ] = [
+					'email' => $user->user_email,
+				];
+			} else {
+				return;
+			}
+		}
+
+		if ( ! isset( self::$updated_authors[ $user_id ][ $type ] ) ) {
+			self::$updated_authors[ $user_id ][ $type ] = [];
+		}
+
+		Debugger::log( 'Author update detected for ' . self::$updated_authors[ $user_id ]['email'] . ": $type: $key" );
+
+		self::$updated_authors[ $user_id ][ $type ][ $key ] = $value;
+	}
+
+	/**
+	 * Runs when a user meta is updated
+	 *
+	 * @param int    $meta_id    The meta ID after successful update.
+	 * @param int    $user_id    The user ID.
+	 * @param string $meta_key   The meta key.
+	 * @param mixed  $meta_value The meta value.
+	 * @return void
+	 */
+	public static function update_user_meta( $meta_id, $user_id, $meta_key, $meta_value ) {
+		if ( self::$processing_author_updated_event ) {
+			return;
+		}
+
+		if ( in_array( $meta_key, self::$watched_meta, true ) ) {
+			self::add_change( $user_id, 'meta', $meta_key, $meta_value );
+		}
+	}
+
+	/**
+	 * Runs when a user is updated
+	 *
+	 * @param int     $user_id The user ID.
+	 * @param WP_User $old_user_data The old user data.
+	 * @param array   $user_data The new user data.
+	 * @return void
+	 */
+	public static function profile_update( $user_id, $old_user_data, $user_data ) {
+		if ( self::$processing_author_updated_event ) {
+			return;
+		}
+
+		foreach ( self::$user_props as $prop ) {
+			if ( $old_user_data->$prop !== $user_data[ $prop ] ) {
+				self::add_change( $user_id, 'prop', $prop, $user_data[ $prop ] );
+			}
+		}
+	}
+
+	/**
+	 * If there are any author updates, trigger an event.
+	 *
+	 * @return void
+	 */
+	public static function maybe_trigger_event() {
+		if ( self::$processing_author_updated_event ) {
+			return;
+		}
+		foreach ( self::$updated_authors as $author ) {
+			do_action( 'newspack_network_author_updated', $author );
+		}
+	}
+
+}

--- a/includes/class-data-listeners.php
+++ b/includes/class-data-listeners.php
@@ -35,6 +35,7 @@ class Data_Listeners {
 
 		Data_Events::register_listener( 'woocommerce_subscription_status_changed', 'newspack_node_subscription_changed', [ __CLASS__, 'item_changed' ] );
 		Data_Events::register_listener( 'woocommerce_order_status_changed', 'newspack_node_order_changed', [ __CLASS__, 'item_changed' ] );
+		Data_Events::register_listener( 'newspack_network_author_updated', 'network_author_updated', [ __CLASS__, 'author_updated' ] );
 	}
 
 	/**
@@ -68,6 +69,16 @@ class Data_Listeners {
 			'payment_count'             => method_exists( $item, 'get_payment_count' ) ? $item->get_payment_count() : 1,
 			'subscription_relationship' => $relationship,
 		];
+	}
+
+	/**
+	 * Filters the user data for the event being triggered
+	 *
+	 * @param array $user_data The user data.
+	 * @return array
+	 */
+	public static function author_updated( $user_data ) {
+		return $user_data;
 	}
 
 }

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -37,9 +37,10 @@ class Initializer {
 				Rest_Authenticaton::init_node_filters();
 			}
 		}
-		
+
 		Data_Listeners::init();
 		Reader_Roles_Filter::init();
+		Author_Update_Watcher::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/hub/stores/event-log-items/class-author-updated.php
+++ b/includes/hub/stores/event-log-items/class-author-updated.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Newspack Author Updated Log Item
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Hub\Stores\Event_Log_Items;
+
+use Newspack_Network\Hub\Stores\Abstract_Event_Log_Item;
+
+/**
+ * Class to handle the Author Updated Log Item
+ */
+class Author_Updated extends Abstract_Event_Log_Item {
+
+	/**
+	 * Gets a summary for this event
+	 *
+	 * @return string
+	 */
+	public function get_summary() {
+		$url = empty( $this->get_node_id() ) ? get_bloginfo( 'url' ) : $this->get_node_url();
+		return sprintf(
+			/* translators: 1: email 2: site url */
+			__( 'User %1$s profile has been updated on %2$s', 'newspack-network' ),
+			$this->get_email(),
+			$url
+		);
+	}
+}

--- a/includes/incoming-events/class-author-updated.php
+++ b/includes/incoming-events/class-author-updated.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Newspack Author Updated Incoming Event class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Author_Update_Watcher;
+use Newspack_Network\Debugger;
+
+/**
+ * Class to handle the Canonical Url Updated Event
+ *
+ * This event is always sent from the Hub and received by Nodes.
+ */
+class Author_Updated extends Abstract_Incoming_Event {
+
+	/**
+	 * Processes the event
+	 *
+	 * @return void
+	 */
+	public function post_process_in_hub() {
+		$this->maybe_update_user();
+	}
+
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		$this->maybe_update_user();
+	}
+
+	/**
+	 * Maybe updates a new WP user based on this event
+	 *
+	 * @return void
+	 */
+	public function maybe_update_user() {
+		$email = $this->get_email();
+		Debugger::log( 'Processing author_updated with email: ' . $email );
+		if ( ! $email ) {
+			return;
+		}
+		$existing_user = get_user_by( 'email', $email );
+
+		if ( ! $existing_user ) {
+			Debugger::log( 'User not found, skipping.' );
+			return;
+		}
+
+		Author_Update_Watcher::$processing_author_updated_event = true;
+
+		$data = $this->get_data();
+
+		if ( isset( $data->prop ) ) {
+			$update_array = [
+				'ID' => $existing_user->ID,
+			];
+			foreach ( $data->prop as $prop_key => $prop_value ) {
+				$update_array[ $prop_key ] = $prop_value;
+			}
+			Debugger::log( 'Updating user with data: ' . print_r( $update_array, true ) );
+			wp_update_user( $update_array );
+		}
+
+		if ( isset( $data->meta ) ) {
+			foreach ( $data->meta as $meta_key => $meta_value ) {
+				Debugger::log( 'Updating user meta: ' . $meta_key );
+				update_user_meta( $existing_user->ID, $meta_key, $meta_value );
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR adds the `author_updated` event.

When a user has one of the fields we watch for updated, it creates an event to the network.

When nodes pull the event, they will update the user information, if the user already exists. This will not create the user.

## How to test

* Setup a network with at least a hub and a node
* Create users in the sites sharing the same email
* In one of the sites, edit the user profile while watching the debug.log. Just save the profile without making any changes
* Confirm that you don't see any entries in the log referring to `Author update detected`
* Now edit the profile again and make a change to a field that we do not watch. for example nickname or billing address
* Confirm you don't see anything in the logs again
* Now make some changes to the fields we watch, like display name, website and social links
* Confirm you see them in the log
* Confirm the event is dispatched and you see them in the Event Log
* Confirm the user in the other site is updated after the event is pulled

QUESTION: should we do this only for users that can be authors of a post?