### PR TITLE
Feat/distribute authors

### DIFF
--- a/includes/class-distributor-customizations.php
+++ b/includes/class-distributor-customizations.php
@@ -20,6 +20,8 @@ class Distributor_Customizations {
 	public static function init() {
 		require_once NEWSPACK_NETWORK_PLUGIN_DIR . '/includes/distributor-customizations/global.php';
 		Distributor_Customizations\Canonical_Url::init();
+		Distributor_Customizations\Author_Distribution::init();
+		Distributor_Customizations\Author_Ingestion::init();
 	}
 
 

--- a/includes/class-user-update-watcher.php
+++ b/includes/class-user-update-watcher.php
@@ -73,7 +73,6 @@ class User_Update_Watcher {
 	public static $user_props = [
 		'display_name',
 		'user_email',
-		'ID',
 		'user_url',
 	];
 

--- a/includes/class-user-update-watcher.php
+++ b/includes/class-user-update-watcher.php
@@ -13,12 +13,12 @@ namespace Newspack_Network;
 class User_Update_Watcher {
 
 	/**
-	 * Flag to indicate if the processing of the user updated event is in progress.
-	 * If true, this class won't fire any events to avoid an infinite loop in author updates.
+	 * Flag to indicate if the watcher should watch.
+	 * If false, this class won't fire any events to avoid an infinite loop in author updates.
 	 *
 	 * @var boolean
 	 */
-	public static $processing_user_updated_event = false;
+	public static $enabled = true;
 
 	/**
 	 * Holds information about the users that were updated in this request, if any.
@@ -125,7 +125,7 @@ class User_Update_Watcher {
 	 * @return void
 	 */
 	public static function update_user_meta( $meta_id, $user_id, $meta_key, $meta_value ) {
-		if ( self::$processing_user_updated_event ) {
+		if ( ! self::$enabled ) {
 			return;
 		}
 
@@ -143,7 +143,7 @@ class User_Update_Watcher {
 	 * @return void
 	 */
 	public static function profile_update( $user_id, $old_user_data, $user_data ) {
-		if ( self::$processing_user_updated_event ) {
+		if ( ! self::$enabled ) {
 			return;
 		}
 
@@ -160,7 +160,7 @@ class User_Update_Watcher {
 	 * @return void
 	 */
 	public static function maybe_trigger_event() {
-		if ( self::$processing_user_updated_event ) {
+		if ( ! self::$enabled ) {
 			return;
 		}
 		foreach ( self::$updated_users as $author ) {

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Distributor_Customizations;
 
 use Newspack\Data_Events;
+use Newspack_Network\User_Update_Watcher;
 
 /**
  * Class to handle author distribution.
@@ -16,56 +17,6 @@ use Newspack\Data_Events;
  * On the target site, the plugin will create the authors if they don't exist, and override the byline
  */
 class Author_Distribution {
-
-	/**
-	 * The user meta we watch for changes.
-	 *
-	 * @var array
-	 */
-	public static $watched_meta = [
-		// Social Links.
-		'facebook',
-		'instagram',
-		'linkedin',
-		'myspace',
-		'pinterest',
-		'soundcloud',
-		'tumblr',
-		'twitter',
-		'youtube',
-		'wikipedia',
-
-		// Core bio.
-		'first_name',
-		'last_name',
-		'description',
-
-		// Newspack.
-		'newspack_job_title',
-		'newspack_role',
-		'newspack_employer',
-		'newspack_phone_number',
-
-		// Yoast SEO.
-		'wpseo_title',
-		'wpseo_metadesc',
-		'wpseo_noindex_author',
-		'wpseo_content_analysis_disable',
-		'wpseo_keyword_analysis_disable',
-		'wpseo_inclusive_language_analysis_disable',
-	];
-
-	/**
-	 * The user properties we're watching and syncing.
-	 *
-	 * @var array
-	 */
-	public static $user_props = [
-		'display_name',
-		'user_email',
-		'user_url',
-		'website', // guest authors.
-	];
 
 	/**
 	 * Initializes the class
@@ -173,13 +124,18 @@ class Author_Distribution {
 		];
 
 
-		foreach ( self::$user_props as $prop ) {
+		foreach ( User_Update_Watcher::$user_props as $prop ) {
 			if ( isset( $user->$prop ) ) {
 				$author[ $prop ] = $user->$prop;
 			}
 		}
 
-		foreach ( self::$watched_meta as $meta_key ) {
+		// CoAuthors' guest authors have a 'website' property.
+		if ( isset( $user->website ) ) {
+			$author['website'] = $user->website;
+		}
+
+		foreach ( User_Update_Watcher::$watched_meta as $meta_key ) {
 			$author[ $meta_key ] = get_user_meta( $user->ID, $meta_key, true );
 		}
 
@@ -203,13 +159,18 @@ class Author_Distribution {
 			'id'   => $guest_author->ID,
 		];
 
-		foreach ( self::$user_props as $prop ) {
+		foreach ( User_Update_Watcher::$user_props as $prop ) {
 			if ( isset( $guest_author->$prop ) ) {
 				$author[ $prop ] = $guest_author->$prop;
 			}
 		}
 
-		foreach ( self::$watched_meta as $meta_key ) {
+		// CoAuthors' guest authors have a 'website' property.
+		if ( isset( $guest_author->website ) ) {
+			$author['website'] = $guest_author->website;
+		}
+
+		foreach ( User_Update_Watcher::$watched_meta as $meta_key ) {
 			if ( isset( $guest_author->$meta_key ) ) {
 				$author[ $meta_key ] = $guest_author->$meta_key;
 			}

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -135,7 +135,7 @@ class Author_Distribution {
 		}
 
 		if ( ! $user ) {
-			return new WP_Error( 'Error getting WP User details for distribution. Invalid User:' );
+			return new WP_Error( 'Error getting WP User details for distribution. Invalid User' );
 		}
 
 		$author = [

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -95,6 +95,7 @@ class Author_Distribution {
 		foreach ( $co_authors as $co_author ) {
 			if ( is_a( $co_author, 'WP_User' ) ) {
 				$authors[] = self::get_wp_user_for_distribution( $co_author );
+				continue;
 			}
 			$authors[] = self::get_guest_author_for_distribution( $co_author );
 		}

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Newspack Network author distriburion.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+use Newspack\Data_Events;
+
+/**
+ * Class to handle author distribution.
+ *
+ * Every time a post is distributed, we also send all the information about the author (or authors if CAP is enabled)
+ * On the target site, the plugin will create the authors if they don't exist, and override the byline
+ */
+class Author_Distribution {
+
+	/**
+	 * The user meta we watch for changes.
+	 *
+	 * @var array
+	 */
+	public static $watched_meta = [
+		// Social Links.
+		'facebook',
+		'instagram',
+		'linkedin',
+		'myspace',
+		'pinterest',
+		'soundcloud',
+		'tumblr',
+		'twitter',
+		'youtube',
+		'wikipedia',
+
+		// Core bio.
+		'first_name',
+		'last_name',
+		'description',
+
+		// Newspack.
+		'newspack_job_title',
+		'newspack_role',
+		'newspack_employer',
+		'newspack_phone_number',
+
+		// Yoast SEO.
+		'wpseo_title',
+		'wpseo_metadesc',
+		'wpseo_noindex_author',
+		'wpseo_content_analysis_disable',
+		'wpseo_keyword_analysis_disable',
+		'wpseo_inclusive_language_analysis_disable',
+	];
+
+	/**
+	 * The user properties we're watching and syncing.
+	 *
+	 * @var array
+	 */
+	public static $user_props = [
+		'display_name',
+		'user_email',
+		'user_url',
+		'website', // guest authors.
+	];
+
+	/**
+	 * Initializes the class
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_filter( 'dt_push_post_args', [ __CLASS__, 'add_author_data_to_push' ], 10, 2 );
+	}
+
+	/**
+	 * Filters the post data sent on a push to add the author data.
+	 *
+	 * @param array   $post_body The post data.
+	 * @param WP_Post $post The post object.
+	 * @return array
+	 */
+	public static function add_author_data_to_push( $post_body, $post ) {
+		$authors = self::get_authors_for_distribution( $post );
+		if ( ! empty( $authors ) ) {
+			$post_body['newspack_network_authors'] = $authors;
+		}
+		return $post_body;
+	}
+
+	/**
+	 * Get the authors of a post to be added to the distribution payload.
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return array An array of authors.
+	 */
+	public static function get_authors_for_distribution( $post ) {
+		if ( ! function_exists( 'get_coauthors' ) ) {
+			return [ self::get_wp_user_for_distribution( $post->post_author ) ];
+		}
+
+		$co_authors = get_coauthors( $post->ID );
+		if ( empty( $co_authors ) ) {
+			return [ self::get_wp_user_for_distribution( $post->post_author ) ];
+		}
+
+		$authors = [];
+
+		foreach ( $co_authors as $co_author ) {
+			if ( is_a( $co_author, 'WP_User' ) ) {
+				$authors[] = self::get_wp_user_for_distribution( $co_author );
+			}
+			$authors[] = self::get_guest_author_for_distribution( $co_author );
+		}
+
+		return $authors;
+
+	}
+
+	/**
+	 * Gets the user data of a WP user to be distributed along with the post.
+	 *
+	 * @param int|WP_Post $user The user ID or object.
+	 * @return array
+	 */
+	public static function get_wp_user_for_distribution( $user ) {
+		if ( ! is_a( $user, 'WP_User' ) ) {
+			$user = get_user_by( 'ID', $user );
+		}
+
+		if ( ! $user ) {
+			return [];
+		}
+
+		$author = [
+			'type' => 'wp_user',
+			'id'   => $user->ID,
+		];
+
+
+		foreach ( self::$user_props as $prop ) {
+			if ( isset( $user->$prop ) ) {
+				$author[ $prop ] = $user->$prop;
+			}
+		}
+
+		foreach ( self::$watched_meta as $meta_key ) {
+			$author[ $meta_key ] = get_user_meta( $user->ID, $meta_key, true );
+		}
+
+		return $author;
+	}
+
+	/**
+	 * Get the guest author data to be distributed along with the post.
+	 *
+	 * @param object $guest_author The Guest Author object.
+	 * @return array
+	 */
+	public static function get_guest_author_for_distribution( $guest_author ) {
+
+		if ( ! is_object( $guest_author ) || ! isset( $guest_author->type ) || 'guest-author' !== $guest_author->type ) {
+			return [];
+		}
+
+		$author = [
+			'type' => 'guest_author',
+			'id'   => $guest_author->ID,
+		];
+
+		foreach ( self::$user_props as $prop ) {
+			if ( isset( $guest_author->$prop ) ) {
+				$author[ $prop ] = $guest_author->$prop;
+			}
+		}
+
+		foreach ( self::$watched_meta as $meta_key ) {
+			if ( isset( $guest_author->$meta_key ) ) {
+				$author[ $meta_key ] = $guest_author->$meta_key;
+			}
+		}
+
+		return $author;
+	}
+
+}

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Network author distriburion.
+ * Newspack Network author distribution.
  *
  * @package Newspack
  */

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Distributor_Customizations;
 
 use Newspack\Data_Events;
+use Newspack_Network\Debugger;
 use Newspack_Network\User_Update_Watcher;
 
 /**
@@ -116,6 +117,8 @@ class Author_Distribution {
 		}
 
 		if ( ! $user ) {
+			Debugger::log( 'Error getting WP User details for distribution. Invalid User:' );
+			Debugger::log( $user );
 			return [];
 		}
 
@@ -152,6 +155,8 @@ class Author_Distribution {
 	public static function get_guest_author_for_distribution( $guest_author ) {
 
 		if ( ! is_object( $guest_author ) || ! isset( $guest_author->type ) || 'guest-author' !== $guest_author->type ) {
+			Debugger::log( 'Error getting guest author details for distribution. Invalid Guest Author:' );
+			Debugger::log( $guest_author );
 			return [];
 		}
 

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -137,7 +137,7 @@ class Author_Ingestion {
 	 * Captures and stores the authorship data for a post
 	 *
 	 * Distributor discards the additional data we send in the REST request, so we need to capture it here
-	 * for later use in self::add_author_data_to_pull
+	 * for later use in self::handle_pull
 	 *
 	 * @param WP_Post $post The post object being pulled.
 	 * @param array   $post_array The post array received from the REST api.

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -93,7 +93,15 @@ class Author_Ingestion {
 
 			Debugger::log( 'Ingesting author: ' . $author['user_email'] );
 
-			$user = User_Utils::get_or_create_user_by_email( $author['user_email'], get_post_meta( $post_id, 'dt_original_site_url', true ), $author['id'] );
+			$insert_array = [];
+
+			foreach ( User_Update_Watcher::$user_props as $prop ) {
+				if ( isset( $author[ $prop ] ) ) {
+					$insert_array[ $prop ] = $author[ $prop ];
+				}
+			}
+
+			$user = User_Utils::get_or_create_user_by_email( $author['user_email'], get_post_meta( $post_id, 'dt_original_site_url', true ), $author['id'], $insert_array );
 
 			if ( is_wp_error( $user ) ) {
 				continue;

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -9,6 +9,8 @@ namespace Newspack_Network\Distributor_Customizations;
 
 use Newspack\Data_Events;
 use Newspack_Network\Debugger;
+use Newspack_Network\User_Update_Watcher;
+
 
 /**
  * Class to handle author ingestion.
@@ -100,7 +102,7 @@ class Author_Ingestion {
 			update_user_meta( $user->ID, 'newspack_remote_site', get_post_meta( $post_id, 'dt_original_site_url', true ) );
 			update_user_meta( $user->ID, 'newspack_remote_id', $author['id'] );
 
-			foreach ( Author_Distribution::$watched_meta as $meta_key ) {
+			foreach ( User_Update_Watcher::$watched_meta as $meta_key ) {
 				if ( isset( $author[ $meta_key ] ) ) {
 					update_user_meta( $user->ID, $meta_key, $author[ $meta_key ] );
 				}
@@ -185,7 +187,7 @@ class Author_Ingestion {
 			'role'          => 'author',
 		];
 
-		foreach ( Author_Distribution::$user_props as $prop ) {
+		foreach ( User_Update_Watcher::$user_props as $prop ) {
 			if ( isset( $distributed_author[ $prop ] ) ) {
 				$insert_array[ $prop ] = $distributed_author[ $prop ];
 			}

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -80,6 +80,8 @@ class Author_Ingestion {
 
 		Debugger::log( 'Ingesting authors from distributed post.' );
 
+		User_Update_Watcher::$enabled = false;
+
 		update_post_meta( $post_id, 'newspack_network_authors', $distributed_authors );
 
 		$coauthors_plus = self::get_coauthors_plus();

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Network author ingestino.
+ * Newspack Network author ingestion.
  *
  * @package Newspack
  */

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -70,7 +70,7 @@ class Author_Ingestion {
 	}
 
 	/**
-	 * Ingest authors for a post distribubted to this site
+	 * Ingest authors for a post distributed to this site
 	 *
 	 * @param int   $post_id The post ID.
 	 * @param array $distributed_authors The distributed authors array.

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -15,7 +15,7 @@ use Newspack_Network\Utils\Users as User_Utils;
 /**
  * Class to handle author ingestion.
  *
- * This class is used to handle the authorship data added by Author_Distriburion to the distributed post
+ * This class is used to handle the authorship data added by Author_Distribution to the distributed post
  */
 class Author_Ingestion {
 

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -93,7 +93,9 @@ class Author_Ingestion {
 
 			Debugger::log( 'Ingesting author: ' . $author['user_email'] );
 
-			$insert_array = [];
+			$insert_array = [
+				'role' => 'author',
+			];
 
 			foreach ( User_Update_Watcher::$user_props as $prop ) {
 				if ( isset( $author[ $prop ] ) ) {

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Newspack Network author ingestino.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+use Newspack\Data_Events;
+use Newspack_Network\Debugger;
+
+/**
+ * Class to handle author ingestion.
+ *
+ * This class is used to handle the authorship data added by Author_Distriburion to the distributed post
+ */
+class Author_Ingestion {
+
+	/**
+	 * Initializes the class
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_insert_post', [ __CLASS__, 'handle_rest_insertion' ], 10, 2 );
+	}
+
+	/**
+	 * Gets the CoAuthors Plus main object, if present
+	 *
+	 * @return false|\CoAuthors_Plus
+	 */
+	public static function get_coauthors_plus() {
+		global $coauthors_plus;
+		if ( is_null( $coauthors_plus ) || ( ! $coauthors_plus instanceof \CoAuthors_Plus ) ) {
+			return false;
+		}
+		return $coauthors_plus;
+	}
+
+	/**
+	 * Fired when a post is inserted via the REST API
+	 *
+	 * Checks if there are newspack network author information and ingests it.
+	 *
+	 * @param WP_Post         $post     Inserted post object.
+	 * @param WP_REST_Request $request  Request object.
+	 * @return void
+	 */
+	public static function handle_rest_insertion( $post, $request ) {
+
+		$distributed_authors = $request->get_param( 'newspack_network_authors' );
+		if ( empty( $distributed_authors ) ) {
+			return;
+		}
+
+		Debugger::log( 'Ingesting authors from distributed post.' );
+
+		update_post_meta( $post->ID, 'newspack_network_authors', $distributed_authors );
+
+		$coauthors_plus = self::get_coauthors_plus();
+		$coauthors      = [];
+
+		foreach ( $distributed_authors as $author ) {
+			if ( 'wp_user' != $author['type'] ) {
+				continue;
+			}
+
+			Debugger::log( 'Ingesting author: ' . $author['user_email'] );
+
+			$user = self::get_or_create_user( $author );
+
+			if ( is_wp_error( $user ) ) {
+				continue;
+			}
+
+			update_user_meta( $user->ID, 'newspack_remote_site', get_post_meta( $post->ID, 'dt_original_site_url', true ) );
+			update_user_meta( $user->ID, 'newspack_remote_id', $author['id'] );
+
+			foreach ( Author_Distribution::$watched_meta as $meta_key ) {
+				if ( isset( $author[ $meta_key ] ) ) {
+					update_user_meta( $user->ID, $meta_key, $author[ $meta_key ] );
+				}
+			}
+
+			// If CoAuthors Plus is not present, just assign the first author as the post author.
+			if ( ! $coauthors_plus ) {
+				wp_update_post(
+					[
+						'ID'          => $post->ID,
+						'post_author' => $user->ID,
+					]
+				);
+				break;
+			}
+
+			$coauthors[] = $user->user_nicename;
+		}
+
+		if ( $coauthors_plus ) {
+			$coauthors_plus->add_coauthors( $post->ID, $coauthors );
+		}
+
+	}
+
+	/**
+	 * Gets or created a user based on the distributed author data.
+	 *
+	 * @param array $distributed_author The distributed author as received from the remote site.
+	 * @return WP_User|WP_Error
+	 */
+	public static function get_or_create_user( $distributed_author ) {
+
+		$existing_user = get_user_by( 'email', $distributed_author['user_email'] );
+
+		if ( $existing_user ) {
+			return $existing_user;
+		}
+
+		$insert_array = [
+			'user_login'    => $distributed_author['user_email'],
+			'user_nicename' => $distributed_author['user_email'],
+			'user_pass'     => wp_generate_password(),
+			'role'          => 'author',
+		];
+
+		foreach ( Author_Distribution::$user_props as $prop ) {
+			if ( isset( $distributed_author[ $prop ] ) ) {
+				$insert_array[ $prop ] = $distributed_author[ $prop ];
+			}
+		}
+
+		$user_id = wp_insert_user( $insert_array );
+
+		if ( is_wp_error( $user_id ) ) {
+			Debugger::log( 'Error creating user: ' . $user_id->get_error_message() );
+			return $user_id;
+		}
+
+		return get_user_by( 'id', $user_id );
+
+	}
+
+}

--- a/includes/distributor-customizations/global.php
+++ b/includes/distributor-customizations/global.php
@@ -26,7 +26,7 @@ add_filter(
 /**
  * Keep the publication date on the new pulled post.
  *
- * This filter is used to filter the arguments sent to the remote server during a pull.
+ * This filters the arguments passed into wp_insert_post during a pull.
  */
 add_filter(
 	'dt_pull_post_args',

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -53,7 +53,7 @@ class User_Updated extends Abstract_Incoming_Event {
 			return;
 		}
 
-		User_Update_Watcher::$processing_user_updated_event = true;
+		User_Update_Watcher::$enabled = false;
 
 		$data = $this->get_data();
 

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -17,7 +17,7 @@ class Users {
 	 *
 	 * @param string $email The email of the user to look for. If no user is found, a new one will be created with this email.
 	 * @param string $remote_site_url The URL of the remote site. Used only when a new user is created.
-	 * @param string $remote_site_id The ID of the remote site. Used only when a new user is created.
+	 * @param string $remote_site_id The ID of the user in the remote site. Used only when a new user is created.
 	 * @param array  $insert_array An array of additional fields to be passed to wp_insert_user() when creating a new user. Use this to set the user's role, the default is NEWSPACK_NETWORK_READER_ROLE.
 	 * @return WP_User|WP_Error
 	 */

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -17,11 +17,11 @@ class Users {
 	 *
 	 * @param string $email The email of the user to look for. If no user is found, a new one will be created with this email.
 	 * @param string $remote_site_url The URL of the remote site. Used only when a new user is created.
-	 * @param string $remote_site_id The ID of the user in the remote site. Used only when a new user is created.
+	 * @param string $remote_id The ID of the user in the remote site. Used only when a new user is created.
 	 * @param array  $insert_array An array of additional fields to be passed to wp_insert_user() when creating a new user. Use this to set the user's role, the default is NEWSPACK_NETWORK_READER_ROLE.
 	 * @return WP_User|WP_Error
 	 */
-	public static function get_or_create_user_by_email( $email, $remote_site_url, $remote_site_id, $insert_array = [] ) {
+	public static function get_or_create_user_by_email( $email, $remote_site_url, $remote_id, $insert_array = [] ) {
 
 		$existing_user = get_user_by( 'email', $email );
 
@@ -47,7 +47,7 @@ class Users {
 		}
 
 		update_user_meta( $user_id, 'newspack_remote_site', $remote_site_url );
-		update_user_meta( $user_id, 'newspack_remote_id', $remote_site_id );
+		update_user_meta( $user_id, 'newspack_remote_id', $remote_id );
 
 		return get_user_by( 'id', $user_id );
 


### PR DESCRIPTION
## Distributes authors upon post distribution via the Distributor plugin

When a post is distributed via Distributor, all the authors (and co-authors if CAP is enabled) information will be attached to the post. 

In the site where the post was distributed to, the authorship information will be stored in a post meta, and later will be used to override the bylines of the posts.

Also in the target site, every author that is a WP user in the origin site, will be created as an `author` if an user with that email yet doesn't exist. Then the post authorship will be assigned to the distributed authors, in the same way they are in the origin site.

Guest Authors will not be created and the authorship will not be established. Information about Guest Authors will only exist in the post_meta, and will be used to filter the byline on the fly (in a future PR).

## How to test

* Establish a network with 2 or 3 sites. (newspack_docker is your friend here, since it automatically creates a bunch of sites and connect them both on Newspack Network plugin and on Distributor plugin, creating needed the keys and application passwords)
* On one of the sites, create a post, and assign it multiple authors, having at least one wp user and one guest author
* Distribute this post via push to another site
* In the target site, observe the WP_User was created and the authorship was properly assigned
* Observe the `newspack_network_authors` post_meta and see all authors are there, including the guest author
* Repeat the process, now pulling a post from a site instead of pushing
* Make sure to fill all fields of the authors and confirm all fields are propagated (name, bio, site, job, etc)