### PR TITLE
fix(data-listeners): handle no user in wc data update

### DIFF
--- a/includes/class-data-listeners.php
+++ b/includes/class-data-listeners.php
@@ -58,10 +58,10 @@ class Data_Listeners {
 				$relationship = 'parent';
 			}
 		}
-		return [
+		$result = [
 			'id'                        => $item_id,
 			'user_id'                   => $item->get_customer_id(),
-			'user_name'                 => $item->get_user()->display_name,
+			'user_name'                 => '',
 			'email'                     => $item->get_billing_email(),
 			'status_before'             => $status_from,
 			'status_after'              => $status_to,
@@ -69,6 +69,11 @@ class Data_Listeners {
 			'payment_count'             => method_exists( $item, 'get_payment_count' ) ? $item->get_payment_count() : 1,
 			'subscription_relationship' => $relationship,
 		];
+		$user   = $item->get_user();
+		if ( $user ) {
+			$result['user_name'] = $user->display_name;
+		}
+		return $result;
 	}
 
 	/**
@@ -80,5 +85,4 @@ class Data_Listeners {
 	public static function user_updated( $user_data ) {
 		return $user_data;
 	}
-
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds handling of a tiny edge-case. 

### How to test the changes in this Pull Request:

1. On `trunk`, set up a subscription and then remove the related user
2. Trash the subscription, observe a PHP warning logged – the user does not exist
3. Switch to this branch, repeat, observe no PHP warning

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->