### PR TITLE
Fix Yoast primary category

### DIFF
--- a/includes/class-distributor-customizations.php
+++ b/includes/class-distributor-customizations.php
@@ -24,6 +24,4 @@ class Distributor_Customizations {
 		Distributor_Customizations\Author_Ingestion::init();
 		Distributor_Customizations\Authorship_Filters::init();
 	}
-
-
 }

--- a/includes/distributor-customizations/global.php
+++ b/includes/distributor-customizations/global.php
@@ -29,13 +29,9 @@ function newspack_network_get_primary_category_slug( $post_body, $post ) {
  * @param WP_REST_Request $request The request data.
  */
 function newspack_network_fix_primary_category( $post, $request ) {
-	$primary_category_id   = get_post_meta( $post->ID, '_yoast_wpseo_primary_category', true );
 	$primary_category_slug = get_post_meta( $post->ID, 'yoast_primary_category_slug', true );
-	$hub_primary_category  = get_term( $primary_category_id );
-	if ( ! $hub_primary_category ) {
-		// Attempt to find a matching category on the Hub site by slug.
-		$hub_primary_category = get_term_by( 'slug', $primary_category_slug, 'category' );
-	}
+	// Match the category by slug, the IDs might have a clash.
+	$hub_primary_category = get_term_by( 'slug', $primary_category_slug, 'category' );
 	if ( $hub_primary_category ) {
 		update_post_meta( $post->ID, '_yoast_wpseo_primary_category', $hub_primary_category->term_id );
 	} elseif ( class_exists( '\Newspack\Logger' ) ) {

--- a/includes/distributor-customizations/global.php
+++ b/includes/distributor-customizations/global.php
@@ -50,11 +50,11 @@ function newspack_network_get_primary_category_slug( $post, $is_pulling = false 
  * @param WP_Post $post The post object.
  */
 function newspack_network_fix_primary_category( $post ) {
-	$primary_category_slug = get_post_meta( $post->ID, 'yoast_primary_category_slug', true );
+	$primary_category_slug = get_post_meta( $post->ID, 'newspack_network_primary_cat_slug', true );
 	// Match the category by slug, the IDs might have a clash.
-	$hub_primary_category = get_term_by( 'slug', $primary_category_slug, 'category' );
-	if ( $hub_primary_category ) {
-		update_post_meta( $post->ID, '_yoast_wpseo_primary_category', $hub_primary_category->term_id );
+	$found_primary_category = get_term_by( 'slug', $primary_category_slug, 'category' );
+	if ( $found_primary_category ) {
+		update_post_meta( $post->ID, '_yoast_wpseo_primary_category', $found_primary_category->term_id );
 	} elseif ( class_exists( '\Newspack\Logger' ) ) {
 		\Newspack\Logger::error( __( 'No matching category found on the Hub site.', 'newspack-network' ) );
 	}
@@ -73,7 +73,7 @@ add_filter(
 
 		$slug = newspack_network_get_primary_category_slug( $post );
 		if ( $slug ) {
-			$post_body['distributor_meta']['yoast_primary_category_slug'] = $slug;
+			$post_body['distributor_meta']['newspack_network_primary_cat_slug'] = $slug;
 		}
 
 		return $post_body;
@@ -94,7 +94,7 @@ add_filter(
 
 		$slug = newspack_network_get_primary_category_slug( $post, true );
 		if ( $slug ) {
-			$post_array['meta_input']['yoast_primary_category_slug'] = $slug;
+			$post_array['meta_input']['newspack_network_primary_cat_slug'] = $slug;
 		}
 
 		return $post_array;
@@ -130,7 +130,7 @@ add_filter(
 	'dt_subscription_post_args',
 	function( $post_body, $post ) {
 		$slug = newspack_network_get_primary_category_slug( $post );
-		$post_body['post_data']['distributor_meta']['yoast_primary_category_slug'] = $slug;
+		$post_body['post_data']['distributor_meta']['newspack_network_primary_cat_slug'] = $slug;
 		return $post_body;
 	},
 	10,

--- a/includes/distributor-customizations/global.php
+++ b/includes/distributor-customizations/global.php
@@ -1,23 +1,64 @@
 <?php
 /**
- * This files contains the global tweaks that are loaded by default in every site in the Network (bot Hub and Nodes)
+ * This files contains the global tweaks that are loaded by default in every site in the Network (both Hub and Nodes).
  *
  * @package newspack-network
  */
 
 /**
- * =========================================
- * ======== Post publication date ==========
- * =========================================
- * Keep the publication date on the new pushed post.
+ * Send primary category slug to the Node along with post update data.
  *
- * This filter is used to filter the arguments sent to the remote server during a push. The below code snippet passes the original published date to the new pushed post and sets the same published date instead of setting it as per the current time.
+ * @param array   $post_body The post data to be sent to the Node.
+ * @param WP_Post $post The post object.
+ */
+function newspack_network_get_primary_category_slug( $post_body, $post ) {
+	if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+		$primary_term = new WPSEO_Primary_Term( 'category', $post->ID );
+		$category_id  = $primary_term->get_primary_term();
+		if ( $category_id ) {
+			$category = get_term( $category_id );
+			return $category->slug;
+		}
+	}
+}
+
+/**
+ * Fix primary category on the Node.
+ *
+ * @param WP_Post         $post The post object.
+ * @param WP_REST_Request $request The request data.
+ */
+function newspack_network_fix_primary_category( $post, $request ) {
+	$primary_category_id   = get_post_meta( $post->ID, '_yoast_wpseo_primary_category', true );
+	$primary_category_slug = get_post_meta( $post->ID, 'yoast_primary_category_slug', true );
+	$hub_primary_category  = get_term( $primary_category_id );
+	if ( ! $hub_primary_category ) {
+		// Attempt to find a matching category on the Hub site by slug.
+		$hub_primary_category = get_term_by( 'slug', $primary_category_slug, 'category' );
+	}
+	if ( $hub_primary_category ) {
+		update_post_meta( $post->ID, '_yoast_wpseo_primary_category', $hub_primary_category->term_id );
+	} elseif ( class_exists( '\Newspack\Logger' ) ) {
+		\Newspack\Logger::error( __( 'No matching category found on the Hub site.', 'newspack-network' ) );
+	}
+}
+
+/**
+ * This filter is used to filter the arguments sent to the remote server during a push.
  */
 add_filter(
 	'dt_push_post_args',
 	function( $post_body, $post ) {
+		// Pass the original published date to the new pushed post and set the same published date
+		// instead of setting it to the current time.
 		$post_body['date']     = $post->post_date;
 		$post_body['date_gmt'] = $post->post_date_gmt;
+
+		$slug = newspack_network_get_primary_category_slug( $post_body, $post );
+		if ( $slug ) {
+			$post_body['distributor_meta']['yoast_primary_category_slug'] = $slug;
+		}
+
 		return $post_body;
 	},
 	10,
@@ -38,34 +79,19 @@ add_filter(
 	10,
 	3
 );
-/**
- * =========================================
- * ===== End of Post publication date ======
- * =========================================
- */
 
 /**
- * =========================================
- * ===== Allow editors to pull content =====
- * =========================================
+ * Allow editors to pull content.
  */
 function newspack_network_filter_distributor_menu_cap() {
 	return 'edit_others_posts';
 }
 add_filter( 'dt_capabilities', 'newspack_network_filter_distributor_menu_cap' );
 add_filter( 'dt_pull_capabilities', 'newspack_network_filter_distributor_menu_cap' );
-/**
- * =========================================
- * ==== End of editors to pull content =====
- * =========================================
- */
 
 /**
- * =========================================
- * =========== Bug Workaround ==============
  * This is a workaround the bug fixed in https://github.com/10up/distributor/pull/1185
  * Until that fix is released, we need to keep this workaround.
- * =========================================
  */
 add_action(
 	'init',
@@ -73,3 +99,23 @@ add_action(
 		wp_cache_delete( 'dt_media::{$post_id}', 'dt::post' );
 	}
 );
+
+/**
+ * Send primary category slug to the Node when updating a post.
+ */
+add_filter(
+	'dt_subscription_post_args',
+	function( $post_body, $post ) {
+		$slug = newspack_network_get_primary_category_slug( $post_body, $post );
+		$post_body['post_data']['distributor_meta']['yoast_primary_category_slug'] = $slug;
+		return $post_body;
+	},
+	10,
+	2
+);
+
+/**
+ * Map Hub primary category to the primary category on the Node.
+ */
+add_action( 'dt_process_subscription_attributes', 'newspack_network_fix_primary_category', 10, 2 );
+add_action( 'dt_process_distributor_attributes', 'newspack_network_fix_primary_category', 10, 2 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With this change, Yoast's primary category will be interpreted on the Node site. Even though the taxonomies are sync'd between sites by Distributor, Yoast's primary category – stored as post meta – was not handled, and its ID still pointed to the ID of the category on the Hub site. 

See 1200550061930446-as-1206399433499334/f

### How to test the changes in this Pull Request:

1. On the hub site, create a new category and publish a post after setting the new category as the primary category
2. Observe that the distributed post on the Node site has the correct primary category set*
3. Create yet another new category and update that same post so now it has this new category as the primary category 
4. Again observe that the distribute post on the Node site has the correct primary category set

\* this is stored as the `_yoast_wpseo_primary_category` post meta

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->