### PR TITLE
feat: enhance network subscriptions and orders search

### DIFF
--- a/includes/hub/admin/class-woo.php
+++ b/includes/hub/admin/class-woo.php
@@ -36,7 +36,6 @@ abstract class Woo {
 	 * Runs the initialization.
 	 */
 	public static function init() {
-
 		$class_name         = get_called_class();
 		$db_class_name      = str_replace( 'Admin', 'Database', $class_name );
 		self::$post_types[] = $db_class_name::POST_TYPE_SLUG;
@@ -180,13 +179,30 @@ abstract class Woo {
 	public static function parse_query( $query ) {
 		global $pagenow;
 
-		if ( ! is_admin() || 'edit.php' !== $pagenow || ! $query->is_main_query() || ! in_array( $query->query_vars['post_type'], self::$post_types, true ) ) {
+		if ( ! is_admin() || 'edit.php' !== $pagenow || empty( $query->query_vars['s'] ) || ! in_array( $query->query_vars['post_type'], self::$post_types, true ) ) {
 			return;
 		}
 
-		error_log( 'Query: ' . $query->query_vars['s'] );
+		$search_term = $query->query_vars['s'];
 
-		// Get Post IDs by query.
+		// Query by name and/or email meta.
+		$meta_query = [
+			'relation' => 'OR',
+			[
+				'key'     => 'user_name',
+				'value'   => sanitize_text_field( $search_term ),
+				'compare' => 'LIKE',
+			],
+			[
+				'key'     => 'user_email',
+				'value'   => sanitize_text_field( $search_term ),
+				'compare' => 'LIKE',
+			]
+		];
+
+		$query->set( 'meta_query', $meta_query );
+
+		unset( $query->query_vars['s'] );
 	}
 
 

--- a/includes/hub/admin/class-woo.php
+++ b/includes/hub/admin/class-woo.php
@@ -185,26 +185,27 @@ abstract class Woo {
 
 		$search_term = $query->query_vars['s'];
 
-		// Query by name and/or email meta.
-		$meta_query = [
-			'relation' => 'OR',
-			[
-				'key'     => 'user_name',
-				'value'   => sanitize_text_field( $search_term ),
-				'compare' => 'LIKE',
-			],
-			[
-				'key'     => 'user_email',
-				'value'   => sanitize_text_field( $search_term ),
-				'compare' => 'LIKE',
-			]
-		];
+		if ( ! is_numeric( $search_term ) ) {
+			// Query by name and/or email meta.
+			$meta_query = [
+				'relation' => 'OR',
+				[
+					'key'     => 'user_name',
+					'value'   => sanitize_text_field( $search_term ),
+					'compare' => 'LIKE',
+				],
+				[
+					'key'     => 'user_email',
+					'value'   => sanitize_text_field( $search_term ),
+					'compare' => 'LIKE',
+				],
+			];
 
-		$query->set( 'meta_query', $meta_query );
+			$query->set( 'meta_query', $meta_query );
 
-		unset( $query->query_vars['s'] );
+			unset( $query->query_vars['s'] );
+		}
 	}
-
 
 	/**
 	 * Modify columns on post type table

--- a/includes/hub/admin/class-woo.php
+++ b/includes/hub/admin/class-woo.php
@@ -46,6 +46,7 @@ abstract class Woo {
 
 		add_filter( 'manage_' . $db_class_name::POST_TYPE_SLUG . '_posts_columns', [ $class_name, 'posts_columns' ] );
 		add_action( 'manage_' . $db_class_name::POST_TYPE_SLUG . '_posts_custom_column', [ $class_name, 'posts_columns_values' ], 10, 2 );
+		add_action( 'parse_query', [ $class_name, 'parse_query' ] );
 
 		add_filter( 'get_edit_post_link', [ $class_name, 'get_edit_post_link' ], 10, 2 );
 
@@ -169,6 +170,25 @@ abstract class Woo {
 
 		return null;
 	}
+
+	/**
+	 * Filters search query to include custom fields
+	 *
+	 * @param \WP_Query $query  The Query object.
+	 * @return void
+	 */
+	public static function parse_query( $query ) {
+		global $pagenow;
+
+		if ( ! is_admin() || 'edit.php' !== $pagenow || ! $query->is_main_query() || ! in_array( $query->query_vars['post_type'], self::$post_types, true ) ) {
+			return;
+		}
+
+		error_log( 'Query: ' . $query->query_vars['s'] );
+
+		// Get Post IDs by query.
+	}
+
 
 	/**
 	 * Modify columns on post type table


### PR DESCRIPTION
Closes 1206477424334739-as-1206535638346945/f

This PR enhances the network subscriptions and orders search, allowing for search by name and email as well.

![Screenshot 2024-02-15 at 15 57 47](https://github.com/Automattic/newspack-network/assets/17905991/b4ae0a2f-06d0-484c-912d-fc86fbb622d2)


### Testing Instructions

1. Make sure you have a hub site setup that has completed subscription orders. 
2. Go to Newspack Network > Subscriptions
3. In the search bar, search for subscriptions from a specific user and confirm the results appear as expected
4. Search by email and again confirm the results appear as expected
5. Search by order number and again confirm the results appear as expected
6. Repeat the above steps for in the Newspack Network > Orders menu