### PR TITLE
fix: update author distribution on pull

### DIFF
--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -27,7 +27,7 @@ class Author_Distribution {
 	public static function init() {
 		add_filter( 'dt_push_post_args', [ __CLASS__, 'add_author_data_to_push' ], 10, 2 );
 		add_filter( 'dt_subscription_post_args', [ __CLASS__, 'add_author_data_to_push' ], 10, 2 );
-		add_filter( 'rest_prepare_post', [ __CLASS__, 'add_author_data_to_pull' ], 10, 3 );
+		add_filter( 'dt_post_to_pull', [ __CLASS__, 'add_author_data_to_pull' ] );
 		add_filter( 'dt_syncable_taxonomies', [ __CLASS__, 'filter_syncable_taxonomies' ] );
 
 		add_filter( 'rest_request_after_callbacks', [ __CLASS__, 'after_coauthors_update' ], 10, 3 );
@@ -74,29 +74,18 @@ class Author_Distribution {
 	 *
 	 * This acts on requests made to pull a post from this site.
 	 *
-	 * @param WP_REST_Response $response The response object.
-	 * @param WP_Post          $post     Post object.
-	 * @param WP_REST_Request  $request  Request object.
+	 * @param array $post_array The post data.
 	 */
-	public static function add_author_data_to_pull( $response, $post, $request ) {
-		if (
-			empty( $request->get_param( 'distributor_request' ) ) ||
-			'GET' !== $request->get_method() ||
-			'edit' !== $request->get_param( 'context' ) ||
-			empty( $request->get_param( 'id' ) )
-		) {
-			return $response;
-		}
+	public static function add_author_data_to_pull( $post_array ) {
 
-		$authors = self::get_authors_for_distribution( $post );
+		$authors = self::get_authors_for_distribution( (object) $post_array );
 
 		if ( ! empty( $authors ) ) {
-			$data                             = $response->get_data();
-			$data['newspack_network_authors'] = $authors;
-			$response->set_data( $data );
+			Debugger::log( 'Adding authors to pull' );
+			$post_array['newspack_network_authors'] = $authors;
 		}
 
-		return $response;
+		return $post_array;
 
 	}
 

--- a/includes/distributor-customizations/class-author-distribution.php
+++ b/includes/distributor-customizations/class-author-distribution.php
@@ -10,6 +10,7 @@ namespace Newspack_Network\Distributor_Customizations;
 use Newspack\Data_Events;
 use Newspack_Network\Debugger;
 use Newspack_Network\User_Update_Watcher;
+use WP_Error;
 
 /**
  * Class to handle author distribution.


### PR DESCRIPTION
Makes it work with Distributor v2.0.3

Testing

* Establish a network with 2 or 3 sites. (newspack_docker is your friend here, since it automatically creates a bunch of sites and connect them both on Newspack Network plugin and on Distributor plugin, creating needed the keys and application passwords)
* Make sure you are running distributor v2.0.3 in all sites
* On one of the sites, create a post, and assign it multiple authors, having at least one wp user and one guest author
* Distribute this post via push to another site
* In the target site, observe the WP_User was created and the authorship was properly assigned
* Observe the `newspack_network_authors` post_meta and see all authors are there, including the guest author
* Repeat the process, now pulling a post from a site instead of pushing
* Make sure to fill all fields of the authors and confirm all fields are propagated (name, bio, site, job, etc)
* In the original site, edit the post and change authors. Save
* Confirm the linked post in the other sites gets the updates