### PR TITLE
fix: prevent coauthors capability check infinite loop

### DIFF
--- a/includes/distributor-customizations/class-authorship-filters.php
+++ b/includes/distributor-customizations/class-authorship-filters.php
@@ -44,13 +44,14 @@ class Authorship_Filters {
 		}
 
 		// We don't want to filter authors on admin, as it might break things.
-		if ( is_admin() || defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		if ( is_admin() ) {
 			return $coauthors;
 		}
 
 		// Only filter posts that are still linked to the original post.
-		$distributor_post = new DistributorPost( $post_id );
-		if ( ! $distributor_post->is_linked ) {
+		// We check the dt_unlinked post meta to determine linked status.
+		// See: https://github.com/10up/distributor/blob/1f180d74db804a057f7331ce62338e571dd73350/docs/post-meta.md?plain=1#L38.
+		if ( get_post_meta( $post_id, 'dt_unlinked', true ) ) {
 			return $coauthors;
 		}
 

--- a/includes/distributor-customizations/class-authorship-filters.php
+++ b/includes/distributor-customizations/class-authorship-filters.php
@@ -44,7 +44,7 @@ class Authorship_Filters {
 		}
 
 		// We don't want to filter authors on admin, as it might break things.
-		if ( is_admin() ) {
+		if ( is_admin() || defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			return $coauthors;
 		}
 


### PR DESCRIPTION
Closes `0/1206331646877116/1206535636784422/f`

This fixes an issue where, when NP Network, Distributor, CAP, and NP Newsletters are active, sending a newsletters causes an infinite capability check which results in a fatal memory error.

The issue happens because we are creating a Distributor Post object to check a distributed posts linked status when filtering coauthors via the `get_coauthors` hook. But this same hook is eventually triggered in the instantiation of the Distributor Post object.

This PR fixes this by checking a posts linked status directly via post meta.

### Testing steps

1. Make sure you have a test site set up with Newspack Network, Distributor, Co-Authors Plus, and Newsletters, and mailchimp ESP setup
2. Create a new newsletter and send it to an audience while watching debug log
3. On trunk, you should see an memory fatal. On this branch you should not

![Screenshot 2024-02-12 at 15 55 57](https://github.com/Automattic/newspack-network/assets/17905991/3e38234f-f95d-4f54-be6d-2b4ed6b07fab)
