### PR TITLE
Feat/custom esp meta fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: newspack/newspack@1.4.4
+  newspack: newspack/newspack@1.5.3
 
 commands:
   checkout_code:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -130,7 +130,7 @@ recreate_db() {
 	shopt -s nocasematch
 	if [[ $1 =~ ^(y|yes)$ ]]
 	then
-		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		mysqladmin drop $DB_NAME --force --user="$DB_USER" --password="$DB_PASS"$EXTRA
 		create_db
 		echo "Recreated the database ($DB_NAME)."
 	else
@@ -168,9 +168,7 @@ install_db() {
 	# create database
 	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
 	then
-		echo "Reinstalling will delete the existing test database ($DB_NAME)"
-		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
-		recreate_db $DELETE_EXISTING_DB
+		recreate_db "y"
 	else
 		create_db
 	fi

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"wp-coding-standards/wpcs": "^3.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"phpcompatibility/phpcompatibility-wp": "*",
-		"yoast/phpunit-polyfills": "^1.0",
+		"yoast/phpunit-polyfills": "^1.1",
 		"phpunit/phpunit": "^7.0 || ^9.5"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b010e97f477cd19dba1ab17bfe091667",
+    "content-hash": "7e64980fa26049e18679109066c21d8b",
     "packages": [],
     "packages-dev": [
         {
@@ -141,30 +141,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -191,7 +191,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -207,7 +207,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -270,25 +270,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
+                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -296,7 +298,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -320,9 +322,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.0"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2024-01-07T17:17:35+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -777,23 +779,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "9.2.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -842,7 +844,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
             },
             "funding": [
                 {
@@ -850,7 +853,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-12-22T06:47:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1095,16 +1098,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.8",
+            "version": "9.6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
                 "shasum": ""
             },
             "require": {
@@ -1119,7 +1122,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-code-coverage": "^9.2.28",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -1178,7 +1181,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
             },
             "funding": [
                 {
@@ -1194,7 +1197,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:14:45+00:00"
+            "time": "2024-01-19T07:03:14+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1439,20 +1442,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1484,7 +1487,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1492,7 +1495,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1702,16 +1705,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
                 "shasum": ""
             },
             "require": {
@@ -1754,7 +1757,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
             },
             "funding": [
                 {
@@ -1762,24 +1765,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-08-02T09:26:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1811,7 +1814,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -1819,7 +1822,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2220,16 +2223,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
                 "shasum": ""
             },
             "require": {
@@ -2296,20 +2299,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-01-11T20:47:48+00:00"
+            "time": "2024-02-16T15:06:51+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -2338,7 +2341,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -2346,7 +2349,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2416,16 +2419,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2472,7 +2475,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -2482,5 +2485,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -35,6 +35,7 @@ class Accepted_Actions {
 		'donation_new'                       => 'Donation_New',
 		'donation_subscription_cancelled'    => 'Donation_Subscription_Cancelled',
 		'network_user_updated'               => 'User_Updated',
+		'esp_metadata_settings_updated'      => 'Esp_Metadata_Settings_Updated',
 	];
 
 	/**
@@ -50,5 +51,6 @@ class Accepted_Actions {
 		'donation_new',
 		'donation_subscription_cancelled',
 		'network_user_updated',
+		'esp_metadata_settings_updated',
 	];
 }

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -20,7 +20,7 @@ class Esp_Metadata_Sync {
 	 *
 	 * @var string
 	 */
-	const OPTION_NAME = 'newspack_esp_metadata';
+	const OPTION_NAME = 'newspack_network_esp_metadata';
 
 	/**
 	 * Gets the current value of the Newspack ESP metadata option.

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network;
 
 use Newspack\Data_Events;
+use Newspack\Newspack_Newsletters as Newspack_Plugin_Newsletters;
 
 /**
  * Class to handle the ESP metadata sync
@@ -28,7 +29,7 @@ class Esp_Metadata_Sync {
 	 */
 	public static function get_option() {
 		$option = get_option( self::OPTION_NAME );
-		if ( ! $option || ! is_array( $option ) ) {
+		if ( ! $option || ! is_array( $option ) || empty( $option ) ) {
 			return 'default';
 		}
 		return $option;
@@ -50,6 +51,7 @@ class Esp_Metadata_Sync {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_listener' ] );
+		add_filter( 'newspack_esp_sync_normalize_contact', [ __CLASS__, 'normalize_contact_data' ] );
 	}
 
 	/**
@@ -80,5 +82,45 @@ class Esp_Metadata_Sync {
 		return [
 			'value' => $value,
 		];
+	}
+
+	/**
+	 * Filters the normalized contact to keep the selected metadata fields
+	 *
+	 * @param array $contact The contact data after it has been normalized by Newspack_Newsletters class.
+	 * @return array
+	 */
+	public static function normalize_contact_data( $contact ) {
+
+		if ( self::is_default() ) {
+			return $contact;
+		}
+
+		// Discard invalid fields, just in case.
+		$selected_fields = array_filter(
+			self::get_option(),
+			function( $field ) {
+				return in_array( $field, array_keys( Newspack_Plugin_Newsletters::$metadata_keys ), true );
+			}
+		);
+
+		if ( empty( $selected_fields ) ) {
+			return $contact;
+		}
+
+		$selected_fields     = array_map( [ Newspack_Plugin_Newsletters::class, 'get_metadata_key' ], self::get_option() );
+		$customizable_fields = array_map( [ Newspack_Plugin_Newsletters::class, 'get_metadata_key' ], array_keys( Newspack_Plugin_Newsletters::$metadata_keys ) );
+		$new_metadata        = [];
+
+		foreach ( $contact['metadata'] as $meta_key => $meta_value ) {
+			// Remove only the fields that exist in Newspack_Plugin_Newsletters::$metadata_keys but are not selected.
+			// We want to keep other native fields like Name or First/Last Name.
+			if ( ! in_array( $meta_key, $customizable_fields, true ) || in_array( $meta_key, $selected_fields, true ) ) {
+				$new_metadata[ $meta_key ] = $meta_value;
+			}
+		}
+
+		$contact['metadata'] = $new_metadata;
+		return $contact;
 	}
 }

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Newspack Network class to filter the fields synced by Newspack to the ESP.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+use Newspack\Data_Events;
+
+/**
+ * Class to handle the ESP metadata sync
+ */
+class Esp_Metadata_Sync {
+
+	/**
+	 * The Newspack ESP metadata option name
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'newspack_esp_metadata';
+
+	/**
+	 * Gets the current value of the Newspack ESP metadata option.
+	 *
+	 * @return array|string The string 'default' or an array with metadata field slugs.
+	 */
+	public static function get_option() {
+		$option = get_option( self::OPTION_NAME );
+		if ( ! $option || ! is_array( $option ) ) {
+			return 'default';
+		}
+		return $option;
+	}
+
+	/**
+	 * Checks if the Newspack ESP metadata option is set to the default value.
+	 *
+	 * @return boolean
+	 */
+	public static function is_default() {
+		return 'default' === self::get_option();
+	}
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_listener' ] );
+	}
+
+	/**
+	 * Register the listener to the Newspack Data Events API
+	 *
+	 * We will only register the listener if the site role is hub, as this option can only be set by the hub.
+	 *
+	 * @return void
+	 */
+	public static function register_listener() {
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return;
+		}
+
+		if ( Site_Role::is_hub() ) {
+			Data_Events::register_listener( 'update_option_' . self::OPTION_NAME, 'esp_metadata_settings_updated', [ __CLASS__, 'dispatch_esp_metadata_settings_updated' ] );
+		}
+	}
+
+	/**
+	 * Dispatches the esp_metadata_settings_updated event data
+	 *
+	 * @param mixed $old_value The old value.
+	 * @param mixed $value The new value.
+	 * @return array
+	 */
+	public static function dispatch_esp_metadata_settings_updated( $old_value, $value ) {
+		return [
+			'value' => $value,
+		];
+	}
+}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -42,6 +42,7 @@ class Initializer {
 		Reader_Roles_Filter::init();
 		User_Update_Watcher::init();
 		Distributor_Customizations::init();
+		Esp_Metadata_Sync::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/hub/admin/class-esp-metadata-settings.php
+++ b/includes/hub/admin/class-esp-metadata-settings.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Newspack Hub ESP Metadata settings
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Hub\Admin;
+
+use Newspack_Network\Admin as Network_Admin;
+use Newspack_Network\Esp_Metadata_Sync;
+use Newspack\Newspack_Newsletters as Newspack_Plugin_Newsletters;
+/**
+ * Class to handle Node settings page
+ */
+class Esp_Metadata_Settings {
+
+	/**
+	 * The admin page slug
+	 */
+	const PAGE_SLUG = 'newspack-network-esp-metadata';
+
+	/**
+	 * The nonce action slug
+	 */
+	const NONCE = 'newspack-network-esp-metadata-save';
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
+		add_action( 'admin_init', [ __CLASS__, 'maybe_process_form' ] );
+	}
+
+	/**
+	 * Adds the submenu page
+	 *
+	 * @return void
+	 */
+	public static function add_menu() {
+		if ( ! class_exists( 'Newspack\Newspack_Newsletters' ) ) {
+			return;
+		}
+		Network_Admin::add_submenu_page( __( 'ESP Metadata sync settings', 'newspack-network' ), self::PAGE_SLUG, [ __CLASS__, 'render' ] );
+	}
+
+	/**
+	 * Enqueues the admin script.
+	 *
+	 * @return void
+	 */
+	public static function admin_enqueue_scripts() {
+		$page_slug = Network_Admin::PAGE_SLUG . '_page_' . self::PAGE_SLUG;
+		if ( get_current_screen()->id !== $page_slug ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'newspack-network-esp-metadata-settings',
+			plugins_url( 'js/esp-metadata-settings.js', __FILE__ ),
+			[],
+			filemtime( NEWSPACK_NETWORK_PLUGIN_DIR . '/includes/hub/admin/js/esp-metadata-settings.js' ),
+			true
+		);
+	}
+
+	/**
+	 * Renders the settings page
+	 *
+	 * @return void
+	 */
+	public static function render() {
+		self::maybe_process_form();
+		$current_value = Esp_Metadata_Sync::get_option();
+		$current_selected_fields = Esp_Metadata_Sync::is_default() ? [] : $current_value;
+		?>
+		<div class='wrap'>
+			<form method="post">
+			<?php wp_nonce_field( self::NONCE ); ?>
+				<h2>
+					<?php esc_html_e( 'ESP Metadata sync settings', 'newspack-network' ); ?>
+				</h2>
+				<p>
+					<?php esc_html_e( 'This page allows you to modify which information about a user Newspack will sync to the connected ESP.', 'newspack-network' ); ?>
+				</p>
+				<p>
+					<?php esc_html_e( 'If you have many sites in your network connected to the same ESP account, you might want to reduce the number of synced fields. This is especially important for Mailchimp, since it has a small limit of Contacts metadata fields you can have.', 'newspack-network' ); ?>
+				</p>
+				<p>
+					<?php esc_html_e( 'You also need to configure a unique prefix for each site in Nespack > Engagement > Reader Activation > Advanced > Metadata Field Prefix.', 'newspack-network' ); ?>
+				</p>
+				<table class="form-table" role="presentation">
+					<tbody>
+						<tr>
+							<th scope="row"><label for="blogname"><?php esc_html_e( 'Metadata settings', 'newspack-network' ); ?></label></th>
+							<td>
+								<select name="np_network_esp_metadata_settings" id="np_network_esp_metadata_settings">
+									<option value="default" <?php selected( Esp_Metadata_Sync::is_default() ); ?>><?php esc_html_e( 'Newspack Default: Sync all fields', 'newspack-network' ); ?></option>
+									<option value="custom" <?php selected( ! Esp_Metadata_Sync::is_default() ); ?>><?php esc_html_e( 'Custom', 'newspack-network' ); ?></option>
+								</select>
+							</td>
+						</tr>
+						<tr id="newspack-network-select-fields-row" style="display: none">
+							<th scope="row">
+								<label for="short_name"><?php esc_html_e( 'Fields to sync', 'newspack-network' ); ?></label>
+							</th>
+							<td>
+								<?php foreach ( Newspack_Plugin_Newsletters::$metadata_keys as $slug => $name ) : ?>
+
+									<input type="checkbox" name="metadata_keys[]" id="<?php echo esc_attr( $slug ); ?>" value="<?php echo esc_attr( $slug ); ?>" <?php checked( in_array( $slug, $current_selected_fields ) ); ?>>
+									<label for="<?php echo esc_attr( $slug ); ?>">
+									<?php echo esc_html( $name ); ?>
+									</label><br>
+
+								<?php endforeach; ?>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<p class='submit'>
+						<input name='submit' type='submit' id='submit' class='button-primary' value='<?php _e( 'Save Changes' ); ?>' />
+				</p>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Process the form when it's submitted
+	 *
+	 * @return void
+	 */
+	public static function maybe_process_form() {
+		if ( ! isset( $_POST['np_network_esp_metadata_settings'] ) ) {
+			return;
+		}
+
+		if ( ! check_admin_referer( self::NONCE ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$metadata_settings = sanitize_text_field( $_POST['np_network_esp_metadata_settings'] );
+		$metadata_keys = isset( $_POST['metadata_keys'] ) ? array_map( 'sanitize_text_field', $_POST['metadata_keys'] ) : [];
+
+		if ( 'default' === $metadata_settings ) {
+			update_option( Esp_Metadata_Sync::OPTION_NAME, 'default' );
+		} else {
+			update_option( Esp_Metadata_Sync::OPTION_NAME, $metadata_keys );
+		}
+
+		add_action( 'admin_notices', [ __CLASS__, 'notice_success' ] );
+	}
+
+	/**
+	 * Displays a success notice
+	 *
+	 * @return void
+	 */
+	public static function notice_success() {
+		?>
+			<div class="notice notice-success is-dismissible">
+			<p><?php esc_html_e( 'Settings saved!', 'newspack-network' ); ?></p>
+			</div>
+		<?php
+	}
+}

--- a/includes/hub/admin/js/esp-metadata-settings.js
+++ b/includes/hub/admin/js/esp-metadata-settings.js
@@ -1,0 +1,14 @@
+jQuery( document ).ready( () => {
+	toggleMetadataSettings = function () {
+		const metadataSettings = jQuery( '#np_network_esp_metadata_settings' ).val();
+		if ( 'default' === metadataSettings ) {
+			jQuery( '#newspack-network-select-fields-row' ).hide();
+		} else {
+			jQuery( '#newspack-network-select-fields-row' ).show();
+		}
+	};
+
+	toggleMetadataSettings();
+
+	jQuery( '#np_network_esp_metadata_settings' ).change( toggleMetadataSettings );
+} );

--- a/includes/hub/class-admin.php
+++ b/includes/hub/class-admin.php
@@ -21,6 +21,7 @@ class Admin {
 		Admin\Orders::init();
 		Admin\Users::init();
 		Admin\Nodes_List::init();
+		Admin\Esp_Metadata_Settings::init();
 		Distributor_Settings::init();
 	}
 }

--- a/includes/hub/stores/event-log-items/class-esp-metadata-settings-updated.php
+++ b/includes/hub/stores/event-log-items/class-esp-metadata-settings-updated.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Newspack ESP Metadata Settings Updated Log Item
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Hub\Stores\Event_Log_Items;
+
+use Newspack_Network\Hub\Stores\Abstract_Event_Log_Item;
+
+/**
+ * Class to handle the ESP Metadata Settings Updated Log Item
+ */
+class Esp_Metadata_Settings_Updated extends Abstract_Event_Log_Item {
+
+	/**
+	 * Gets a summary for this event
+	 *
+	 * @return string
+	 */
+	public function get_summary() {
+		return __( 'ESP Metadata settings updated', 'newspack-network' );
+	}
+}

--- a/includes/incoming-events/class-esp-metadata-settings-updated.php
+++ b/includes/incoming-events/class-esp-metadata-settings-updated.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Newspack ESP Metadta Settings Updated Incoming Event class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Esp_Metadata_Sync;
+
+/**
+ * Class to handle the ESP Metadta Settings Updated Event
+ *
+ * This event is always sent from the Hub and received by Nodes.
+ */
+class Esp_Metadata_Settings_Updated extends Abstract_Incoming_Event {
+
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		update_option( Esp_Metadata_Sync::OPTION_NAME, $this->get_data()->value );
+	}
+}

--- a/tests/unit-tests/class-newspack-newsletters.php
+++ b/tests/unit-tests/class-newspack-newsletters.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Mock for the Newspack\Newspack_Newsletters class, present in the newspack plugin
+ *
+ * @package Newspack_Network
+ */
+
+namespace Newspack;
+
+/**
+ * Mock Class for Newspack\Newspack Newsletters
+ */
+class Newspack_Newsletters {
+
+	/**
+	 * Metadata keys map for Reader Activation.
+	 *
+	 * @var array
+	 */
+	public static $metadata_keys = [
+		'field_1' => 'Field 1',
+		'field_2' => 'Field 2',
+		'field_3' => 'Field 3',
+		'field_4' => 'Field 4',
+	];
+
+	/**
+	 * Given a field name, prepend it with the metadata field prefix.
+	 *
+	 * @param string $key Metadata field to fetch.
+	 *
+	 * @return string Prefixed field name.
+	 */
+	public static function get_metadata_key( $key ) {
+		if ( ! isset( self::$metadata_keys[ $key ] ) ) {
+			return false;
+		}
+
+		$prefix = 'NP_';
+		$name   = self::$metadata_keys[ $key ];
+		return $prefix . $name;
+	}
+}

--- a/tests/unit-tests/test-esp-metadata-sync.php
+++ b/tests/unit-tests/test-esp-metadata-sync.php
@@ -1,6 +1,6 @@
-<?php
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing (something about the require_once below breaks the lint)
 /**
- * Class TestEspMetadataSync
+ * Class Test_Esp_Metadata_Sync
  *
  * @package Newspack_Network
  */

--- a/tests/unit-tests/test-esp-metadata-sync.php
+++ b/tests/unit-tests/test-esp-metadata-sync.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Class TestEspMetadataSync
+ *
+ * @package Newspack_Network
+ */
+
+require_once __DIR__ . '/class-newspack-newsletters.php';
+
+use Newspack_Network\Esp_Metadata_Sync;
+use Newspack\Newspack_Newsletters as Newspack_Plugin_Newsletters;
+
+/**
+ * Test the Esp_Metadata_Sync class.
+ */
+class Test_Esp_Metadata_Sync extends WP_UnitTestCase {
+
+	/**
+	 * Gets a sample contact for the tests
+	 *
+	 * @return array
+	 */
+	public function get_sample_contact() {
+		$contact = [];
+		$contact['metadata'] = [
+			'first_name' => 'John',
+			'last_name'  => 'Doe',
+		];
+		foreach ( array_keys( Newspack_Plugin_Newsletters::$metadata_keys ) as $key ) {
+			$contact['metadata'][ Newspack_Plugin_Newsletters::get_metadata_key( $key ) ] = 'value';
+		}
+		return $contact;
+	}
+
+	/**
+	 * Sets the Metadata keys option to the given value
+	 *
+	 * @param array|string $value The value to set the option to.
+	 */
+	public function set_option( $value ) {
+		update_option( Esp_Metadata_Sync::OPTION_NAME, $value );
+	}
+
+
+	/**
+	 * Test the normalize_contact_data method with the default option
+	 */
+	public function test_with_default_option() {
+		$contact = $this->get_sample_contact();
+		$normalized = Esp_Metadata_Sync::normalize_contact_data( $contact );
+		$this->assertSame( $contact, $normalized );
+	}
+
+	/**
+	 * Test the normalize_contact_data method with the option set to empty
+	 */
+	public function test_with_empty_selected() {
+		$contact = $this->get_sample_contact();
+		$this->set_option( [] );
+		$normalized = Esp_Metadata_Sync::normalize_contact_data( $contact );
+		$this->assertSame( $contact, $normalized );
+	}
+
+	/**
+	 * Test the normalize_contact_data method with the option containing only invalid values
+	 */
+	public function test_with_all_invalid_selected() {
+		$contact = $this->get_sample_contact();
+		$this->set_option( [ 'invalid_1', 'invalid_2' ] );
+		$normalized = Esp_Metadata_Sync::normalize_contact_data( $contact );
+		$this->assertSame( $contact, $normalized );
+	}
+
+	/**
+	 * Test the normalize_contact_data method with the option containing only valid values
+	 */
+	public function test_with_all_valid_selected() {
+		$contact = $this->get_sample_contact();
+		$this->set_option( [ 'field_1', 'field_2' ] );
+		$normalized = Esp_Metadata_Sync::normalize_contact_data( $contact );
+		$this->assertArrayHasKey( 'first_name', $normalized['metadata'] );
+		$this->assertArrayHasKey( 'last_name', $normalized['metadata'] );
+		$this->assertArrayHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_1' ), $normalized['metadata'] );
+		$this->assertArrayHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_2' ), $normalized['metadata'] );
+		$this->assertArrayNotHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_3' ), $normalized['metadata'] );
+		$this->assertArrayNotHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_4' ), $normalized['metadata'] );
+	}
+
+	/**
+	 * Test the normalize_contact_data method with the option containing valid and invalid values
+	 */
+	public function test_with_valid_and_invalid_selected() {
+		$contact = $this->get_sample_contact();
+		$this->set_option( [ 'field_1', 'field_2', 'invalid' ] );
+		$normalized = Esp_Metadata_Sync::normalize_contact_data( $contact );
+		$this->assertArrayHasKey( 'first_name', $normalized['metadata'] );
+		$this->assertArrayHasKey( 'last_name', $normalized['metadata'] );
+		$this->assertArrayHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_1' ), $normalized['metadata'] );
+		$this->assertArrayHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_2' ), $normalized['metadata'] );
+		$this->assertArrayNotHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_3' ), $normalized['metadata'] );
+		$this->assertArrayNotHasKey( Newspack_Plugin_Newsletters::get_metadata_key( 'field_4' ), $normalized['metadata'] );
+		$this->assertCount( 4, $normalized['metadata'] );
+	}
+}


### PR DESCRIPTION
This PR adds an option to select which contact metadata fields will be synced to the ESP, by filtering Newspack's method that normalizes the contact.

This is useful for a network because Mailchimp has a very strict limit in the number of contact metadata fields you can have. If each site in the network was to sync every field with a different prefix, this can quickly reach that limit and some sites won't be able to sync their data.

## Testing the option 

* Make sure tests pass
* Checkout https://github.com/Automattic/newspack-plugin/pull/2940
* In the Hub, go to Newspack Network > ESP Metadata Sync settings

![image](https://github.com/Automattic/newspack-network/assets/971483/87d2b9b4-c388-4aa1-8543-4d1faac73275)

* Confirm that when you change the select to "Custom", you see a list of metadata fields to select:

![image](https://github.com/Automattic/newspack-network/assets/971483/09599412-959d-49a5-8b4d-e67d27d78913)

* Make a selection and save changes. Do it a couple of times and make sure the settings persist as expected
* Confirm that you see a  new event in the Event Log for each change to the option

![image](https://github.com/Automattic/newspack-network/assets/971483/f0027a0a-b946-41fe-8fbf-f200a993b059)

* Update a Node and make sure the option was persisted in the node as well:

```
get_option( 'newspack_network_esp_metadata' );
```

## Testing the fields

* In two sites, configure different prefixes in Newspack > Reader Revenue > RAS > Advanced
* Perform some actions that will trigger user sync, for example registration or buying a product
* Confirm in the ESP that only the selected fields were synced

## Copy

Please review all the copy, menu item labels, etc.