### PR TITLE
fix: dynamic class property deprecated warnings

### DIFF
--- a/includes/hub/stores/class-abstract-event-log-item.php
+++ b/includes/hub/stores/class-abstract-event-log-item.php
@@ -57,6 +57,13 @@ abstract class Abstract_Event_Log_Item {
 	private $timestamp;
 
 	/**
+	 * The action name associated with the Event Log Item.
+	 *
+	 * @var string
+	 */
+	private $action_name;
+
+	/**
 	 * Creates an instance of an Event Log Item
 	 *
 	 * Do not create an object of this class directly. Instead, use the Event_Log Store class.

--- a/includes/hub/stores/class-abstract-event-log-item.php
+++ b/includes/hub/stores/class-abstract-event-log-item.php
@@ -40,7 +40,7 @@ abstract class Abstract_Event_Log_Item {
 	 *
 	 * @var string
 	 */
-	private $action;
+	private $action_name;
 
 	/**
 	 * The data associated with the Event Log Item.
@@ -55,13 +55,6 @@ abstract class Abstract_Event_Log_Item {
 	 * @var string
 	 */
 	private $timestamp;
-
-	/**
-	 * The action name associated with the Event Log Item.
-	 *
-	 * @var string
-	 */
-	private $action_name;
 
 	/**
 	 * Creates an instance of an Event Log Item

--- a/includes/incoming-events/class-abstract-incoming-event.php
+++ b/includes/incoming-events/class-abstract-incoming-event.php
@@ -40,6 +40,13 @@ class Abstract_Incoming_Event {
 	protected $timestamp;
 
 	/**
+	 * The site url
+	 *
+	 * @var string
+	 */
+	protected $site;
+
+	/**
 	 * Constructs a new Incoming Event
 	 *
 	 * @param string       $site      The origin site URL.


### PR DESCRIPTION
This PR just addresses some warnings flooding the logs:

![Screenshot 2024-02-13 at 10 40 58](https://github.com/Automattic/newspack-network/assets/17905991/8aaec44e-f2a9-4bcc-8516-fa95f391e741)

![Screenshot 2024-02-13 at 10 40 40](https://github.com/Automattic/newspack-network/assets/17905991/9243e12b-c795-4363-9c69-cb53b1171b68)


### Testing instructions

Code review should be fine, but feel free to checkout this branch and confirm these warning no longer appear whenever network related events are triggered.