### PR TITLE
feat: update authors on post update

### DIFF
--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -26,8 +26,11 @@ class Author_Distribution {
 	 */
 	public static function init() {
 		add_filter( 'dt_push_post_args', [ __CLASS__, 'add_author_data_to_push' ], 10, 2 );
+		add_filter( 'dt_subscription_post_args', [ __CLASS__, 'add_author_data_to_push' ], 10, 2 );
 		add_filter( 'rest_prepare_post', [ __CLASS__, 'add_author_data_to_pull' ], 10, 3 );
 		add_filter( 'dt_syncable_taxonomies', [ __CLASS__, 'filter_syncable_taxonomies' ] );
+
+		add_filter( 'rest_request_after_callbacks', [ __CLASS__, 'after_coauthors_update' ], 10, 3 );
 	}
 
 	/**
@@ -50,6 +53,9 @@ class Author_Distribution {
 
 	/**
 	 * Filters the post data sent on a push to add the author data.
+	 *
+	 * This callback is also used to add data to the post sent to the subscription endpoint.
+	 * (sends an update to the linked posts in other sites)
 	 *
 	 * @param array   $post_body The post data.
 	 * @param WP_Post $post The post object.
@@ -216,6 +222,41 @@ class Author_Distribution {
 		}
 
 		return $author;
+	}
+
+	/**
+	 * Sends an extra notification to subscribers when the authors of a post are updated.
+	 *
+	 * CoAuthors Plus updates the authors through an additional ajax request in the editor after the post is updated,
+	 * therefore when we change the authors and update the post in the Editor, the notification sent to the subscribers still
+	 * has the old authors
+	 *
+	 * We don't filter the response here, we just send the notification.
+	 *
+	 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response Result to send to the client.
+	 * @param array                                            $handler  Route handler used for the request.
+	 * @param WP_REST_Request                                  $request  Request used to generate the response.
+	 * @return WP_REST_Response|WP_HTTP_Response|WP_Error|mixed
+	 */
+	public static function after_coauthors_update( $response, $handler, $request ) {
+
+		if ( ! class_exists( 'CoAuthors\API\Endpoints' ) || ! function_exists( 'Distributor\Subscriptions\send_notifications' ) ) {
+			return $response;
+		}
+
+		$coauthors_endpoint_base = \CoAuthors\API\Endpoints::NS . '/' . \CoAuthors\API\Endpoints::AUTHORS_ROUTE;
+
+		if ( false === strpos( $request->get_route(), $coauthors_endpoint_base ) ) {
+			return $response;
+		}
+
+		if ( 'POST' !== $request->get_method() ) {
+			return $response;
+		}
+
+		\Distributor\Subscriptions\send_notifications( (int) $request->get_param( 'post_id' ) );
+
+		return $response;
 	}
 
 }

--- a/includes/distributor-customizations/class-author-ingestion.php
+++ b/includes/distributor-customizations/class-author-ingestion.php
@@ -33,6 +33,7 @@ class Author_Ingestion {
 	 */
 	public static function init() {
 		add_action( 'rest_insert_post', [ __CLASS__, 'handle_rest_insertion' ], 10, 2 );
+		add_action( 'dt_process_subscription_attributes', [ __CLASS__, 'handle_rest_insertion' ], 10, 2 );
 		add_filter( 'dt_item_mapping', [ __CLASS__, 'capture_authorship' ], 10, 2 );
 		add_action( 'dt_pull_post', [ __CLASS__, 'handle_pull' ] );
 	}
@@ -54,6 +55,8 @@ class Author_Ingestion {
 	 * Fired when a post is inserted via the REST API
 	 *
 	 * Checks if there are newspack network author information and ingests it.
+	 *
+	 * This callback is also used when a subscription update is received.
 	 *
 	 * @param WP_Post         $post     Inserted post object.
 	 * @param WP_REST_Request $request  Request object.


### PR DESCRIPTION
https://github.com/Automattic/newspack-network/pull/17 distributes authors when a post is first distributed.

But if a post is updated, and there are still linked posts out there, the authorship is not being updated... until this PR.

Distributor plugin calls it Subscriptions. A post that have been distributed to another site (either via push or pull) creates a subscription to the post on the origin site. If the original post changes, Distributor sends a notification to all subscribers of that post and update the linked posts.

This PR hooks into this action and also update the authors when this happens.

There was an extra step needed for CAP, because it does not update authors on the `save_post` event, but through a additional REST request made after the post is saved in the editor. So when we receive that API request and the authors are updates, we need to send a new notification.

## How to test

* Create a post, with multiple authors and push it to another site
* Confirm the post is distributed along with its authors
* Back to the origin site, edit a post and change the authors. Save
* Confirm that the authors are updated in the distributed post
* Try changing the authorship through quick edit and confirm the changes are also distributed