### PR TITLE
fix: race condition when creating a Node

### DIFF
--- a/includes/hub/class-newspack-ads-gam.php
+++ b/includes/hub/class-newspack-ads-gam.php
@@ -25,7 +25,7 @@ final class Newspack_Ads_GAM {
 	 */
 	public static function init() {
 		add_action( 'newspack_ads_setup_gam', [ __CLASS__, 'create_targeting_keys' ] );
-		add_action( 'save_post_' . Nodes::POST_TYPE_SLUG, [ __CLASS__, 'create_targeting_keys' ] );
+		add_action( 'newspack_network_node_saved', [ __CLASS__, 'create_targeting_keys' ], 1 );
 	}
 
 	/**

--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -258,5 +258,12 @@ class Nodes {
 			$secret_key = Crypto::generate_secret_key();
 			update_post_meta( $post_id, 'secret-key', $secret_key );
 		}
+
+		/**
+		 * Fires an action after a node is successfully saved (created/updated) in the Hub admin
+		 *
+		 * @param int $post_id The ID of the node post.
+		 */
+		do_action( 'newspack_network_node_saved', $post_id );
 	}
 }


### PR DESCRIPTION
Both `Newspack_Ads_GAM` and `Hub\Nodes` classes were hooking on `save_post` when a Node was created / updated.

Depending on the order in which plugins were loaded, the GAM class would try to access the node metadata before it was created, because their hook was called earlier.

This PR fixes this race condition.

Instead of changing the priority of the `add_action`, I suggested that we created a dedicated new action, so we don't risk of making the same mistake again.