### PR TITLE
Add/sync newsletters subscriptions

### DIFF
--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -35,6 +35,8 @@ class Accepted_Actions {
 		'donation_new'                       => 'Donation_New',
 		'donation_subscription_cancelled'    => 'Donation_Subscription_Cancelled',
 		'network_user_updated'               => 'User_Updated',
+		'newsletter_subscribed'              => 'Newsletter_Subscribed',
+		'newsletter_updated'                 => 'Newsletter_Subscription_Updated',
 	];
 
 	/**
@@ -50,5 +52,7 @@ class Accepted_Actions {
 		'donation_new',
 		'donation_subscription_cancelled',
 		'network_user_updated',
+		'newsletter_subscribed',
+		'newsletter_updated',
 	];
 }

--- a/includes/incoming-events/class-donation-new.php
+++ b/includes/incoming-events/class-donation-new.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Hub Canonical Url Updated Incoming Event class
+ * Newspack Hub Donation New Incoming Event class
  *
  * @package Newspack
  */
@@ -12,9 +12,7 @@ use Newspack_Network\Node\Canonical_Url;
 use Newspack_Network\Utils\Users as User_Utils;
 
 /**
- * Class to handle the Canonical Url Updated Event
- *
- * This event is always sent from the Hub and received by Nodes.
+ * Class to handle the Donation New Event
  */
 class Donation_New extends Abstract_Incoming_Event {
 

--- a/includes/incoming-events/class-newsletter-subscribed.php
+++ b/includes/incoming-events/class-newsletter-subscribed.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Newspack Hub Newsletter Subscribed Incoming Event class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Debugger;
+use Newspack_Network\Utils\Users as User_Utils;
+
+/**
+ * Class to handle the Newsletter Subscribed Event
+ */
+class Newsletter_Subscribed extends Abstract_Incoming_Event {
+
+	/**
+	 * Processes the event
+	 *
+	 * @return void
+	 */
+	public function post_process_in_hub() {
+		$this->process_subscription();
+	}
+
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		$this->process_subscription();
+	}
+
+	/**
+	 * Process process_subscription
+	 *
+	 * @return void
+	 */
+	public function process_subscription() {
+		$email = $this->get_email();
+		Debugger::log( 'Processing newsleteter_subscribed with email: ' . $email );
+		if ( ! $email ) {
+			return;
+		}
+
+		$existing_user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
+
+		if ( is_wp_error( $existing_user ) ) {
+			return;
+		}
+
+		$node                               = $this->get_site();
+		$network_newsletter_subscriber_data = \Newspack\Reader_Data::get_data( $existing_user->ID, 'network_newsletter_subscriber' );
+
+		if ( $network_newsletter_subscriber_data ) {
+			$network_newsletter_subscriber_data = json_decode( $network_newsletter_subscriber_data, true );
+		} else {
+			$network_newsletter_subscriber_data = [];
+		}
+		if ( ! isset( $network_newsletter_subscriber_data[ $node ] ) ) {
+			$network_newsletter_subscriber_data[ $node ] = [];
+		}
+		$network_newsletter_subscriber_data[ $node ][ $this->get_timestamp() ] = [
+			'subscribed' => $this->get_data()->lists,
+		];
+		\Newspack\Reader_Data::update_item( $existing_user->ID, 'network_newsletter_subscriber', wp_json_encode( $network_newsletter_subscriber_data ) );
+		Debugger::log( 'Updated ' . $email . ' network newsletter subscriber status with for node ' . $node );
+	}
+
+}

--- a/includes/incoming-events/class-newsletter-subscription-updated.php
+++ b/includes/incoming-events/class-newsletter-subscription-updated.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Newspack Hub Newsletter Subscription_Updated Incoming Event class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Debugger;
+use Newspack_Network\Utils\Users as User_Utils;
+
+/**
+ * Class to handle the Newsletter Subscription_Updated Event
+ */
+class Newsletter_Subscription_Updated extends Abstract_Incoming_Event {
+
+	/**
+	 * Processes the event
+	 *
+	 * @return void
+	 */
+	public function post_process_in_hub() {
+		$this->process_subscription();
+	}
+
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		$this->process_subscription();
+	}
+
+	/**
+	 * Process process_subscription
+	 *
+	 * @return void
+	 */
+	public function process_subscription() {
+		$email = $this->get_email();
+		Debugger::log( 'Processing newsleteter_updated with email: ' . $email );
+		if ( ! $email ) {
+			return;
+		}
+
+		$existing_user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
+
+		if ( is_wp_error( $existing_user ) ) {
+			return;
+		}
+
+		$node                               = $this->get_site();
+		$network_newsletter_subscriber_data = \Newspack\Reader_Data::get_data( $existing_user->ID, 'network_newsletter_subscriber' );
+
+		if ( $network_newsletter_subscriber_data ) {
+			$network_newsletter_subscriber_data = json_decode( $network_newsletter_subscriber_data, true );
+		} else {
+			$network_newsletter_subscriber_data = [];
+		}
+		if ( ! isset( $network_newsletter_subscriber_data[ $node ] ) ) {
+			$network_newsletter_subscriber_data[ $node ] = [];
+		}
+		$network_newsletter_subscriber_data[ $node ][ $this->get_timestamp() ] = [
+			'subscribed'   => $this->get_data()->lists_added,
+			'unsubscribed' => $this->get_data()->lists_removed,
+		];
+		\Newspack\Reader_Data::update_item( $existing_user->ID, 'network_newsletter_subscriber', wp_json_encode( $network_newsletter_subscriber_data ) );
+		Debugger::log( 'Updated ' . $email . ' network newsletter subscriber status with for node ' . $node );
+	}
+
+}


### PR DESCRIPTION
Syncs events related to newsletters subscription to populate the Reader Data library.

This will create the `network_newsletter_subscriber` entry in the local storage.

## Testing

* In a site in the network, subscribe to a newsletter with a brand new user
* See the `newletter_subscribed` event appear in the Event Log
* In another site, see the new `network_newsletter_subscriber` entry appearing in the local storage once you log in with the same email

![image](https://github.com/Automattic/newspack-network/assets/971483/65c2c932-2810-417c-ba51-624f9e74167d)

The item should containt the url of the site where the subscription happened, the timestamp, and then the lists they were subscribed to

* Verify the user and go to My Account
* Change your chosen lists
* See the `newsletter_updated` appear in the Event log
* When the event is propagated to the other site, see a new entry in the `network_newsletter_subscriber`, now with a list of subscribed and unsubscribed lists

![Captura de tela de 2023-12-12 16-09-00](https://github.com/Automattic/newspack-network/assets/971483/631eea92-5f7e-4b5b-a49f-b487e921cda4)
