### PR TITLE
feat: sync user avatar

### DIFF
--- a/includes/class-user-update-watcher.php
+++ b/includes/class-user-update-watcher.php
@@ -70,6 +70,15 @@ class User_Update_Watcher {
 	];
 
 	/**
+	 * Meta keys we watched but we don't want to update in the same way we do with all the others.
+	 *
+	 * @var array
+	 */
+	public static $read_only_meta = [
+		'simple_local_avatar', // The avatar is sideloaded in a different way.
+	];
+
+	/**
 	 * The user properties we're watching and syncing.
 	 *
 	 * @var array
@@ -84,9 +93,20 @@ class User_Update_Watcher {
 	 * Runs the initialization.
 	 */
 	public static function init() {
+		add_action( 'add_user_meta', [ __CLASS__, 'add_user_meta' ], 10, 3 );
 		add_action( 'update_user_meta', [ __CLASS__, 'update_user_meta' ], 10, 4 );
+		add_action( 'deleted_user_meta', [ __CLASS__, 'deleted_user_meta' ], 10, 3 );
 		add_action( 'profile_update', [ __CLASS__, 'profile_update' ], 10, 3 );
 		add_action( 'shutdown', [ __CLASS__, 'maybe_trigger_event' ] );
+	}
+
+	/**
+	 * Gets a list of metadata we can update.
+	 *
+	 * @return array
+	 */
+	public static function get_writable_meta() {
+		return array_diff( self::$watched_meta, self::$read_only_meta );
 	}
 
 	/**
@@ -120,6 +140,24 @@ class User_Update_Watcher {
 	}
 
 	/**
+	 * Runs when a user meta is added
+	 *
+	 * @param int    $user_id    The user ID.
+	 * @param string $meta_key   The meta key.
+	 * @param mixed  $meta_value The meta value.
+	 * @return void
+	 */
+	public static function add_user_meta( $user_id, $meta_key, $meta_value ) {
+		if ( ! self::$enabled ) {
+			return;
+		}
+
+		if ( in_array( $meta_key, self::$watched_meta, true ) ) {
+			self::add_change( $user_id, 'meta', $meta_key, $meta_value );
+		}
+	}
+
+	/**
 	 * Runs when a user meta is updated
 	 *
 	 * @param int    $meta_id    The meta ID after successful update.
@@ -134,7 +172,29 @@ class User_Update_Watcher {
 		}
 
 		if ( in_array( $meta_key, self::$watched_meta, true ) ) {
+			if ( method_exists( __CLASS__, 'watch_meta_' . $meta_key ) ) {
+				call_user_func( [ __CLASS__, 'watch_meta_' . $meta_key ], $user_id, $meta_value );
+				return;
+			}
 			self::add_change( $user_id, 'meta', $meta_key, $meta_value );
+		}
+	}
+
+	/**
+	 * Runs when a user meta is deleted
+	 *
+	 * @param string[] $meta_ids    An array of metadata entry IDs to delete.
+	 * @param int      $user_id   ID of the object metadata is for.
+	 * @param string   $meta_key    Metadata key.
+	 * @return void
+	 */
+	public static function deleted_user_meta( $meta_ids, $user_id, $meta_key ) {
+		if ( ! self::$enabled ) {
+			return;
+		}
+
+		if ( in_array( $meta_key, self::$watched_meta, true ) ) {
+			self::add_change( $user_id, 'meta', $meta_key, '' );
 		}
 	}
 
@@ -169,6 +229,34 @@ class User_Update_Watcher {
 		}
 		foreach ( self::$updated_users as $author ) {
 			do_action( 'newspack_network_user_updated', $author );
+		}
+	}
+
+	/**
+	 * Watcher for the simple_local_avatar meta.
+	 *
+	 * This meta gets updated every time a new image size is created for the avatar,
+	 * and we only want to fire an event if the media ID changes.
+	 *
+	 * @param int    $user_id The user ID.
+	 * @param string $new_value The meta value.
+	 * @return void
+	 */
+	public static function watch_meta_simple_local_avatar( $user_id, $new_value ) {
+		$old_value = get_user_meta( $user_id, 'simple_local_avatar', true );
+
+		Debugger::log( 'simple_local_avatar meta updated, but will only trigger a user update if the media id has changed.' );
+
+		if ( ! is_array( $old_value ) || empty( $old_value['media_id'] ) ) {
+			return;
+		}
+
+		if ( ! is_array( $new_value ) || empty( $new_value['media_id'] ) ) {
+			return;
+		}
+
+		if ( (int) $old_value['media_id'] !== (int) $new_value['media_id'] ) {
+			self::add_change( $user_id, 'meta', 'simple_local_avatar', $new_value );
 		}
 	}
 

--- a/includes/class-user-update-watcher.php
+++ b/includes/class-user-update-watcher.php
@@ -63,6 +63,10 @@ class User_Update_Watcher {
 		'wpseo_content_analysis_disable',
 		'wpseo_keyword_analysis_disable',
 		'wpseo_inclusive_language_analysis_disable',
+
+		// Simple Local Avatars.
+		'simple_local_avatar',
+		'simple_local_avatar_rating',
 	];
 
 	/**

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -174,7 +174,7 @@ class Author_Distribution {
 			$author['website'] = $user->website;
 		}
 
-		foreach ( User_Update_Watcher::get_writable_meta() as $meta_key ) {
+		foreach ( User_Update_Watcher::$watched_meta as $meta_key ) {
 			$author[ $meta_key ] = get_user_meta( $user->ID, $meta_key, true );
 		}
 

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -174,7 +174,7 @@ class Author_Distribution {
 			$author['website'] = $user->website;
 		}
 
-		foreach ( User_Update_Watcher::$watched_meta as $meta_key ) {
+		foreach ( User_Update_Watcher::get_writable_meta() as $meta_key ) {
 			$author[ $meta_key ] = get_user_meta( $user->ID, $meta_key, true );
 		}
 

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -117,6 +117,8 @@ class Author_Ingestion {
 				}
 			}
 
+			User_Utils::maybe_sideload_avatar( $user->ID, $author );
+
 			// If CoAuthors Plus is not present, just assign the first author as the post author.
 			if ( ! $coauthors_plus ) {
 				wp_update_post(

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -111,13 +111,13 @@ class Author_Ingestion {
 				continue;
 			}
 
-			foreach ( User_Update_Watcher::$watched_meta as $meta_key ) {
+			foreach ( User_Update_Watcher::get_writable_meta() as $meta_key ) {
 				if ( isset( $author[ $meta_key ] ) ) {
 					update_user_meta( $user->ID, $meta_key, $author[ $meta_key ] );
 				}
 			}
 
-			User_Utils::maybe_sideload_avatar( $user->ID, $author );
+			User_Utils::maybe_sideload_avatar( $user->ID, $author, false );
 
 			// If CoAuthors Plus is not present, just assign the first author as the post author.
 			if ( ! $coauthors_plus ) {

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Incoming_Events;
 
 use Newspack_Network\User_Update_Watcher;
 use Newspack_Network\Debugger;
+use Newspack_Network\Utils\Users as User_Utils;
 
 /**
  * Class to handle the User Updated Event
@@ -76,23 +77,7 @@ class User_Updated extends Abstract_Incoming_Event {
 			}
 		}
 
-		// @TODO move this to the User Utils class when it gets merged.
-		global $simple_local_avatars;
-		if ( ! $simple_local_avatars || ! is_a( $simple_local_avatars, 'Simple_Local_Avatars' ) ) {
-			return;
-		}
-
-		$avatar_meta_key = 'simple_local_avatar';
-
-		if ( array_key_exists( $avatar_meta_key, $data->meta ) && ! empty( $data->meta[ $avatar_meta_key ]['full'] ) ) {
-			Debugger::log( 'Updating user avatar' );
-			$avatar_url = $data->meta[ $avatar_meta_key ]['full'];
-			$avatar_id  = media_sideload_image( $avatar_url, 0, null, 'id' );
-			if ( $avatar_id && is_int( $avatar_id ) ) {
-				Debugger::log( 'Avatar successfully sideloaded with ID: ' . $avatar_id );
-				$simple_local_avatars->assign_new_user_avatar( $avatar_id, $existing_user->ID );
-			}
-		}
+		User_Utils::maybe_sideload_avatar( $existing_user->ID, $data->meta );
 
 	}
 

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -77,7 +77,7 @@ class User_Updated extends Abstract_Incoming_Event {
 			}
 		}
 
-		User_Utils::maybe_sideload_avatar( $existing_user->ID, $data->meta );
+		User_Utils::maybe_sideload_avatar( $existing_user->ID, $data->meta, true );
 
 	}
 

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -76,6 +76,24 @@ class User_Updated extends Abstract_Incoming_Event {
 			}
 		}
 
+		// @TODO move this to the User Utils class when it gets merged.
+		global $simple_local_avatars;
+		if ( ! $simple_local_avatars || ! is_a( $simple_local_avatars, 'Simple_Local_Avatars' ) ) {
+			return;
+		}
+
+		$avatar_meta_key = 'simple_local_avatar';
+
+		if ( array_key_exists( $avatar_meta_key, $data->meta ) && ! empty( $data->meta[ $avatar_meta_key ]['full'] ) ) {
+			Debugger::log( 'Updating user avatar' );
+			$avatar_url = $data->meta[ $avatar_meta_key ]['full'];
+			$avatar_id  = media_sideload_image( $avatar_url, 0, null, 'id' );
+			if ( $avatar_id && is_int( $avatar_id ) ) {
+				Debugger::log( 'Avatar successfully sideloaded with ID: ' . $avatar_id );
+				$simple_local_avatars->assign_new_user_avatar( $avatar_id, $existing_user->ID );
+			}
+		}
+
 	}
 
 }

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Network\Utils;
 
+use Newspack_Network\Debugger;
+
 /**
  * Class to watch the user for updates and trigger events
  */
@@ -51,6 +53,52 @@ class Users {
 
 		return get_user_by( 'id', $user_id );
 
+	}
+
+	/**
+	 * Looks for avatar information and tries to sideload it to the user
+	 *
+	 * @param int   $user_id The user ID to add the avatar to.
+	 * @param array $user_data The user data where we are going to look for the avatar. We are looking for the 'simple_local_avatar' meta key.
+	 * @return bool True if the avatar was sideloaded, false otherwise.
+	 */
+	public static function maybe_sideload_avatar( $user_id, $user_data ) {
+
+		Debugger::log( 'Attempting to sideload user avatar' );
+
+		global $simple_local_avatars;
+		if ( ! $simple_local_avatars || ! is_a( $simple_local_avatars, 'Simple_Local_Avatars' ) ) {
+			Debugger::log( 'Simple Local Avatars plugin not active, skipping' );
+			return false;
+		}
+
+		$avatar_meta_key = 'simple_local_avatar';
+
+		if ( ! is_array( $user_data ) ) {
+			$user_data = (array) $user_data;
+		}
+
+		if ( array_key_exists( $avatar_meta_key, $user_data ) && ! empty( $user_data[ $avatar_meta_key ]['full'] ) ) {
+			Debugger::log( 'Updating user avatar' );
+			$avatar_url = $user_data[ $avatar_meta_key ]['full'];
+
+			if ( ! function_exists( 'media_sideload_image' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/media.php';
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+				require_once ABSPATH . 'wp-admin/includes/media.php';
+				require_once ABSPATH . 'wp-admin/includes/image.php';
+			}
+
+			$avatar_id = media_sideload_image( $avatar_url, 0, null, 'id' );
+			if ( $avatar_id && is_int( $avatar_id ) ) {
+				Debugger::log( 'Avatar successfully sideloaded with ID: ' . $avatar_id );
+				$simple_local_avatars->assign_new_user_avatar( $avatar_id, $user_id );
+				return true;
+			}
+		}
+
+		Debugger::log( 'No avatar found in user data' );
+		return false;
 	}
 
 }

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -93,7 +93,6 @@ class Users {
 			if ( ! function_exists( 'media_sideload_image' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/media.php';
 				require_once ABSPATH . 'wp-admin/includes/file.php';
-				require_once ABSPATH . 'wp-admin/includes/media.php';
 				require_once ABSPATH . 'wp-admin/includes/image.php';
 			}
 

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -97,6 +97,12 @@ class Users {
 			}
 
 			$avatar_id = media_sideload_image( $avatar_url, 0, null, 'id' );
+
+			if ( is_wp_error( $avatar_id ) ) {
+				Debugger::log( 'Error sideloading avatar: ' . $avatar_id->get_error_message() );
+				return false;
+			}
+
 			if ( $avatar_id && is_int( $avatar_id ) ) {
 				Debugger::log( 'Avatar successfully sideloaded with ID: ' . $avatar_id );
 				$simple_local_avatars->assign_new_user_avatar( $avatar_id, $user_id );

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -60,9 +60,10 @@ class Users {
 	 *
 	 * @param int   $user_id The user ID to add the avatar to.
 	 * @param array $user_data The user data where we are going to look for the avatar. We are looking for the 'simple_local_avatar' meta key.
+	 * @param bool  $overwrite Whether to overwrite the existing avatar or not.
 	 * @return bool True if the avatar was sideloaded, false otherwise.
 	 */
-	public static function maybe_sideload_avatar( $user_id, $user_data ) {
+	public static function maybe_sideload_avatar( $user_id, $user_data, $overwrite ) {
 
 		Debugger::log( 'Attempting to sideload user avatar' );
 
@@ -73,6 +74,13 @@ class Users {
 		}
 
 		$avatar_meta_key = 'simple_local_avatar';
+
+		$existing_avatar = get_user_meta( $user_id, $avatar_meta_key, true );
+
+		if ( ! empty( $existing_avatar ) && ! $overwrite ) {
+			Debugger::log( 'User already has an avatar and overwrite is false, skipping' );
+			return false;
+		}
 
 		if ( ! is_array( $user_data ) ) {
 			$user_data = (array) $user_data;


### PR DESCRIPTION
Syncs user avatar upon changes - using Simple Local Avatars plugin

## Testing

* Set up a network with at least two sites
* Watch the logs for changes on the `simple_local_avatar` meta: `tail -f .../logfile | grep simple_local_avatar`
* Create a new user or edit a user that does not have an avatar yet
* Set an avatar for the user
* Confirm you see `Author update detected for xxxx: meta: simple_local_avatar` on your logs
* When you save the user you will also see one entry for `simple_local_avatar_rating`
* Create a new post and assign this author to the post
* Distribute the post to another site
* Confirm the user is created on the target site, and the avatar is also created there
* On the target site, Look at the media library and spot the new avatar there as the most recent item
* Back to the first site, edit a new post and assign the same author
* Distribute this new post
* Check that the post was distributed to the target site, but note that a new attachment was not uploaded to the media library - the user still gets the same avatar.

* On either of the sites, edit the user and change the avatar
* Watch the event being added in the Event Log
* Wait for the event to be pulled in the other site
* See the avatar was synced - confirm a new image was downloaded and added to the target site media library
* Now run the same test, but deleting the avatar from the user. After the event is propagated, the avatar should be removed from the user in the target site as well

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206041342845152