### PR TITLE
feat: add event queue debug

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -30,7 +30,7 @@ For example, the `reader_registered` event will create or update a WP User in th
 
 The Hub can also be an active site in the network. So events that happen on the Hub should also be propagated as if it was just another node.
 
-But when an event is fired in the Hub, there's no need to send a webhook request to itself. So we simply listen to events fired by the Data Events API and trigger the process to persist it into the `Event_Log`. This is done by `Hub\Event_Listeners` and it basically does the same thing `Hub\Webhook` does, but it is listening to local events instead of receiving webhook requests from a Node. 
+But when an event is fired in the Hub, there's no need to send a webhook request to itself. So we simply listen to events fired by the Data Events API and trigger the process to persist it into the `Event_Log`. This is done by `Hub\Event_Listeners` and it basically does the same thing `Hub\Webhook` does, but it is listening to local events instead of receiving webhook requests from a Node.
 
 ## Nodes pulling events from the hub
 
@@ -109,20 +109,15 @@ All log messages will include the process id (pid) as the first part of the mess
 
 ### When an event is fired in a Node
 
-Newspack Network will listen to the Newspack Data Events API, which has its own way to dispatch events asynchronously. If Woocommerce is installed, it will use the Action Scheduler lib, otherwise it will simply dispatch a dedicated request to process the event.
+Newspack Network will listen to the Newspack Data Events API.
 
-So before we can even begin to follow the event through the Newspack Network flow, it needs to be dispatched. Sometimes it can take one or two minutes.
-
-You can inspect it in the `Tools > Scheduled Actions` panel if Woocommerce is active, and the Data Events API will also output plenty of information in the logs.
-
-When the event is finally dispatched in a Node, it will create a new webhook request. See [Data Events Webhooks](https://github.com/Automattic/newspack-plugin/blob/master/includes/data-events/class-webhooks.php) for details on how it works.
+When an event dispatched in a Node, it will create a new webhook request. See [Data Events Webhooks](https://github.com/Automattic/newspack-plugin/blob/master/includes/data-events/class-webhooks.php) for details on how it works.
 
 In short, a webhook is a Custom Post type post scheduled to be published in the future. Once it's published, the request is sent. If it fails, it schedules itself again for the future, incresing the wait time in a geometric progression.
 
-When the event is dispatched, you should not see anything special in the logs. Everything is handled by webhooks, so you can:
-* Go to Newspack > Connections > Webhooks and see if the request was scheduled there
-* Manually check the requests on the database
-* Manually dispatch requests using `Newspack\Data_Events\Webhooks::process_request( $request_id )`
+You can see the scheduled webhook requests in Newspack Network > Node Settings under the "Events queue" section.
+
+* If you want to manually and immeditally send a webhook request, you can do so using `Newspack\Data_Events\Webhooks::process_request( $request_id )`
 
 When the request is sent, Webhooks will output a message starting with `[NEWSPACK-WEBHOOKS] Sending request` in the logs.
 

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -336,7 +336,7 @@ class Settings {
 									sprintf(
 										/* translators: %s is the number of errors */
 										_n(
-											'There was %s failed attempts to send this request',
+											'There was %s failed attempt to send this request',
 											'There were %s failed attempts to send this request',
 											count( $request['errors'] ),
 											'newspack-network'

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -314,7 +314,7 @@ class Settings {
 				?>
 
 				<tr>
-					<td><?php echo esc_html( $date ); ?></td>
+					<td><?php echo esc_html( $date ); ?> (#<?php echo esc_html( $r['request_id'] ); ?>)</td>
 					<td><?php echo esc_html( $r['action'] ); ?></td>
 					<td><code><?php echo esc_html( $data ); ?></code></td>
 					<td>

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -283,10 +283,10 @@ class Settings {
 
 		?>
 		<h3>
-			<?php esc_html_e( 'Events queue', 'newspack-network' ); ?>
+			<?php esc_html_e( 'Scheduled Events', 'newspack-network' ); ?>
 		</h3>
 		<p>
-			<?php esc_html_e( 'The following events are queued to be sent or have recently been sent to the Hub.', 'newspack-network' ); ?>
+			<?php esc_html_e( 'The following events are scheduled to be sent or have recently been sent to the Hub.', 'newspack-network' ); ?>
 		</p>
 		<table class="wp-list-table widefat fixed striped table-view-list">
 			<thead>


### PR DESCRIPTION
Adds a debug section that shows the events that are scheduled to be sent from the Node to the Hub

## Testing

Perform some actions in the Node, like registering with a new user, or editing a user profile in admin.

Go to Newspack Network > Node Settings and see the new "Events queue" section. Confirm the events are there, scheduled to be sent

![Captura de tela de 2024-01-15 12-42-12](https://github.com/Automattic/newspack-network/assets/971483/aeeba2dd-03ca-4fcf-a84a-dcaf3aa00178)

Force some errors, by setting a wrong URL to the Hub, or making the Hub not accessible.

Perform a new action and wait for it to display errors

![Captura de tela de 2024-01-15 12-42-35](https://github.com/Automattic/newspack-network/assets/971483/3b85dc86-e99a-4d07-a9b4-66c3688de467)

Note 1: Not adding a "Send now" button at this moment
