### PR TITLE
feat: add hub bookmarks to nodes

### DIFF
--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -37,6 +37,7 @@ class Accepted_Actions {
 		'network_user_updated'                    => 'User_Updated',
 		'newspack_network_woo_membership_updated' => 'Woocommerce_Membership_Updated',
 		'network_manual_sync_user'                => 'User_Manually_Synced',
+		'network_nodes_synced'                    => 'Nodes_Synced',
 	];
 
 	/**
@@ -54,5 +55,6 @@ class Accepted_Actions {
 		'network_user_updated',
 		'newspack_network_woo_membership_updated',
 		'network_manual_sync_user',
+		'network_nodes_synced',
 	];
 }

--- a/includes/class-data-listeners.php
+++ b/includes/class-data-listeners.php
@@ -36,6 +36,7 @@ class Data_Listeners {
 		Data_Events::register_listener( 'woocommerce_subscription_status_changed', 'newspack_node_subscription_changed', [ __CLASS__, 'item_changed' ] );
 		Data_Events::register_listener( 'woocommerce_order_status_changed', 'newspack_node_order_changed', [ __CLASS__, 'item_changed' ] );
 		Data_Events::register_listener( 'newspack_network_user_updated', 'network_user_updated', [ __CLASS__, 'user_updated' ] );
+		Data_Events::register_listener( 'newspack_network_nodes_synced', 'network_nodes_synced', [ __CLASS__, 'nodes_synced' ] );
 	}
 
 	/**
@@ -84,5 +85,15 @@ class Data_Listeners {
 	 */
 	public static function user_updated( $user_data ) {
 		return $user_data;
+	}
+
+	/**
+	 * Filters the nodes data for the event being triggered
+	 *
+	 * @param array $nodes_data The nodes data.
+	 * @return array
+	 */
+	public static function nodes_synced( $nodes_data ) {
+		return [ 'nodes_data' => $nodes_data ];
 	}
 }

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -54,7 +54,7 @@ class Nodes_List {
 				function ( $bookmark ) {
 					return sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $bookmark['url'] ), esc_html( $bookmark['label'] ) );
 				},
-				Node::get_bookmarks( $node->get_url() )
+				$node->get_bookmarks()
 			);
 			$allowed_tags = [
 				'a' => [
@@ -107,7 +107,7 @@ class Nodes_List {
 			];
 			$wp_admin_bar->add_node( $args );
 
-			foreach ( Node::get_bookmarks( $node->get_url() ) as $bookmark ) {
+			foreach ( $node->get_bookmarks() as $bookmark ) {
 				$sub_item_id = $item_id . '-' . sanitize_title( $bookmark['label'] );
 				$args        = [
 					'id'     => $sub_item_id,

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -54,7 +54,7 @@ class Nodes_List {
 				function ( $bookmark ) {
 					return sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $bookmark['url'] ), esc_html( $bookmark['label'] ) );
 				},
-				$node->get_bookmarks()
+				Node::get_bookmarks( $node->get_url() )
 			);
 			$allowed_tags = [
 				'a' => [
@@ -107,7 +107,7 @@ class Nodes_List {
 			];
 			$wp_admin_bar->add_node( $args );
 
-			foreach ( $node->get_bookmarks() as $bookmark ) {
+			foreach ( Node::get_bookmarks( $node->get_url() ) as $bookmark ) {
 				$sub_item_id = $item_id . '-' . sanitize_title( $bookmark['label'] );
 				$args        = [
 					'id'     => $sub_item_id,

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -15,6 +15,10 @@ use WP_Post;
  * Class to represent one Node of the netowrk
  */
 class Node {
+	/**
+	 * HUB_NODES_SYNCED_OPTION for network nodes.
+	 */
+	const HUB_NODES_SYNCED_OPTION = 'newspack_hub_nodes_synced';
 
 	/**
 	 * The WP_Post object for this Node

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -120,13 +120,12 @@ class Node {
 	}
 
 	/**
-	 * Gets a collection of bookmarks for this Node
+	 * Generates a collection of bookmarks for this Node
 	 *
 	 * @param  string $url The URL of the Node.
 	 * @return array
 	 */
-	public static function get_bookmarks( $url ) {
-
+	public static function generate_bookmarks( $url ) {
 		$base_url = trailingslashit( $url );
 
 		return [
@@ -159,5 +158,16 @@ class Node {
 				'url'   => $base_url . 'wp-admin/options-general.php',
 			],
 		];
+	}
+
+	/**
+	 * Gets a collection of bookmarks for this Node.
+	 *
+	 * @return array
+	 */
+	public function get_bookmarks() {
+		$base_url = $this->get_url();
+
+		return self::generate_bookmarks( $base_url );
 	}
 }

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -118,11 +118,12 @@ class Node {
 	/**
 	 * Gets a collection of bookmarks for this Node
 	 *
+	 * @param  string $url The URL of the Node.
 	 * @return array
 	 */
-	public function get_bookmarks() {
+	public static function get_bookmarks( $url ) {
 
-		$base_url = trailingslashit( $this->get_url() );
+		$base_url = trailingslashit( $url );
 
 		return [
 			[

--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -21,14 +21,19 @@ class Nodes {
 	const POST_TYPE_SLUG = 'newspack_hub_nodes';
 
 	/**
+	 * HUB_NODES_SYNCED_OPTION for network nodes.
+	 */
+	const HUB_NODES_SYNCED_OPTION = 'newspack_hub_nodes_synced';
+
+	/**
 	 * Initialize this class and register hooks
 	 *
 	 * @return void
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'register_nodes_init' ] );
+		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'save_post', [ __CLASS__, 'save_post' ] );
-		add_action( 'save_post_' . self::POST_TYPE_SLUG, [ __CLASS__, 'sync_nodes_list' ] );
+		add_action( 'save_post_' . self::POST_TYPE_SLUG, [ __CLASS__, 'sync_nodes' ] );
 	}
 
 	/**
@@ -144,29 +149,6 @@ class Nodes {
 			'register_meta_box_cb' => [ __CLASS__, 'add_metabox' ],
 		);
 		register_post_type( self::POST_TYPE_SLUG, $args );
-	}
-
-	/**
-	 * Register the listeners to the Newspack Data Events API
-	 *
-	 * @return void
-	 */
-	public static function register_listener() {
-		if ( ! class_exists( 'Data_Events' ) ) {
-			return;
-		}
-
-		Data_Events::register_listener( 'newspack_network_nodes_synced', 'network_nodes_synced' );
-	}
-
-	/**
-	 * Initialize registration.
-	 *
-	 * @return void
-	 */
-	public static function register_nodes_init() {
-		self::register_post_type();
-		self::register_listener();
 	}
 
 	/**
@@ -297,27 +279,27 @@ class Nodes {
 	}
 
 	/**
-	 * Sync nodes list
+	 * Sync nodes data to all nodes in network.
 	 *
 	 * @param int $post_id The ID of the post being saved.
 	 * @return void
 	 */
-	public static function sync_nodes_list( $post_id ) {
+	public static function sync_nodes( $post_id ) {
 		$nodes = self::get_all_nodes();
 
 		if ( empty( $nodes ) ) {
 			return;
 		}
 
-		$node_data = [];
+		$nodes_data = [];
 		foreach ( $nodes as $node ) {
-			$node_data[] = [
+			$nodes_data[] = [
 				'id'    => $node->get_id(),
 				'title' => $node->get_name(),
 				'url'   => $node->get_url(),
 			];
 		}
 
-		do_action( 'newspack_network_nodes_synced', $node_data );
+		do_action( 'newspack_network_nodes_synced', $nodes_data );
 	}
 }

--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -14,16 +14,10 @@ use Newspack_Network\Admin as Network_Admin;
  * Class to handle Nodes post type
  */
 class Nodes {
-
 	/**
 	 * POST_TYPE_SLUG for the Nodes.
 	 */
 	const POST_TYPE_SLUG = 'newspack_hub_nodes';
-
-	/**
-	 * HUB_NODES_SYNCED_OPTION for network nodes.
-	 */
-	const HUB_NODES_SYNCED_OPTION = 'newspack_hub_nodes_synced';
 
 	/**
 	 * Initialize this class and register hooks

--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -27,7 +27,11 @@ class Nodes {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'save_post', [ __CLASS__, 'save_post' ] );
-		add_action( 'save_post_' . self::POST_TYPE_SLUG, [ __CLASS__, 'sync_nodes' ] );
+		add_action( 'trashed_post', [ __CLASS__, 'trashed_node' ] );
+		add_action( 'untrashed_post', [ __CLASS__, 'untrashed_node' ] );
+		add_action( 'newspack_network_node_saved', [ __CLASS__, 'sync_nodes' ] );
+		add_action( 'newspack_network_node_trashed', [ __CLASS__, 'sync_nodes' ] );
+		add_action( 'newspack_network_node_untrashed', [ __CLASS__, 'sync_nodes' ] );
 	}
 
 	/**
@@ -270,6 +274,44 @@ class Nodes {
 		 * @param int $post_id The ID of the node post.
 		 */
 		do_action( 'newspack_network_node_saved', $post_id );
+	}
+
+	/**
+	 * Trashed post callback
+	 *
+	 * @param int $post_id The ID of the post being trashed.
+	 * @return void
+	 */
+	public static function trashed_node( $post_id ) {
+		if ( self::POST_TYPE_SLUG !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		/**
+		 * Fires an action when a node is successfully trashed in the Hub admin
+		 *
+		 * @param int $post_id The ID of the node post.
+		 */
+		do_action( 'newspack_network_node_trashed', $post_id );
+	}
+
+	/**
+	 * Untrashed post callback
+	 *
+	 * @param int $post_id The ID of the post being untrashed.
+	 * @return void
+	 */
+	public static function untrashed_node( $post_id ) {
+		if ( self::POST_TYPE_SLUG !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		/**
+		 * Fires an action when a node is successfully untrashed in the Hub admin
+		 *
+		 * @param int $post_id The ID of the node post.
+		 */
+		do_action( 'newspack_network_node_untrashed', $post_id );
 	}
 
 	/**

--- a/includes/hub/stores/event-log-items/class-nodes-synced.php
+++ b/includes/hub/stores/event-log-items/class-nodes-synced.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Newspack Nodes Synced Log Item
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Hub\Stores\Event_Log_Items;
+
+use Newspack_Network\Hub\Stores\Abstract_Event_Log_Item;
+
+/**
+ * Class to handle the Nodes Synced Log Item
+ */
+class Nodes_Synced extends Abstract_Event_Log_Item {
+
+	/**
+	 * Gets a summary for this event
+	 *
+	 * @return string
+	 */
+	public function get_summary() {
+		return __( 'Node data synced', 'newspack-network' );
+	}
+}

--- a/includes/incoming-events/class-nodes-synced.php
+++ b/includes/incoming-events/class-nodes-synced.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Newspack Nodes Synced Incoming Event class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Debugger;
+
+/**
+ * Class to handle the Nodes Synced Event
+ *
+ * This event is always sent from the Hub and received by Nodes.
+ */
+class Nodes_Synced extends Abstract_Incoming_Event {
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		Debugger::log( 'Processing nodes_synced event.' );
+		// Get data passed for node urls.
+		$data = $this->get_data();
+		// If the data is empty, return early.
+		if ( empty( $data ) ) {
+			Debugger::log( 'No data passed for nodes_synced event.' );
+			return;
+		}
+
+		foreach ( $data as $key => $node ) {
+			if ( $data['url'] === get_site_url() ) {
+				unset( $data[ $key ] );
+			}
+		}
+
+		$updated = update_option( 'newspack_hub_nodes_synced', $data );
+
+		if ( $updated ) {
+			Debugger::log( 'Nodes synced event processed.' );
+		} else {
+			Debugger::log( 'Error processing nodes_synced event.' );
+		}
+	}
+}

--- a/includes/incoming-events/class-nodes-synced.php
+++ b/includes/incoming-events/class-nodes-synced.php
@@ -8,7 +8,7 @@
 namespace Newspack_Network\Incoming_Events;
 
 use Newspack_Network\Debugger;
-use Newspack_Network\Hub\Nodes;
+use Newspack_Network\Hub\Node;
 
 /**
  * Class to handle the Nodes Synced Event
@@ -47,7 +47,7 @@ class Nodes_Synced extends Abstract_Incoming_Event {
 			}
 		}
 
-		$updated = update_option( Nodes::HUB_NODES_SYNCED_OPTION, $nodes_data );
+		$updated = update_option( Node::HUB_NODES_SYNCED_OPTION, $nodes_data );
 
 		if ( $updated ) {
 			Debugger::log( 'network_nodes_synced event processed. Synced ' . count( $nodes_data ) . ' nodes.' );

--- a/includes/incoming-events/class-nodes-synced.php
+++ b/includes/incoming-events/class-nodes-synced.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Incoming_Events;
 
 use Newspack_Network\Debugger;
+use Newspack_Network\Hub\Nodes;
 
 /**
  * Class to handle the Nodes Synced Event
@@ -21,27 +22,37 @@ class Nodes_Synced extends Abstract_Incoming_Event {
 	 * @return void
 	 */
 	public function process_in_node() {
-		Debugger::log( 'Processing nodes_synced event.' );
+		Debugger::log( 'Processing network_nodes_synced event.' );
 		// Get data passed for node urls.
 		$data = $this->get_data();
+
 		// If the data is empty, return early.
 		if ( empty( $data ) ) {
-			Debugger::log( 'No data passed for nodes_synced event.' );
+			Debugger::log( 'No data passed for network_nodes_synced event.' );
 			return;
 		}
 
-		foreach ( $data as $key => $node ) {
-			if ( $data['url'] === get_site_url() ) {
-				unset( $data[ $key ] );
+		$nodes_data = $data->nodes_data;
+
+		// If the nodes data is empty, return early.
+		if ( empty( $nodes_data ) ) {
+			Debugger::log( 'No nodes data passed for network_nodes_synced event.' );
+			return;
+		}
+
+		foreach ( $nodes_data as $key => $node ) {
+			// We don't need top store data for the current node.
+			if ( $node['url'] === get_site_url() ) {
+				unset( $nodes_data[ $key ] );
 			}
 		}
 
-		$updated = update_option( 'newspack_hub_nodes_synced', $data );
+		$updated = update_option( Nodes::HUB_NODES_SYNCED_OPTION, $nodes_data );
 
 		if ( $updated ) {
-			Debugger::log( 'Nodes synced event processed.' );
+			Debugger::log( 'network_nodes_synced event processed. Synced ' . count( $nodes_data ) . ' nodes.' );
 		} else {
-			Debugger::log( 'Error processing nodes_synced event.' );
+			Debugger::log( 'Error processing network_nodes_synced event.' );
 		}
 	}
 }

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -593,7 +593,7 @@ class Settings {
 				]
 			);
 
-			foreach ( Hub_Node::get_bookmarks( $node['url'] ) as $bookmark ) {
+			foreach ( Hub_Node::generate_bookmarks( $node['url'] ) as $bookmark ) {
 				$wp_admin_bar->add_node(
 					[
 						'id'     => $item_id . '-' . sanitize_title( $bookmark['label'] ),

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -574,24 +574,32 @@ class Settings {
 	 * @return void
 	 */
 	public static function admin_bar_menu( $wp_admin_bar ) {
-		$wp_admin_bar->add_node(
-			[
-				'id'     => 'hub',
-				'title'  => 'Hub',
-				'href'   => false,
-				'parent' => 'site-name',
-			]
-		);
+		$node_data   = get_option( 'newspack_hub_nodes_synced', [] );
+		$node_data[] = [
+			'url'   => self::get_hub_url(),
+			'title' => __( 'Hub', 'newspack-network' ),
+		];
 
-		foreach ( Hub_Node::get_bookmarks( self::get_hub_url() ) as $bookmark ) {
+		foreach ( $node_data as $node ) {
 			$wp_admin_bar->add_node(
 				[
-					'id'     => 'hub-' . sanitize_title( $bookmark['label'] ),
-					'title'  => $bookmark['label'],
-					'href'   => $bookmark['url'],
-					'parent' => 'hub',
+					'id'     => 'node-' . sanitize_title( $node['id'] ),
+					'title'  => $node['title'],
+					'href'   => $node['url'],
+					'parent' => 'site-name',
 				]
 			);
+
+			foreach ( Hub_Node::get_bookmarks( $node['url'] ) as $bookmark ) {
+				$wp_admin_bar->add_node(
+					[
+						'id'     => 'node-' . sanitize_title( $bookmark['label'] ),
+						'title'  => $bookmark['label'],
+						'href'   => $bookmark['url'],
+						'parent' => 'node-' . $node['id'],
+					]
+				);
+			}
 		}
 	}
 }

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -9,7 +9,7 @@ namespace Newspack_Network\Node;
 
 use Newspack_Network\Admin;
 use Newspack_Network\Crypto;
-use Newspack_Network\Hub\Node as Hub_Node;
+use Newspack_Network\Hub\Nodes as Hub_Nodes;
 use WP_Error;
 
 /**
@@ -574,29 +574,31 @@ class Settings {
 	 * @return void
 	 */
 	public static function admin_bar_menu( $wp_admin_bar ) {
-		$node_data   = get_option( 'newspack_hub_nodes_synced', [] );
-		$node_data[] = [
+		$nodes_data   = get_option( Hub_Nodes::HUB_NODES_SYNCED_OPTION, [] );
+		$nodes_data[] = [
+			'id'    => 0,
 			'url'   => self::get_hub_url(),
 			'title' => __( 'Hub', 'newspack-network' ),
 		];
 
-		foreach ( $node_data as $node ) {
+		foreach ( $nodes_data as $node ) {
+			$item_id = 'node-' . $node['id'];
 			$wp_admin_bar->add_node(
 				[
-					'id'     => 'node-' . sanitize_title( $node['id'] ),
+					'id'     => $item_id,
 					'title'  => $node['title'],
 					'href'   => $node['url'],
 					'parent' => 'site-name',
 				]
 			);
 
-			foreach ( Hub_Node::get_bookmarks( $node['url'] ) as $bookmark ) {
+			foreach ( Node::get_bookmarks( $node['url'] ) as $bookmark ) {
 				$wp_admin_bar->add_node(
 					[
-						'id'     => 'node-' . sanitize_title( $bookmark['label'] ),
+						'id'     => $item_id . '-' . sanitize_title( $bookmark['label'] ),
 						'title'  => $bookmark['label'],
 						'href'   => $bookmark['url'],
-						'parent' => 'node-' . $node['id'],
+						'parent' => $item_id,
 					]
 				);
 			}

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Node;
 
 use Newspack_Network\Admin;
 use Newspack_Network\Crypto;
+use Newspack_Network\Hub\Node as Hub_Node;
 use Newspack_Network\Hub\Nodes as Hub_Nodes;
 use WP_Error;
 
@@ -544,7 +545,7 @@ class Settings {
 			<div class="misc-pub-section">
 				<a
 					class="button"
-					href="<?php echo esc_url( wp_unslash( self::get_hub_url() ) ); ?>/wp-admin/edit.php?post_type=<?php echo esc_attr( \Newspack_Network\Hub\Nodes::POST_TYPE_SLUG ); ?>"
+					href="<?php echo esc_url( wp_unslash( self::get_hub_url() ) ); ?>/wp-admin/edit.php?post_type=<?php echo esc_attr( Hub_Nodes::POST_TYPE_SLUG ); ?>"
 				>
 					<?php esc_html_e( 'Go back to the Hub', 'newspack-network' ); ?>
 				</a>
@@ -574,7 +575,7 @@ class Settings {
 	 * @return void
 	 */
 	public static function admin_bar_menu( $wp_admin_bar ) {
-		$nodes_data   = get_option( Hub_Nodes::HUB_NODES_SYNCED_OPTION, [] );
+		$nodes_data   = get_option( Hub_Node::HUB_NODES_SYNCED_OPTION, [] );
 		$nodes_data[] = [
 			'id'    => 0,
 			'url'   => self::get_hub_url(),
@@ -592,7 +593,7 @@ class Settings {
 				]
 			);
 
-			foreach ( Node::get_bookmarks( $node['url'] ) as $bookmark ) {
+			foreach ( Hub_Node::get_bookmarks( $node['url'] ) as $bookmark ) {
 				$wp_admin_bar->add_node(
 					[
 						'id'     => $item_id . '-' . sanitize_title( $bookmark['label'] ),

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Node;
 
 use Newspack_Network\Admin;
 use Newspack_Network\Crypto;
+use Newspack_Network\Hub\Node as Hub_Node;
 use WP_Error;
 
 /**
@@ -48,6 +49,7 @@ class Settings {
 		add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
 		add_action( 'admin_init', [ __CLASS__, 'process_connection_form' ] );
+		add_action( 'admin_bar_menu', [ __CLASS__, 'admin_bar_menu' ], 100 );
 	}
 
 	/**
@@ -563,5 +565,33 @@ class Settings {
 			<p><?php echo esc_html( self::$connection_error ); ?></p>
 			</div>
 		<?php
+	}
+	
+	/**
+	 * Adds the nodes and their bookmarks to the Admin Bar menu
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 * @return void
+	 */
+	public static function admin_bar_menu( $wp_admin_bar ) {
+		$wp_admin_bar->add_node(
+			[
+				'id'     => 'hub',
+				'title'  => 'Hub',
+				'href'   => false,
+				'parent' => 'site-name',
+			]
+		);
+
+		foreach ( Hub_Node::get_bookmarks( self::get_hub_url() ) as $bookmark ) {
+			$wp_admin_bar->add_node(
+				[
+					'id'     => 'hub-' . sanitize_title( $bookmark['label'] ),
+					'title'  => $bookmark['label'],
+					'href'   => $bookmark['url'],
+					'parent' => 'hub',
+				]
+			);
+		}
 	}
 }


### PR DESCRIPTION
Closes 1206274567818686-as-1206445911335988 

This PR adds the bookmarks dropdown that was previously only available on the hub to all nodes in the network.

To do this, we add a new network event which is triggered whenever a node is saved or updated, which propagates some basic node data to all nodes in the network. The nodes store this data as an option and use it to render this dropdown.

![Screenshot 2024-02-20 at 17 55 54](https://github.com/Automattic/newspack-network/assets/17905991/15420a24-8d64-4240-86c7-9792315b8611)


### Testing Instructions

1. Have a network with at least two nodes setup (in addition to the hub)
2. With these changes checked out, go to wp-admin in the hub site, and select a node to edit via Newspack Network > Nodes > YOUR NODE
3. Click update (no need to make any changes)
4. Go to the event log in the hub via Newspack Network > Event Log
5. Confirm a nodes synced event appears:
![Screenshot 2024-02-20 at 17 58 27](https://github.com/Automattic/newspack-network/assets/17905991/4c47432b-35a8-4b89-80db-8cc7a7fc2f91)
6. Wait for the event to propagate to the nodes, then visit the wp-admin of a node site.
7. Confirm the dropdown menu is available and contains an entry for the hub as well as the other node in the network, but not for itself.
8. Do the same for the other node site.
9. Go back to the hub site and trash one of the nodes.
10. Confirm another nodes synced event in the event logs
11. Wait for the event to propagate
12. Go to wp-admin for the node that has not been removed from the network
13. Confirm the removed node is not present in the dropdown menu

Note: The removed node still has the dropdown and still thinks its part of the network. I think we should address cleaning up not only this dropdown, but all network settings for a removed node in a follow-up PR.