### PR TITLE
fix: memberships sync

### DIFF
--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -49,7 +49,7 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 			return;
 		}
 
-		if ( ! class_exists( 'WC_Memberships' ) ) {
+		if ( ! function_exists( 'wc_memberships_get_user_membership' ) || ! function_exists( 'wc_memberships_create_user_membership' ) ) {
 			return;
 		}
 
@@ -76,7 +76,7 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 
 		$user_membership = wc_memberships_get_user_membership( $user->ID, $local_plan_id );
 
-		if ( ! $user_membership ) {
+		if ( null === $user_membership ) {
 			$user_membership = wc_memberships_create_user_membership(
 				[
 					'plan_id' => $local_plan_id,

--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -83,6 +83,10 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 					'user_id' => $user->ID,
 				]
 			);
+
+			update_post_meta( $user_membership->get_id(), Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
+			update_post_meta( $user_membership->get_id(), Memberships_Admin::REMOTE_ID_META_KEY, $this->get_membership_id() );
+			update_post_meta( $user_membership->get_id(), Memberships_Admin::SITE_URL_META_KEY, $this->get_site() );
 		}
 
 		if ( is_wp_error( $user_membership ) ) {
@@ -94,10 +98,6 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 			Debugger::log( 'Error creating membership plan' );
 			return;
 		}
-
-		update_post_meta( $user_membership->get_id(), Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
-		update_post_meta( $user_membership->get_id(), Memberships_Admin::REMOTE_ID_META_KEY, $this->get_membership_id() );
-		update_post_meta( $user_membership->get_id(), Memberships_Admin::SITE_URL_META_KEY, $this->get_site() );
 
 		$user_membership->update_status( $this->get_new_status() );
 		$user_membership->add_note(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the memberships sync (#40). If a membership is created, it means that it already exists on a remote site (it was synced to the site running the sync). 

### How to test the changes in this Pull Request:

This can't actually be tested until memberships backfill (https://github.com/Automattic/newspack-network/pull/62) is in place.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->