### PR TITLE
feat(backfill): WP CLI script to backfill reader_registered, donation_new events

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -169,7 +169,6 @@ install_db() {
 	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
 		echo "Reinstalling will delete the existing test database ($DB_NAME)"
-		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
 		recreate_db $DELETE_EXISTING_DB
 	else
 		create_db

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"wp-coding-standards/wpcs": "^3.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",
-		"yoast/phpunit-polyfills": "^1.0",
+		"yoast/phpunit-polyfills": "^2.0",
 		"phpunit/phpunit": "^7.0 || ^9.5"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b010e97f477cd19dba1ab17bfe091667",
+    "content-hash": "7835aa929977bc9c1d5bbca434dc49a2",
     "packages": [],
     "packages-dev": [
         {
@@ -2416,21 +2416,21 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c758753e8f9dac251fed396a73c8305af3f17922",
+                "reference": "c758753e8f9dac251fed396a73c8305af3f17922",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
             },
             "require-dev": {
                 "yoast/yoastcs": "^2.3.0"
@@ -2472,7 +2472,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-06-06T20:28:24+00:00"
         }
     ],
     "aliases": [],

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -42,6 +42,7 @@ class Initializer {
 		Reader_Roles_Filter::init();
 		User_Update_Watcher::init();
 		Distributor_Customizations::init();
+		Data_Backfill::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/cli/backfillers/class-abstract-backfiller.php
+++ b/includes/cli/backfillers/class-abstract-backfiller.php
@@ -109,12 +109,12 @@ abstract class Abstract_Backfiller {
 					$event->process_in_hub();
 					Data_Backfill::increment_results_counter( $event->get_action_name(), $event->is_persisted ? 'processed' : 'duplicate' );
 				} else {
-					$requests = $this->find_webhook_requests( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					$requests = $this->find_webhook_requests( $event->get_action_name(), $event->get_timestamp(), $event->get_data() );
 					if ( count( $requests ) > 0 ) {
 						Data_Backfill::increment_results_counter( $event->get_action_name(), 'duplicate' );
 						return;
 					}
-					\Newspack\Data_Events\Webhooks::handle_dispatch( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					\Newspack\Data_Events\Webhooks::handle_dispatch( $event->get_action_name(), $event->get_timestamp(), $event->get_data() );
 					Data_Backfill::increment_results_counter( $event->get_action_name(), 'processed' );
 				}
 			}

--- a/includes/cli/backfillers/class-abstract-backfiller.php
+++ b/includes/cli/backfillers/class-abstract-backfiller.php
@@ -62,8 +62,8 @@ abstract class Abstract_Backfiller {
 	public function __construct( $start, $end, $live, $verbose ) {
 		$this->start = $start;
 		$this->end = $end;
-		$this->live     = $live;
-		$this->verbose  = $verbose;
+		$this->live = $live;
+		$this->verbose = $verbose;
 	}
 
 	/**
@@ -99,7 +99,6 @@ abstract class Abstract_Backfiller {
 	 * Process the events.
 	 */
 	public function process_events() {
-
 		$events = $this->get_events();
 
 		foreach ( $events as $event ) {

--- a/includes/cli/backfillers/class-abstract-backfiller.php
+++ b/includes/cli/backfillers/class-abstract-backfiller.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Data Backfiller abstract class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+use Newspack_Network\Data_Backfill;
+use Newspack_Network\Site_Role;
+use WP_CLI;
+
+/**
+ * Abstract class for backfillers.
+ */
+abstract class Abstract_Backfiller {
+
+	/**
+	 * Whether to run the backfiller in live mode.
+	 *
+	 * @var bool
+	 */
+	protected $live;
+
+	/**
+	 * Whether to run the backfiller in verbose mode.
+	 *
+	 * @var bool
+	 */
+	protected $verbose;
+
+	/**
+	 * The progress bar object if not in verbose mode.
+	 *
+	 * @var ?object
+	 */
+	protected $progress = null;
+
+	/**
+	 * The start date to process data from
+	 *
+	 * @var string
+	 */
+	protected $start;
+
+	/**
+	 * The end date to process data to
+	 *
+	 * @var string
+	 */
+	protected $end;
+
+	/**
+	 * Object contructor
+	 *
+	 * @param string $start The start date.
+	 * @param string $end The end date.
+	 * @param bool   $live Whether to run the backfiller in live mode.
+	 * @param bool   $verbose Whether to run the backfiller in verbose mode.
+	 */
+	public function __construct( $start, $end, $live, $verbose ) {
+		$this->start = $start;
+		$this->end = $end;
+		$this->live     = $live;
+		$this->verbose  = $verbose;
+	}
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	abstract protected function get_processed_item_output( $event );
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	abstract public function get_events();
+
+	/**
+	 * Initializes the WP CLI progress bar if in verbose mode
+	 *
+	 * @param string $label The progress bar label.
+	 * @param int    $total The total number of items to be processed.
+	 * @return void
+	 */
+	protected function maybe_initialize_progress_bar( $label, $total ) {
+		if ( ! $this->verbose ) {
+			Data_Backfill::$progress = \WP_CLI\Utils\make_progress_bar( $label, $total );
+		}
+	}
+
+	/**
+	 * Process the events.
+	 */
+	public function process_events() {
+
+		$events = $this->get_events();
+
+		foreach ( $events as $event ) {
+
+			if ( $this->live ) {
+				if ( Site_Role::is_hub() ) {
+					$event->process_in_hub();
+					Data_Backfill::increment_results_counter( $event->get_action_name(), $event->is_persisted ? 'processed' : 'duplicate' );
+				} else {
+					$requests = $this->find_webhook_requests( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					if ( count( $requests ) > 0 ) {
+						Data_Backfill::increment_results_counter( $event->get_action_name(), 'duplicate' );
+						return;
+					}
+					\Newspack\Data_Events\Webhooks::handle_dispatch( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					Data_Backfill::increment_results_counter( $event->get_action_name(), 'processed' );
+				}
+			}
+
+			if ( $this->verbose ) {
+				WP_CLI::line( '👉 ' . $this->get_processed_item_output( $event ) );
+			}
+
+			if ( ! $this->verbose ) {
+				Data_Backfill::$progress->tick();
+			}
+		}
+	}
+
+	/**
+	 * Find existing webhook requests for a given action and data.
+	 *
+	 * @param string $action The action name.
+	 * @param int    $timestamp The timestamp.
+	 * @param array  $data The data.
+	 */
+	private function find_webhook_requests( $action, $timestamp, $data ) {
+		return get_posts(
+			[
+				'post_type'   => \Newspack\Data_Events\Webhooks::REQUEST_POST_TYPE,
+				'post_title'  => $action,
+				'post_status' => 'any',
+				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'AND',
+					[
+						'key'     => 'timestamp',
+						'value'   => $timestamp,
+						'compare' => '=',
+					],
+					[
+						'key'     => 'action_name',
+						'value'   => $action,
+						'compare' => '=',
+					],
+					[
+						'key'     => 'data',
+						'value'   => wp_json_encode( $data ),
+						'compare' => '=',
+					],
+				],
+			]
+		);
+	}
+}

--- a/includes/cli/backfillers/class-donation-new.php
+++ b/includes/cli/backfillers/class-donation-new.php
@@ -43,7 +43,7 @@ class Donation_New extends Abstract_Backfiller {
 
 		foreach ( $orders as $order ) {
 			$order_id = $order->get_id();
-			$order_data = \Newspack\Data_Events\Utils::get_order_data( $order_id );
+			$order_data = \Newspack\Data_Events\Utils::get_order_data( $order_id, true );
 			if ( ! $order_data ) {
 				continue;
 			}

--- a/includes/cli/backfillers/class-donation-new.php
+++ b/includes/cli/backfillers/class-donation-new.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Data Backfiller for donation_new events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+/**
+ * Backfiller class.
+ */
+class Donation_New extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Order #%d completed on %s.', $event->get_data()->platform_data['order_id'], $event->get_formatted_date() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		$orders = wc_get_orders(
+			[
+				'status'       => 'completed',
+				'date_created' => $this->start . '...' . $this->end,
+				'limit'        => -1,
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing orders', count( $orders ) );
+
+		$events = [];
+
+		foreach ( $orders as $order ) {
+			$order_id = $order->get_id();
+			$order_data = \Newspack\Data_Events\Utils::get_order_data( $order_id );
+			if ( ! $order_data ) {
+				continue;
+			}
+			$timestamp = strtotime( $order->get_date_completed() );
+
+			$event = new \Newspack_Network\Incoming_Events\Donation_New( get_bloginfo( 'url' ), $order_data, $timestamp );
+
+			$events[] = $event;
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-donation-subscription-cancelled.php
+++ b/includes/cli/backfillers/class-donation-subscription-cancelled.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Data Backfiller for donation_subcription_cancelled events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+/**
+ * Backfiller class.
+ */
+class Donation_Subscription_Cancelled extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Subscription #%d cancelled on %s.', $event->get_data()->subscription_id, $event->get_formatted_date() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		$subscriptions = wcs_get_subscriptions(
+			[
+				'subscription_status'    => 'cancelled',
+				'subscriptions_per_page' => -1,
+				'meta_query'             => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'AND',
+					[
+						'key'     => wcs_get_date_meta_key( 'cancelled' ),
+						'compare' => '>=',
+						'value'   => $this->start,
+					],
+					[
+						'key'     => wcs_get_date_meta_key( 'cancelled' ),
+						'compare' => '<=',
+						'value'   => $this->end,
+					],
+				],
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing subscriptions', count( $subscriptions ) );
+
+		$events = [];
+
+		foreach ( $subscriptions as $subscription ) {
+			$subscription_data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
+			if ( ! $subscription_data ) {
+				continue;
+			}
+			$timestamp = strtotime( $subscription->get_date( 'cancelled' ) );
+
+			$event = new \Newspack_Network\Incoming_Events\Donation_Subscription_Cancelled( get_bloginfo( 'url' ), $subscription_data, $timestamp );
+
+			$events[] = $event;
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Data Backfiller for reader_registered events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+/**
+ * Backfiller class.
+ */
+class Reader_Registered extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'User %s (#%d) registered on %s.', $event->get_email(), $event->get_data()->user_id, $event->get_formatted_date() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		// Get all users registered between this-> and $end.
+		$users = get_users(
+			[
+				'role__in'   => \Newspack\Reader_Activation::get_reader_roles(),
+				'date_query' => [
+					'after'     => $this->start,
+					'before'    => $this->end,
+					'inclusive' => true,
+				],
+				'fields'     => [ 'id', 'user_email', 'user_registered' ],
+				'number'     => -1,
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE,
+						'compare' => 'NOT EXISTS',
+					],
+				],
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing users', count( $users ) );
+
+		$events = [];
+
+		foreach ( $users as $user ) {
+			$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
+			$user_data = [
+				'user_id'  => $user->ID,
+				'email'    => $user->user_email,
+				'metadata' => [
+					// 'current_page_url' is not saved, can't be backfilled.
+					'registration_method' => empty( $registration_method ) ? 'backfill-script' : $registration_method,
+				],
+			];
+
+			$incoming_event = new \Newspack_Network\Incoming_Events\Reader_Registered( get_bloginfo( 'url' ), $user_data, strtotime( $user->user_registered ) );
+			$events[] = $incoming_event;
+
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -57,7 +57,7 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 			$status = $membership->get_status();
 			$plan_network_id = get_post_meta( $membership->get_plan()->get_id(), \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true );
 			if ( ! $plan_network_id ) {
-				if ( $verbose ) {
+				if ( $this->verbose ) {
 					WP_CLI::line( sprintf( 'Skipping membership #%d with status %s, the plan has no network ID.', $membership->get_id(), $status ) );
 				}
 				Data_Backfill::increment_results_counter( 'newspack_network_woo_membership_updated', 'skipped' );

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -84,7 +84,6 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 			}
 
 			$events[] = new \Newspack_Network\Incoming_Events\Woocommerce_Membership_Updated( get_bloginfo( 'url' ), $membership_data, $timestamp );
-
 		}
 
 		return $events;

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Data Backfiller for newspack_network_woo_membership_updated events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+use Newspack_Network\Data_Backfill;
+use WP_Cli;
+
+/**
+ * Backfiller class.
+ */
+class Woocommerce_Membership_Updated extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Membership #%d with status %s on %s, linked with network ID "%s".', $event->get_membership_id(), $event->get_new_status(), $event->get_formatted_date(), $event->get_plan_network_id() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		// Get all memberships created or updated between $start and $end.
+		$membership_posts_ids = get_posts(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'date_query'  => [
+					'column'    => 'post_modified_gmt',
+					'after'     => $this->start,
+					'before'    => $this->end,
+					'inclusive' => true,
+				],
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing memberships', count( $membership_posts_ids ) );
+
+		$events = [];
+
+		foreach ( $membership_posts_ids as $post_id ) {
+			$membership = new \WC_Memberships_User_Membership( $post_id );
+			$status = $membership->get_status();
+			$plan_network_id = get_post_meta( $membership->get_plan()->get_id(), \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true );
+			if ( ! $plan_network_id ) {
+				if ( $verbose ) {
+					WP_CLI::line( sprintf( 'Skipping membership #%d with status %s, the plan has no network ID.', $membership->get_id(), $status ) );
+				}
+				Data_Backfill::increment_results_counter( 'newspack_network_woo_membership_updated', 'skipped' );
+				continue;
+			}
+			$membership_data = [
+				'email'           => $membership->get_user()->user_email,
+				'user_id'         => $membership->get_user()->ID,
+				'plan_network_id' => $plan_network_id,
+				'membership_id'   => $membership->get_id(),
+				'new_status'      => $status,
+			];
+			if ( $status === 'active' ) {
+				$timestamp = strtotime( $membership->get_start_date() );
+			} else {
+				$timestamp = strtotime( $membership->get_end_date() );
+			}
+
+			$events[] = new \Newspack_Network\Incoming_Events\Woocommerce_Membership_Updated( get_bloginfo( 'url' ), $membership_data, $timestamp );
+
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Backfillers;
 
 use Newspack_Network\Data_Backfill;
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
 use WP_Cli;
 
 /**
@@ -44,6 +45,12 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 					'after'     => $this->start,
 					'before'    => $this->end,
 					'inclusive' => true,
+				],
+				'meta_query'  => [ // phpcs:ignore
+					[
+						'key'     => Memberships_Admin::NETWORK_MANAGED_META_KEY,
+						'compare' => 'NOT EXISTS',
+					],
 				],
 			]
 		);

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -167,7 +167,9 @@ class Data_Backfill {
 		foreach ( $orders as $order ) {
 			$order_id = $order->get_id();
 			$order_data = \Newspack\Data_Events\Utils::get_order_data( $order_id );
-
+			if ( ! $order_data ) {
+				continue;
+			}
 			$timestamp = strtotime( $order->get_date_completed() );
 			if ( $live ) {
 				self::process_event_entity( $order_data, $timestamp, 'donation_new' );
@@ -215,7 +217,7 @@ class Data_Backfill {
 		foreach ( $subscriptions as $subscription ) {
 			$subscription_data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
 			if ( ! $subscription_data ) {
-				return;
+				continue;
 			}
 			$timestamp = strtotime( $subscription->get_date( 'cancelled' ) );
 			if ( $live ) {

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -356,14 +356,28 @@ class Data_Backfill {
 		}
 		if ( $live ) {
 			WP_CLI::line( '' );
-			WP_CLI::success(
-				sprintf(
-					'Processed %d %s events, skipped %d as duplicates.',
-					self::$results[ $action ]['processed'],
-					$action,
-					self::$results[ $action ]['duplicate']
-				)
-			);
+			if ( $action === 'all' ) {
+				$processed = 0;
+				$duplicate = 0;
+				foreach ( array_values( self::$results ) as $key => $value ) {
+					if ( isset( $value['processed'] ) ) {
+						$processed += $value['processed'];
+					}
+					if ( isset( $value['duplicate'] ) ) {
+						$duplicate += $value['duplicate'];
+					}
+				}
+				WP_CLI::success( sprintf( 'Processed %d events, skipped %d as duplicates.', $processed, $duplicate ) );
+			} else {
+				WP_CLI::success(
+					sprintf(
+						'Processed %d %s events, skipped %d as duplicates.',
+						self::$results[ $action ]['processed'],
+						$action,
+						self::$results[ $action ]['duplicate']
+					)
+				);
+			}
 		}
 		WP_CLI::line( '' );
 	}

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -130,7 +130,8 @@ class Data_Backfill {
 			];
 			if ( $live ) {
 				self::process_event_entity( $user_data, strtotime( $user->user_registered ), 'reader_registered' );
-			} elseif ( $verbose ) {
+			}
+			if ( $verbose ) {
 				WP_CLI::line( '👉 ' . sprintf( 'User %s (#%d) registered on %s.', $user->user_email, $user->ID, $user->user_registered ) );
 			}
 			if ( self::$progress ) {
@@ -165,7 +166,8 @@ class Data_Backfill {
 			$timestamp = strtotime( $order->get_date_completed() );
 			if ( $live ) {
 				self::process_event_entity( $order_data, $timestamp, 'donation_new' );
-			} elseif ( $verbose ) {
+			}
+			if ( $verbose ) {
 				WP_CLI::line( '👉 ' . sprintf( 'Order #%d completed on %s.', $order_id, gmdate( 'Y-m-d H:i:s', $timestamp ) ) );
 			}
 			if ( self::$progress ) {
@@ -210,7 +212,8 @@ class Data_Backfill {
 			$timestamp = strtotime( $subscription->get_date( 'cancelled' ) );
 			if ( $live ) {
 				self::process_event_entity( $subscription_data, $timestamp, 'donation_subscription_cancelled' );
-			} elseif ( $verbose ) {
+			}
+			if ( $verbose ) {
 				WP_CLI::line( '👉 ' . sprintf( 'Subscription #%d cancelled on %s.', $subscription->get_id(), gmdate( 'Y-m-d H:i:s', $timestamp ) ) );
 			}
 			if ( self::$progress ) {

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -25,7 +25,7 @@ class Data_Backfill {
 	 *
 	 * @var class
 	 */
-	private static $progress = false;
+	public static $progress = false;
 
 	/**
 	 * Initialize this class and register hooks
@@ -44,182 +44,6 @@ class Data_Backfill {
 	public static function register_commands() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'newspack-network data-backfill', [ __CLASS__, 'data_backfill' ] );
-		}
-	}
-
-	/**
-	 * Find existing webhook requests for a given action and data.
-	 *
-	 * @param string $action The action name.
-	 * @param int    $timestamp The timestamp.
-	 * @param array  $data The data.
-	 */
-	private static function find_webhook_requests( $action, $timestamp, $data ) {
-		return get_posts(
-			[
-				'post_type'   => \Newspack\Data_Events\Webhooks::REQUEST_POST_TYPE,
-				'post_title'  => $action,
-				'post_status' => 'any',
-				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					'relation' => 'AND',
-					[
-						'key'     => 'timestamp',
-						'value'   => $timestamp,
-						'compare' => '=',
-					],
-					[
-						'key'     => 'action_name',
-						'value'   => $action,
-						'compare' => '=',
-					],
-					[
-						'key'     => 'data',
-						'value'   => wp_json_encode( $data ),
-						'compare' => '=',
-					],
-				],
-			]
-		);
-	}
-
-	/**
-	 * Process reader_registered events.
-	 *
-	 * @param string $start The start date.
-	 * @param string $end The end date.
-	 * @param bool   $live Whether to run in live mode.
-	 * @param bool   $verbose Whether to output verbose information.
-	 */
-	private static function process_reader_registered( $start, $end, $live, $verbose ) {
-		// Get all users registered between $start and $end.
-		$users = get_users(
-			[
-				'role__in'   => \Newspack\Reader_Activation::get_reader_roles(),
-				'date_query' => [
-					'after'     => $start,
-					'before'    => $end,
-					'inclusive' => true,
-				],
-				'fields'     => [ 'id', 'user_email', 'user_registered' ],
-				'number'     => -1,
-				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					[
-						'key'     => \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE,
-						'compare' => 'NOT EXISTS',
-					],
-				],
-			]
-		);
-		if ( ! $verbose ) {
-			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing users', count( $users ) );
-		}
-
-		foreach ( $users as $user ) {
-			$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
-			$user_data = [
-				'user_id'  => $user->ID,
-				'email'    => $user->user_email,
-				'metadata' => [
-					// 'current_page_url' is not saved, can't be backfilled.
-					'registration_method' => empty( $registration_method ) ? 'backfill-script' : $registration_method,
-				],
-			];
-			if ( $live ) {
-				self::process_event_entity( $user_data, strtotime( $user->user_registered ), 'reader_registered' );
-			}
-			if ( $verbose ) {
-				WP_CLI::line( '👉 ' . sprintf( 'User %s (#%d) registered on %s.', $user->user_email, $user->ID, $user->user_registered ) );
-			}
-			if ( self::$progress ) {
-				self::$progress->tick();
-			}
-		}
-	}
-
-	/**
-	 * Process donation_new events.
-	 *
-	 * @param string $start The start date.
-	 * @param string $end The end date.
-	 * @param bool   $live Whether to run in live mode.
-	 * @param bool   $verbose Whether to output verbose information.
-	 */
-	private static function process_donation_new( $start, $end, $live, $verbose ) {
-		$orders = wc_get_orders(
-			[
-				'status'       => 'completed',
-				'date_created' => $start . '...' . $end,
-				'limit'        => -1,
-			]
-		);
-		if ( ! $verbose ) {
-			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing orders', count( $orders ) );
-		}
-		foreach ( $orders as $order ) {
-			$order_id = $order->get_id();
-			$order_data = \Newspack\Data_Events\Utils::get_order_data( $order_id );
-			if ( ! $order_data ) {
-				continue;
-			}
-			$timestamp = strtotime( $order->get_date_completed() );
-			if ( $live ) {
-				self::process_event_entity( $order_data, $timestamp, 'donation_new' );
-			}
-			if ( $verbose ) {
-				WP_CLI::line( '👉 ' . sprintf( 'Order #%d completed on %s.', $order_id, gmdate( 'Y-m-d H:i:s', $timestamp ) ) );
-			}
-			if ( self::$progress ) {
-				self::$progress->tick();
-			}
-		}
-	}
-
-	/**
-	 * Process donation_subscription_cancelled events.
-	 *
-	 * @param string $start The start date.
-	 * @param string $end The end date.
-	 * @param bool   $live Whether to run in live mode.
-	 * @param bool   $verbose Whether to output verbose information.
-	 */
-	private static function process_donation_subscription_cancelled( $start, $end, $live, $verbose ) {
-		$subscriptions = wcs_get_subscriptions(
-			[
-				'subscription_status'    => 'cancelled',
-				'subscriptions_per_page' => -1,
-				'meta_query'             => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					'relation' => 'AND',
-					[
-						'key'     => wcs_get_date_meta_key( 'cancelled' ),
-						'compare' => '>=',
-						'value'   => $start,
-					],
-					[
-						'key'     => wcs_get_date_meta_key( 'cancelled' ),
-						'compare' => '<=',
-						'value'   => $end,
-					],
-				],
-			]
-		);
-		if ( ! $verbose ) {
-			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing subscriptions', count( $subscriptions ) );
-		}
-		foreach ( $subscriptions as $subscription ) {
-			$subscription_data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
-			if ( ! $subscription_data ) {
-				continue;
-			}
-			$timestamp = strtotime( $subscription->get_date( 'cancelled' ) );
-			if ( $live ) {
-				self::process_event_entity( $subscription_data, $timestamp, 'donation_subscription_cancelled' );
-			}
-			if ( $verbose ) {
-				WP_CLI::line( '👉 ' . sprintf( 'Subscription #%d cancelled on %s.', $subscription->get_id(), gmdate( 'Y-m-d H:i:s', $timestamp ) ) );
-			}
-			if ( self::$progress ) {
-				self::$progress->tick();
-			}
 		}
 	}
 
@@ -302,33 +126,7 @@ class Data_Backfill {
 		self::$results[ $action ][ $counter ]++;
 	}
 
-	/**
-	 * Process a WooCommerce entity.
-	 *
-	 * @param array  $data The data.
-	 * @param int    $timestamp The ti;mestamp.
-	 * @param string $action The action.
-	 */
-	private static function process_event_entity( $data, $timestamp, $action ) {
-		if ( Site_Role::is_hub() ) {
-			$event = new \Newspack_Network\Incoming_Events\Abstract_Incoming_Event(
-				get_bloginfo( 'url' ),
-				$data,
-				$timestamp,
-				$action
-			);
-			$event->process_in_hub();
-			self::increment_results_counter( $action, $event->is_persisted ? 'processed' : 'duplicate' );
-		} else {
-			$requests = self::find_webhook_requests( $action, $timestamp, $data );
-			if ( count( $requests ) > 0 ) {
-				self::increment_results_counter( $action, 'duplicate' );
-				return;
-			}
-			\Newspack\Data_Events\Webhooks::handle_dispatch( $action, $timestamp, $data );
-			self::increment_results_counter( $action, 'processed' );
-		}
-	}
+
 
 	/**
 	 * Backfill data for a specific action.
@@ -362,8 +160,8 @@ class Data_Backfill {
 		$action = $args[0];
 		$start = isset( $assoc_args['start'] ) ? $assoc_args['start'] : null;
 		$end = isset( $assoc_args['end'] ) ? $assoc_args['end'] : null;
-		$live = isset( $assoc_args['live'] ) ? $assoc_args['live'] : null;
-		$verbose = isset( $assoc_args['verbose'] ) ? $assoc_args['verbose'] : null;
+		$live = isset( $assoc_args['live'] ) ? true : false;
+		$verbose = isset( $assoc_args['verbose'] ) ? true : false;
 
 		WP_CLI::line( '' );
 
@@ -401,28 +199,23 @@ class Data_Backfill {
 		}
 		WP_CLI::line( '' );
 
-		switch ( $action ) {
-			case 'reader_registered':
-				self::process_reader_registered( $start, $end, $live, $verbose );
-				break;
-			case 'donation_new':
-				self::process_donation_new( $start, $end, $live, $verbose );
-				break;
-			case 'donation_subscription_cancelled':
-				self::process_donation_subscription_cancelled( $start, $end, $live, $verbose );
-				break;
-			case 'newspack_network_woo_membership_updated':
-				self::process_newspack_network_woo_membership_updated( $start, $end, $live, $verbose );
-				break;
-			case 'all':
-				self::process_reader_registered( $start, $end, $live, $verbose );
-				self::process_donation_new( $start, $end, $live, $verbose );
-				self::process_donation_subscription_cancelled( $start, $end, $live, $verbose );
-				self::process_newspack_network_woo_membership_updated( $start, $end, $live, $verbose );
-				break;
-			default:
-				WP_CLI::error( 'Backfilling data for this action is not supported yet.' );
-				break;
+		if ( 'all' === $action ) {
+			$actions = array_keys( Accepted_Actions::ACTIONS );
+		} else {
+			$actions = [ $action ];
+		}
+
+		foreach ( $actions as $action_name ) {
+			$class_name = 'Newspack_Network\\Backfillers\\' . Accepted_Actions::ACTIONS[ $action_name ];
+			if ( ! class_exists( $class_name ) ) {
+				if ( 'all' !== $action ) {
+					WP_CLI::error( sprintf( 'Backfilling data for %s is not supported yet.', $action_name ) );
+				}
+				continue;
+			}
+			$backfiller = new $class_name( $start, $end, $live, $verbose );
+			$backfiller->process_events();
+
 		}
 
 		if ( self::$progress ) {
@@ -430,18 +223,16 @@ class Data_Backfill {
 		}
 		if ( $live ) {
 			WP_CLI::line( '' );
-			foreach ( [ 'reader_registered', 'donation_new', 'donation_subscription_cancelled', 'newspack_network_woo_membership_updated' ] as $action_key ) {
-				if ( isset( self::$results[ $action_key ] ) ) {
-					WP_CLI::success(
-						sprintf(
-							'Processed %d %s events, ignored %d as duplicates and skipped %d.',
-							self::$results[ $action_key ]['processed'],
-							$action_key,
-							self::$results[ $action_key ]['duplicate'],
-							self::$results[ $action_key ]['skipped']
-						)
-					);
-				}
+			foreach ( self::$results as $action_key => $result ) {
+				WP_CLI::success(
+					sprintf(
+						'Processed %d %s events, ignored %d as duplicates and skipped %d.',
+						$result['processed'],
+						$action_key,
+						$result['duplicate'],
+						$result['skipped']
+					)
+				);
 			}
 		}
 		WP_CLI::line( '' );

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -7,7 +7,6 @@
 
 namespace Newspack_Network;
 
-use Automattic\Jetpack\VideoPress\Data;
 use WP_CLI;
 
 /**
@@ -112,6 +111,12 @@ class Data_Backfill {
 				],
 				'fields'     => [ 'id', 'user_email', 'user_registered' ],
 				'number'     => -1,
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE,
+						'compare' => 'NOT EXISTS',
+					],
+				],
 			]
 		);
 		if ( ! $verbose ) {
@@ -357,6 +362,4 @@ class Data_Backfill {
 		}
 		WP_CLI::line( '' );
 	}
-
-	// TODO: a script to run the above on all nodes of the network.
 }

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Data Backfill scripts.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+use Automattic\Jetpack\VideoPress\Data;
+use WP_CLI;
+
+/**
+ * Data Backfill class.
+ */
+class Data_Backfill {
+	/**
+	 * The final results object.
+	 *
+	 * @var array
+	 */
+	private static $results = [
+		'reader_registered' => [
+			'processed' => 0,
+			'duplicate' => 0,
+		],
+	];
+
+	/**
+	 * WP_CLI progress handler.
+	 *
+	 * @var class
+	 */
+	private static $progress = false;
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_commands' ] );
+	}
+
+	/**
+	 * Register the WP-CLI commands
+	 *
+	 * @return void
+	 */
+	public static function register_commands() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'newspack-network data-backfill', [ __CLASS__, 'data_backfill' ] );
+		}
+	}
+
+	/**
+	 * Process reader_registered events.
+	 *
+	 * @param string $start The start date.
+	 * @param string $end The end date.
+	 * @param bool   $live Whether to run in live mode.
+	 * @param bool   $verbose Whether to output verbose information.
+	 */
+	private static function process_reader_registered( $start, $end, $live, $verbose ) {
+		$is_hub = Site_Role::is_hub();
+		$is_node = Site_Role::is_node();
+		if ( ! $is_hub && ! $is_node ) {
+			WP_CLI::error( 'This command can only be run on a Hub or Node site.' );
+		}
+
+		if ( $is_hub ) {
+			WP_CLI::line( 'Running on a Hub site – will create events for the event log.' );
+		} else {
+			WP_CLI::line( 'Running on a Node site – will create webhook requests. This may result in duplicate requests if the request queue was cleared already.' );
+		}
+		WP_CLI::line( '' );
+
+		$action = 'reader_registered';
+		// Get all users registered between $start and $end.
+		$users = get_users(
+			[
+				'role__in'   => \Newspack\Reader_Activation::get_reader_roles(),
+				'date_query' => [
+					'after'     => $start,
+					'before'    => $end,
+					'inclusive' => true,
+				],
+				'fields'     => [ 'id', 'user_email', 'user_registered' ],
+				'number'     => -1,
+			]
+		);
+		if ( ! $verbose ) {
+			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing users', count( $users ) );
+		}
+
+		foreach ( $users as $user ) {
+			$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
+			$user_data = [
+				'user_id'  => $user->ID,
+				'email'    => $user->user_email,
+				'metadata' => [
+					// 'current_page_url' is not saved, can't be backfilled.
+					'registration_method' => empty( $registration_method ) ? 'backfill-script' : $registration_method,
+				],
+			];
+			if ( $live ) {
+				$timestamp = strtotime( $user->user_registered );
+				if ( $is_hub ) {
+					// Check against duplicate events.
+					$maybe_event = \Newspack_Network\Hub\Stores\Event_Log::get(
+						[
+							'action_name' => $action,
+							'email'       => $user->user_email,
+						]
+					);
+					if ( ! empty( $maybe_event ) ) {
+						self::$results['reader_registered']['duplicate']++;
+						continue;
+					}
+					// Add a user registration to the event log, with the timestamp of the registration.
+					$event = new \Newspack_Network\Incoming_Events\Abstract_Incoming_Event(
+						get_bloginfo( 'url' ),
+						$user_data,
+						$timestamp,
+						$action
+					);
+					$event->process_in_hub();
+					self::$results['reader_registered']['processed']++;
+				} else {
+					$requests = get_posts(
+						[
+							'post_type'   => \Newspack\Data_Events\Webhooks::REQUEST_POST_TYPE,
+							'post_title'  => $action,
+							'post_status' => 'any',
+							'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+								'relation' => 'AND',
+								[
+									'key'     => 'timestamp',
+									'value'   => $timestamp,
+									'compare' => '=',
+								],
+								[
+									'key'     => 'action_name',
+									'value'   => $action,
+									'compare' => '=',
+								],
+								[
+									'key'     => 'data',
+									'value'   => wp_json_encode( $user_data ),
+									'compare' => '=',
+								],
+							],
+						]
+					);
+					if ( count( $requests ) > 0 ) {
+						self::$results['reader_registered']['duplicate']++;
+						continue;
+					}
+					\Newspack\Data_Events\Webhooks::handle_dispatch( $action, $timestamp, $user_data );
+					self::$results['reader_registered']['processed']++;
+				}
+			} elseif ( $verbose ) {
+				WP_CLI::line( sprintf( 'User %s (#%d) registered on %s.', $user->user_email, $user->ID, $user->user_registered ) );
+			}
+			if ( self::$progress ) {
+				self::$progress->tick();
+			}
+		}
+	}
+
+	/**
+	 * Backfill data for a specific action.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : The action to backfill.
+	 *
+	 * [--start=<start>]
+	 * : The start date for the backfill.
+	 *
+	 * [--end=<end>]
+	 * : The end date for the backfill.
+	 *
+	 * [--live]
+	 * : Run the backfill in live mode, which will process the events.
+	 *
+	 * [--verbose]
+	 * : Output more verbose information.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack-network data-backfill reader_registered --start=2020-01-01 --end=2020-12-31 --live
+	 *
+	 * @param array $args The command arguments.
+	 * @param array $assoc_args The command options.
+	 * @return void
+	 */
+	public static function data_backfill( $args, $assoc_args ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
+		$action = $args[0];
+		$start = isset( $assoc_args['start'] ) ? $assoc_args['start'] : null;
+		$end = isset( $assoc_args['end'] ) ? $assoc_args['end'] : null;
+		$live = isset( $assoc_args['live'] ) ? $assoc_args['live'] : null;
+		$verbose = isset( $assoc_args['verbose'] ) ? $assoc_args['verbose'] : null;
+
+		WP_CLI::line( '' );
+
+		if ( ! in_array( $action, array_keys( Accepted_Actions::ACTIONS ) ) ) {
+			WP_CLI::error( 'Invalid action.' );
+		}
+
+		if ( ! method_exists( '\Newspack\Reader_Activation', 'get_reader_roles' ) ) {
+			WP_CLI::error( 'Incompatible Newspack plugin version.' );
+		}
+		if ( $live ) {
+			WP_CLI::line( '⚡️ Heads up! Running live, data will be updated.' );
+		} else {
+			WP_CLI::line( 'Running in dry-run mode, data will not be updated. Use --live flag to run in live mode.' );
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( sprintf( 'Backfilling data for action %s, from %s to %s.', $action, $start, $end ) );
+		WP_CLI::line( '' );
+
+		switch ( $action ) {
+			case 'reader_registered':
+				self::process_reader_registered( $start, $end, $live, $verbose );
+				break;
+			default:
+				WP_CLI::error( 'Backfilling data for this action is not supported yet.' );
+				break;
+		}
+
+		if ( self::$progress ) {
+			self::$progress->finish();
+		}
+		WP_CLI::line( '' );
+		WP_CLI::success(
+			sprintf(
+				'Processed %d reader_registered events, skipped %d as duplicates.',
+				self::$results['reader_registered']['processed'],
+				self::$results['reader_registered']['duplicate']
+			)
+		);
+		WP_CLI::line( '' );
+	}
+}

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -150,7 +150,7 @@ class Data_Backfill {
 					self::$results[ $action ]['processed']++;
 				}
 			} elseif ( $verbose ) {
-				WP_CLI::line( sprintf( '👉 ' . 'User %s (#%d) registered on %s.', $user->user_email, $user->ID, $user->user_registered ) );
+				WP_CLI::line( '👉 ' . sprintf( 'User %s (#%d) registered on %s.', $user->user_email, $user->ID, $user->user_registered ) );
 			}
 			if ( self::$progress ) {
 				self::$progress->tick();
@@ -217,7 +217,7 @@ class Data_Backfill {
 	 * ## OPTIONS
 	 *
 	 * <action>
-	 * : The action to backfill.
+	 * : The action to backfill. Choose "all" to backfill all actions.
 	 *
 	 * [--start=<start>]
 	 * : The start date for the backfill.
@@ -248,7 +248,7 @@ class Data_Backfill {
 
 		WP_CLI::line( '' );
 
-		if ( ! in_array( $action, array_keys( Accepted_Actions::ACTIONS ) ) ) {
+		if ( $action !== 'all' && ! in_array( $action, array_keys( Accepted_Actions::ACTIONS ) ) ) {
 			WP_CLI::error( 'Invalid action.' );
 		}
 
@@ -275,7 +275,11 @@ class Data_Backfill {
 		}
 
 		WP_CLI::line( '' );
-		WP_CLI::line( sprintf( 'Backfilling data for action %s, from %s to %s.', $action, $start, $end ) );
+		if ( $action === 'all' ) {
+			WP_CLI::line( sprintf( 'Backfilling data for all supported actions, from %s to %s.', $start, $end ) );
+		} else {
+			WP_CLI::line( sprintf( 'Backfilling data for action %s, from %s to %s.', $action, $start, $end ) );
+		}
 		WP_CLI::line( '' );
 
 		switch ( $action ) {
@@ -283,6 +287,10 @@ class Data_Backfill {
 				self::process_reader_registered( $start, $end, $live, $verbose );
 				break;
 			case 'donation_new':
+				self::process_donation_new( $start, $end, $live, $verbose );
+				break;
+			case 'all':
+				self::process_reader_registered( $start, $end, $live, $verbose );
 				self::process_donation_new( $start, $end, $live, $verbose );
 				break;
 			default:

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -213,7 +213,10 @@ class Data_Backfill {
 			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing subscriptions', count( $subscriptions ) );
 		}
 		foreach ( $subscriptions as $subscription ) {
-			$subscription_data = \Newspack\Data_Events\Utils::get_subscription_data( $subscription );
+			$subscription_data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
+			if ( ! $subscription_data ) {
+				return;
+			}
 			$timestamp = strtotime( $subscription->get_date( 'cancelled' ) );
 			if ( $live ) {
 				self::process_event_entity( $subscription_data, $timestamp, 'donation_subscription_cancelled' );

--- a/includes/hub/stores/class-event-log.php
+++ b/includes/hub/stores/class-event-log.php
@@ -143,6 +143,14 @@ class Event_Log {
 			$where .= $wpdb->prepare( ' AND action_name = %s', $args['action_name'] );
 		}
 
+		if ( ! empty( $args['timestamp'] ) ) {
+			$where .= $wpdb->prepare( ' AND timestamp = %s', $args['timestamp'] );
+		}
+
+		if ( ! empty( $args['data'] ) ) {
+			$where .= $wpdb->prepare( ' AND data = %s', $args['data'] );
+		}
+
 		if ( ! empty( $args['action_name_in'] ) && is_array( $args['action_name_in'] ) ) {
 			$escaped_actions = array_map(
 				function( $a ) {
@@ -170,7 +178,6 @@ class Event_Log {
 	 */
 	public static function persist( Abstract_Incoming_Event $event ) {
 		global $wpdb;
-		Debugger::log( 'Persisting Event' );
 
 		$node    = Nodes::get_node_by_url( $event->get_site() );
 		$node_id = 0;
@@ -179,20 +186,28 @@ class Event_Log {
 			$node_id = $node->get_id();
 		}
 
-		$insert = $wpdb->insert( //phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-			Database::get_table_name(),
-			[
-				'node_id'     => $node_id,
-				'action_name' => $event->get_action_name(),
-				'email'       => $event->get_email(),
-				'data'        => wp_json_encode( $event->get_data() ),
-				'timestamp'   => $event->get_timestamp(),
-			]
-		);
+		$event_payload = [
+			'node_id'     => $node_id,
+			'action_name' => $event->get_action_name(),
+			'email'       => $event->get_email(),
+			'data'        => wp_json_encode( $event->get_data() ),
+			'timestamp'   => $event->get_timestamp(),
+		];
+
+		// Check against duplicates.
+		$maybe_event = self::get( $event_payload );
+		if ( ! empty( $maybe_event ) ) {
+			Debugger::log( 'Not persisting event, it\'s already in the log.' );
+			return;
+		}
+
+		Debugger::log( 'Persisting Event' );
+		$insert = $wpdb->insert( Database::get_table_name(), $event_payload ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		Debugger::log( $insert );
 		if ( ! $insert ) {
 			return false;
 		}
+		$event->is_persisted = true;
 		return $wpdb->insert_id;
 	}
 }

--- a/includes/incoming-events/class-abstract-incoming-event.php
+++ b/includes/incoming-events/class-abstract-incoming-event.php
@@ -47,16 +47,25 @@ class Abstract_Incoming_Event {
 	protected $site;
 
 	/**
+	 * Action name for this event
+	 *
+	 * @var string
+	 */
+	protected $action_name;
+
+	/**
 	 * Constructs a new Incoming Event
 	 *
 	 * @param string       $site      The origin site URL.
 	 * @param array|object $data      The data for this event.
 	 * @param int          $timestamp The timestamp for this event.
+	 * @param string       $action_name The action name for this event.
 	 */
-	public function __construct( $site, $data, $timestamp ) {
+	public function __construct( $site, $data, $timestamp, $action_name = false ) {
 		$this->site      = $site;
 		$this->data      = (object) $data;
 		$this->timestamp = $timestamp;
+		$this->action_name = $action_name;
 	}
 
 	/**
@@ -117,6 +126,9 @@ class Abstract_Incoming_Event {
 	 * @return string
 	 */
 	public function get_action_name() {
+		if ( $this->action_name ) {
+			return $this->action_name;
+		}
 		$class      = new \ReflectionClass( $this );
 		$class_name = $class->getShortName();
 		return array_search( $class_name, Accepted_Actions::ACTIONS );

--- a/includes/incoming-events/class-abstract-incoming-event.php
+++ b/includes/incoming-events/class-abstract-incoming-event.php
@@ -66,13 +66,11 @@ class Abstract_Incoming_Event {
 	 * @param string       $site      The origin site URL.
 	 * @param array|object $data      The data for this event.
 	 * @param int          $timestamp The timestamp for this event.
-	 * @param string       $action_name The action name for this event.
 	 */
-	public function __construct( $site, $data, $timestamp, $action_name = false ) {
+	public function __construct( $site, $data, $timestamp ) {
 		$this->site      = $site;
 		$this->data      = (object) $data;
 		$this->timestamp = $timestamp;
-		$this->action_name = $action_name;
 	}
 
 	/**
@@ -158,9 +156,6 @@ class Abstract_Incoming_Event {
 	 * @return string
 	 */
 	public function get_action_name() {
-		if ( $this->action_name ) {
-			return $this->action_name;
-		}
 		$class      = new \ReflectionClass( $this );
 		$class_name = $class->getShortName();
 		return array_search( $class_name, Accepted_Actions::ACTIONS );

--- a/includes/incoming-events/class-abstract-incoming-event.php
+++ b/includes/incoming-events/class-abstract-incoming-event.php
@@ -54,6 +54,13 @@ class Abstract_Incoming_Event {
 	protected $action_name;
 
 	/**
+	 * Has this event been persisted in the Event Log?
+	 *
+	 * @var string
+	 */
+	public $is_persisted = false;
+
+	/**
 	 * Constructs a new Incoming Event
 	 *
 	 * @param string       $site      The origin site URL.

--- a/includes/incoming-events/class-abstract-incoming-event.php
+++ b/includes/incoming-events/class-abstract-incoming-event.php
@@ -128,6 +128,16 @@ class Abstract_Incoming_Event {
 	}
 
 	/**
+	 * Returns the formatted date for this event based on its timestamp
+	 *
+	 * @param string $format The date format.
+	 * @return string
+	 */
+	public function get_formatted_date( $format = 'Y-m-d H:i:s' ) {
+		return gmdate( $format, $this->timestamp );
+	}
+
+	/**
 	 * Returns the action name for this event
 	 *
 	 * @return string

--- a/includes/incoming-events/class-reader-registered.php
+++ b/includes/incoming-events/class-reader-registered.php
@@ -10,6 +10,7 @@ namespace Newspack_Network\Incoming_Events;
 use Newspack_Network\Debugger;
 use Newspack_Network\Hub\Node;
 use Newspack_Network\Hub\Stores\Event_Log;
+use Newspack_Network\User_Update_Watcher;
 use Newspack_Network\Utils\Users as User_Utils;
 
 /**
@@ -46,6 +47,8 @@ class Reader_Registered extends Abstract_Incoming_Event {
 		if ( ! $email ) {
 			return;
 		}
+
+		User_Update_Watcher::$enabled = false;
 
 		$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
 	}

--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Incoming_Events;
 
 use Newspack_Network\User_Manual_Sync;
 use Newspack_Network\Debugger;
+use Newspack_Network\User_Update_Watcher;
 use Newspack_Network\Utils\Users as User_Utils;
 
 /**
@@ -47,6 +48,8 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 		if ( ! $email ) {
 			return;
 		}
+
+		User_Update_Watcher::$enabled = false;
 
 		$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
 

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -13,6 +13,8 @@ use Newspack_Network\Debugger;
  * Class to watch the user for updates and trigger events
  */
 class Users {
+	const USER_META_REMOTE_SITE = 'newspack_remote_site';
+	const USER_META_REMOTE_ID = 'newspack_remote_id';
 
 	/**
 	 * Gets an existing user or creates a user propagated from another site in the Network
@@ -48,8 +50,8 @@ class Users {
 			return $user_id;
 		}
 
-		update_user_meta( $user_id, 'newspack_remote_site', $remote_site_url );
-		update_user_meta( $user_id, 'newspack_remote_id', $remote_id );
+		update_user_meta( $user_id, self::USER_META_REMOTE_SITE, $remote_site_url );
+		update_user_meta( $user_id, self::USER_META_REMOTE_ID, $remote_id );
 
 		return get_user_by( 'id', $user_id );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a WP CLI script to backfill historical data. 

### How to test the changes in this Pull Request:

1. Switch `newspack-plugin` to `feat/tweaks-for-network-update` branch (https://github.com/Automattic/newspack-plugin/pull/2935)
2. Disable this plugin on both the hub and a node site, in order to build up historical data
3. On both sites (using different email addresses): 
    1. register a user, 
    2. make a donation
    3. make a recurring donation and the cancel the related subscription in WC
5. Activate the `newspack-network` plugin on both sites
6. Verify that the new user registrations and donations are not present in the Hub's event log
7. Run `wp newspack-network data-backfill reader_registered --start=2024-01-01 --end=2024-12-31` on the Hub site, observe the output the dry run and confirm nothing was added to the event log. 
    1. Do the same with `donation_new` as the argument instead of `reader_registered`.
    2. And then with `donation_subscription_cancelled` 
9. Try with `--verbose` flag for more output
10. Run `wp newspack-network data-backfill reader_registered --start=2024-01-01 --end=2024-12-31 --live` on the Hub site and observe the event was added to the event log. 
    1. Do the same with `donation_new` as the argument instead of `reader_registered`.
    2. And then with `donation_subscription_cancelled` 
12. Repeat the last three steps on the Node site, but instead of the event log look as the scheduled events in the Node Settings
13. Run in the live mode _again_ to ensure that duplicate events are not added to the event log or the scheduled events* (in the CLI output, observe it's noted that no events were processed and how many were skipped as duplicates)
14. After the scheduled event is transmitted, observe it was added to the Hub's event log
15. Run the script with `all` as action name argument and observe it has the same effect as running the above two scripts one after another

\* unless the webhook request queue has be cleared already, but the event log should handle deduplication itself anyway

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->