### PR TITLE
feat: sync billing and shipping addresses

### DIFF
--- a/includes/class-user-update-watcher.php
+++ b/includes/class-user-update-watcher.php
@@ -50,13 +50,17 @@ class User_Update_Watcher {
 		'last_name',
 		'description',
 
-		// Shipping and Billing
+		// Shipping and Billing.
+		'billing_first_name',
+		'billing_last_name',
 		'billing_address_1',
 		'billing_address_2',
 		'billing_city',
 		'billing_state',
 		'billing_postcode',
 		'billing_country',
+		'shipping_first_name',
+		'shipping_last_name',
 		'shipping_address_1',
 		'shipping_address_2',
 		'shipping_city',

--- a/includes/class-user-update-watcher.php
+++ b/includes/class-user-update-watcher.php
@@ -50,6 +50,20 @@ class User_Update_Watcher {
 		'last_name',
 		'description',
 
+		// Shipping and Billing
+		'billing_address_1',
+		'billing_address_2',
+		'billing_city',
+		'billing_state',
+		'billing_postcode',
+		'billing_country',
+		'shipping_address_1',
+		'shipping_address_2',
+		'shipping_city',
+		'shipping_state',
+		'shipping_postcode',
+		'shipping_country',
+
 		// Newspack.
 		'newspack_job_title',
 		'newspack_role',


### PR DESCRIPTION
Closes `/0/1206331646877116/1206510843311106/f`

This PR adds address data to synced user meta. 

![Screenshot 2024-02-13 at 15 49 22](https://github.com/Automattic/newspack-network/assets/17905991/4ee47b9a-26b9-4820-a94d-cf41f8c2b061)

### Testing Instructions

1. On a node site, register a new reader by going through the donation flow as an unregistered user. (Make sure you check the register account option if you make a one-time purchase)
2. Check that the node site's network node settings contains an update user event, and this event contains billing information.
![Screenshot 2024-02-13 at 15 52 41](https://github.com/Automattic/newspack-network/assets/17905991/49632e31-9a1a-40c8-9205-b03abc2dc30d)
3. Once the event has been sent to the hub site, check your hub site for the respective reader and confirm the billing details are present in wp-admin > users menu
4. On the hub site, log in as the newly created reader and go to my account
5. Confirm an addresses tab appears in my account and that the billing address is present
6. Edit the billing and shipping addresses and check the hub event log, confirming your changes are present in a user updated event
7. Wait for the event to be pulled on the node site from step 1 and then confirm the changes are present in wp-admin as well as in my account for the logged in user