### PR TITLE
fix(newspack-ads): remove gam ad targeting

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -26,6 +26,7 @@ class Initializer {
 			Hub\Event_Listeners::init();
 			Hub\Database\Subscriptions::init();
 			Hub\Database\Orders::init();
+			Hub\Newspack_Ads_GAM::init();
 		}
 
 		if ( Site_Role::is_node() ) {
@@ -40,7 +41,6 @@ class Initializer {
 		Data_Listeners::init();
 		Reader_Roles_Filter::init();
 		Distributor_Customizations::init();
-		GAM::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/hub/class-newspack-ads-gam.php
+++ b/includes/hub/class-newspack-ads-gam.php
@@ -3,27 +3,28 @@
  * Newspack Ads GAM Integration.
  *
  * Implements support for custom targeting key-val pairs for each site in the
- * network. The ad slots are then targeted to the site's URL.
+ * network.
  *
  * @package Newspack
  */
 
-namespace Newspack_Network;
+namespace Newspack_Network\Hub;
 
-use Newspack_Ads\Providers\GAM\Api as GAM_API;
+use Newspack_Network\Site_Role;
+use Newspack_Network\Debugger;
+
 use Newspack_Ads\Providers\GAM_Model;
 
 /**
- * Integration class for Newspack Ads' GAM support.
+ * Integration class for Newspack Ads GAM support.
  */
-final class GAM {
+final class Newspack_Ads_GAM {
 	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		add_action( 'newspack_ads_setup_gam', [ __CLASS__, 'create_targeting_keys' ] );
-		add_action( 'save_post_' . Hub\Nodes::POST_TYPE_SLUG, [ __CLASS__, 'create_targeting_keys' ] );
-		add_filter( 'newspack_ads_ad_targeting', [ __CLASS__, 'add_targeting' ], 10, 2 );
+		add_action( 'save_post_' . Nodes::POST_TYPE_SLUG, [ __CLASS__, 'create_targeting_keys' ] );
 	}
 
 	/**
@@ -41,28 +42,15 @@ final class GAM {
 			Debugger::log( 'Error adding GAM targeting keys: GAM API is not available.' );
 			return;
 		}
-		$nodes     = Hub\Nodes::get_all_nodes();
+		$nodes     = Nodes::get_all_nodes();
 		$node_urls = array_map(
 			function( $node ) {
 				return $node->get_url();
 			},
 			$nodes
 		);
-		$urls      = array_merge( [ \get_site_url() ], $node_urls );
+		$urls      = array_merge( [ \get_bloginfo( 'url' ) ], $node_urls );
 		$api->targeting_keys->create_targeting_key( 'site', $urls, 'PREDEFINED', 'CUSTOM_DIMENSION' );
 		Debugger::log( 'Updated GAM targeting keys.' );
-	}
-
-	/**
-	 * Add targeting.
-	 *
-	 * @param array $targeting Targeting.
-	 * @param array $ad_unit   Ad unit.
-	 *
-	 * @return array
-	 */
-	public static function add_targeting( $targeting, $ad_unit ) {
-		$targeting['site'] = \get_site_url();
-		return $targeting;
 	}
 }


### PR DESCRIPTION
The primary logic for `site` custom targeting key-val is moving to Newspack Ads (https://github.com/Automattic/newspack-ads/pull/770), so we no longer need to perform the ad slot targeting here.

The integration should now only ensure that all the URLs are part of the inventory.

### Testing

1. If you have the site targeting key already created, visit your GAM Inventory -> Key-values, edit and delete each value, then delete the key (mind that GAM never deletes an entity, it's only archived)
2. Make sure your hub is connected to a GAM account 
3. Check out this branch, visit Newspack -> Advertising, visit the GAM inventory, and confirm the targeting key is created along with values for each node and the hub itself