### PR TITLE
chore: reorganize distributor tweaks code

### DIFF
--- a/includes/class-distributor-customizations.php
+++ b/includes/class-distributor-customizations.php
@@ -18,7 +18,11 @@ class Distributor_Customizations {
 	 * @return void
 	 */
 	public static function init() {
-		Distributor_Customizations\Base::init();
+		Distributor_Customizations\Pull_Permissions::init();
+		Distributor_Customizations\Publication_Date::init();
+		Distributor_Customizations\Cache_Bug_Workaround::init();
+		Distributor_Customizations\Yoast_Primary_Cat::init();
+		Distributor_Customizations\Sync_Post_Status::init();
 		Distributor_Customizations\Canonical_Url::init();
 		Distributor_Customizations\Author_Distribution::init();
 		Distributor_Customizations\Author_Ingestion::init();

--- a/includes/distributor-customizations/class-cache-bug-workaround.php
+++ b/includes/distributor-customizations/class-cache-bug-workaround.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Newspack Distributor Bug Workaround
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+/**
+ * Class to workaround a bug in the Distributor plugin that affects site running with memcached.
+ *
+ * This is a workaround the bug fixed in https://github.com/10up/distributor/pull/1185
+ * Until that fix is released, we need to keep this workaround.
+ */
+class Cache_Bug_Workaround {
+
+	/**
+	 * Initialize hooks
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'workaround' ] );
+	}
+
+	/**
+	 * Deletes the buggy cache key
+	 */
+	public static function workaround() {
+		wp_cache_delete( 'dt_media::{$post_id}', 'dt::post' );
+	}
+
+}

--- a/includes/distributor-customizations/class-publication-date.php
+++ b/includes/distributor-customizations/class-publication-date.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Newspack Distributor Publication Date tweak.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+/**
+ * Class to keep the publication date on the distributed posts.
+ */
+class Publication_Date {
+
+	/**
+	 * Initialize hooks
+	 */
+	public static function init() {
+		add_filter( 'dt_push_post_args', [ __CLASS__, 'filter_push_post_args' ], 10, 2 );
+		add_filter( 'dt_pull_post_args', [ __CLASS__, 'filter_pull_post_args' ], 10, 3 );
+	}
+
+	/**
+	 * Filter the arguments sent to the remote server during a push
+	 *
+	 * @param array   $post_body The post data to be sent to the Node.
+	 * @param WP_Post $post The post object.
+	 */
+	public static function filter_push_post_args( $post_body, $post ) {
+		// Pass the original published date to the new pushed post and set the same published date
+		// instead of setting it to the current time.
+		$post_body['date']     = $post->post_date;
+		$post_body['date_gmt'] = $post->post_date_gmt;
+
+		return $post_body;
+	}
+
+	/**
+	 * Keep the publication date on the new pulled post
+	 *
+	 * @param array   $post_array The post data to be sent to the Node.
+	 * @param int     $remote_id The remote post ID.
+	 * @param WP_Post $post The post object.
+	 */
+	public static function filter_pull_post_args( $post_array, $remote_id, $post ) {
+		$post_array['post_date']     = $post->post_date;
+		$post_array['post_date_gmt'] = $post->post_date_gmt;
+
+		return $post_array;
+	}
+}

--- a/includes/distributor-customizations/class-pull-permissions.php
+++ b/includes/distributor-customizations/class-pull-permissions.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Newspack Distributor Tweak who can pull content
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+/**
+ * Class to allow editors to pull content
+ */
+class Pull_Permissions {
+
+	/**
+	 * Initialize hooks
+	 */
+	public static function init() {
+		add_filter( 'dt_capabilities', [ __CLASS__, 'filter_distributor_menu_cap' ] );
+		add_filter( 'dt_pull_capabilities', [ __CLASS__, 'filter_distributor_menu_cap' ] );
+	}
+
+	/**
+	 * Allow editors to pull content
+	 */
+	public static function filter_distributor_menu_cap() {
+		return 'edit_others_posts';
+	}
+}

--- a/includes/distributor-customizations/class-sync-post-status.php
+++ b/includes/distributor-customizations/class-sync-post-status.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Newspack Distributor Sync post status
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+/**
+ * Class to sync post status when a post is trashed or restored from trash
+ */
+class Sync_Post_Status {
+
+	const POST_STATUS_META_NAME = 'newspack_network_post_status';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'dt_subscription_post_args', [ __CLASS__, 'filter_subscription_post_args' ], 10, 2 );
+		add_action( 'dt_process_subscription_attributes', [ __CLASS__, 'process_attributes' ], 10, 2 );
+		add_action( 'dt_process_distributor_attributes', [ __CLASS__, 'process_attributes' ], 10, 2 );
+	}
+
+	/**
+	 * Process distributed post attributes after the distribution has completed.
+	 *
+	 * @param WP_Post $post The post object.
+	 */
+	public static function process_attributes( $post ) {
+		$hub_post_status     = get_post_meta( $post->ID, self::POST_STATUS_META_NAME, true );
+		$current_post_status = get_post_status( $post->ID );
+		if ( $hub_post_status && $hub_post_status !== $current_post_status ) {
+			wp_update_post(
+				[
+					'ID'          => $post->ID,
+					'post_status' => $hub_post_status,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Send primary category slug to the Node when updating a post.
+	 *
+	 * @param array   $post_body The post data to be sent to the Node.
+	 * @param WP_Post $post The post object.
+	 */
+	public static function filter_subscription_post_args( $post_body, $post ) {
+		// Attaching the post status only on updates (so not in filter_push_post_args).
+		// By default, only published posts are distributable, so there's no need to attach the post status on new posts.
+		$distributable_statuses = [ 'publish', 'trash' ];
+		if ( in_array( $post->post_status, $distributable_statuses, true ) ) {
+			$post_body['post_data']['distributor_meta'][ self::POST_STATUS_META_NAME ] = $post->post_status;
+		}
+		return $post_body;
+	}
+
+
+}

--- a/includes/distributor-customizations/class-sync-post-status.php
+++ b/includes/distributor-customizations/class-sync-post-status.php
@@ -29,13 +29,13 @@ class Sync_Post_Status {
 	 * @param WP_Post $post The post object.
 	 */
 	public static function process_attributes( $post ) {
-		$hub_post_status     = get_post_meta( $post->ID, self::POST_STATUS_META_NAME, true );
+		$origin_post_status  = get_post_meta( $post->ID, self::POST_STATUS_META_NAME, true );
 		$current_post_status = get_post_status( $post->ID );
-		if ( $hub_post_status && $hub_post_status !== $current_post_status ) {
+		if ( $origin_post_status && $origin_post_status !== $current_post_status ) {
 			wp_update_post(
 				[
 					'ID'          => $post->ID,
-					'post_status' => $hub_post_status,
+					'post_status' => $origin_post_status,
 				]
 			);
 		}

--- a/includes/distributor-customizations/class-yoast-primary-cat.php
+++ b/includes/distributor-customizations/class-yoast-primary-cat.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This files contains the global tweaks that are loaded by default in every site in the Network (both Hub and Nodes).
+ * Newspack Network Distributor Yoast Primary Category
  *
  * @package newspack-network
  */
@@ -8,37 +8,22 @@
 namespace Newspack_Network\Distributor_Customizations;
 
 /**
- * General Distributor customizations.
+ * Class to handle Yoast's primary category metadata distribution
  */
-class Base {
+class Yoast_Primary_Cat {
 	const YOAST_PRIMARY_CAT_META_NAME = '_yoast_wpseo_primary_category';
 	const PRIMARY_CAT_SLUG_META_NAME  = 'newspack_network_primary_cat_slug';
-	const POST_STATUS_META_NAME       = 'newspack_network_post_status';
 
 	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		add_filter( 'dt_capabilities', [ __CLASS__, 'filter_distributor_menu_cap' ] );
-		add_filter( 'dt_pull_capabilities', [ __CLASS__, 'filter_distributor_menu_cap' ] );
-
 		add_filter( 'dt_push_post_args', [ __CLASS__, 'filter_push_post_args' ], 10, 2 );
 		add_filter( 'dt_pull_post_args', [ __CLASS__, 'filter_pull_post_args' ], 10, 3 );
 		add_filter( 'dt_subscription_post_args', [ __CLASS__, 'filter_subscription_post_args' ], 10, 2 );
 		add_action( 'dt_process_subscription_attributes', [ __CLASS__, 'process_attributes' ], 10, 2 );
 		add_action( 'dt_process_distributor_attributes', [ __CLASS__, 'process_attributes' ], 10, 2 );
 		add_action( 'dt_pull_post', [ __CLASS__, 'pull_post' ] );
-
-		/**
-		 * This is a workaround the bug fixed in https://github.com/10up/distributor/pull/1185
-		 * Until that fix is released, we need to keep this workaround.
-		 */
-		add_action(
-			'init',
-			function () {
-				wp_cache_delete( 'dt_media::{$post_id}', 'dt::post' );
-			}
-		);
 	}
 
 	/**
@@ -95,18 +80,6 @@ class Base {
 		} elseif ( class_exists( '\Newspack\Logger' ) ) {
 			\Newspack\Logger::error( __( 'No matching category found on the Hub site.', 'newspack-network' ) );
 		}
-
-		// Synchronize the post status.
-		$hub_post_status     = get_post_meta( $post->ID, self::POST_STATUS_META_NAME, true );
-		$current_post_status = get_post_status( $post->ID );
-		if ( $hub_post_status && $hub_post_status !== $current_post_status ) {
-			wp_update_post(
-				[
-					'ID'          => $post->ID,
-					'post_status' => $hub_post_status,
-				]
-			);
-		}
 	}
 
 	/**
@@ -116,11 +89,6 @@ class Base {
 	 * @param WP_Post $post The post object.
 	 */
 	public static function filter_push_post_args( $post_body, $post ) {
-		// Pass the original published date to the new pushed post and set the same published date
-		// instead of setting it to the current time.
-		$post_body['date']     = $post->post_date;
-		$post_body['date_gmt'] = $post->post_date_gmt;
-
 		$slug = self::get_primary_category_slug( $post );
 		if ( $slug ) {
 			$post_body['distributor_meta'][ self::PRIMARY_CAT_SLUG_META_NAME ] = $slug;
@@ -130,16 +98,13 @@ class Base {
 	}
 
 	/**
-	 * Keep the publication date on the new pulled post.
+	 * Filters the arguments passed into wp_insert_post during a pull
 	 *
 	 * @param array   $post_array The post data to be sent to the Node.
 	 * @param int     $remote_id The remote post ID.
 	 * @param WP_Post $post The post object.
 	 */
 	public static function filter_pull_post_args( $post_array, $remote_id, $post ) {
-		$post_array['post_date']     = $post->post_date;
-		$post_array['post_date_gmt'] = $post->post_date_gmt;
-
 		$slug = self::get_primary_category_slug( $post, true );
 		if ( $slug ) {
 			$post_array['meta_input'][ self::PRIMARY_CAT_SLUG_META_NAME ] = $slug;
@@ -157,12 +122,6 @@ class Base {
 	public static function filter_subscription_post_args( $post_body, $post ) {
 		$slug = self::get_primary_category_slug( $post );
 		$post_body['post_data']['distributor_meta'][ self::PRIMARY_CAT_SLUG_META_NAME ] = $slug;
-		// Attaching the post status only on updates (so not in filter_push_post_args).
-		// By default, only published posts are distributable, so there's no need to attach the post status on new posts.
-		$distributable_statuses = [ 'publish', 'trash' ];
-		if ( in_array( $post->post_status, $distributable_statuses, true ) ) {
-			$post_body['post_data']['distributor_meta'][ self::POST_STATUS_META_NAME ] = $post->post_status;
-		}
 		return $post_body;
 	}
 
@@ -175,10 +134,4 @@ class Base {
 		self::process_attributes( get_post( $new_post_id ) );
 	}
 
-	/**
-	 * Allow editors to pull content.
-	 */
-	public static function filter_distributor_menu_cap() {
-		return 'edit_others_posts';
-	}
 }


### PR DESCRIPTION
This PR simply breaks the "Base" class and puts each feature in its own file to keep things more organized.