### PR TITLE
feat: better security on automatic connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Hub holds an Event Log, where we have the history of all events in all sites
 2. In that site, go to Newspack Network > Site Role and set this site as the Hub
 3. Go to Newspack Network > Nodes and add the nodes that will be part of the network
 4. Note that for each Node, a Secret key is generated. This key will be used to sign requests between Hub and Nodes.
-5. Click the "Link the site" button and then "Save Changes" (on the Node site) to link the sites.
+5. Click the "Link the site" button and then "Connect" (on the Node site) to link the sites.
 
 ## Techinical docs
 

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -27,6 +27,7 @@ class Initializer {
 			Hub\Database\Subscriptions::init();
 			Hub\Database\Orders::init();
 			Hub\Newspack_Ads_GAM::init();
+			Hub\Connect_Node::init();
 		}
 
 		// Allow to access node settings before the site has a role, so it can be set via URL.

--- a/includes/hub/class-connect-node.php
+++ b/includes/hub/class-connect-node.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Newspack Network Utils to automatically link Nodes to the Hub
+ *
+ * @package Newspack_Network
+ */
+
+namespace Newspack_Network\Hub;
+
+use WP_REST_Response;
+use WP_REST_Server;
+/**
+ * Class to handle the automatic connection between Nodes and the Hub
+ */
+class Connect_Node {
+
+	/**
+	 * The option name for the connection nonces
+	 */
+	const NONCES_OPTIONS = 'newspack_network_connection_nonces';
+
+	/**
+	 * Runs the initialization.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+	}
+
+	/**
+	 * Generates a connection nonce for a node
+	 *
+	 * @param int $node_id The node ID.
+	 * @return string
+	 */
+	public static function generate_nonce( $node_id ) {
+		$nonces = get_option( self::NONCES_OPTIONS, [] );
+		$nonces[ $node_id ] = [
+			'nonce' => wp_generate_password( 12, false ),
+			'time'  => time(),
+		];
+		update_option( self::NONCES_OPTIONS, $nonces );
+		return $nonces[ $node_id ]['nonce'];
+	}
+
+	/**
+	 * Checks a nonce for a node
+	 *
+	 * @param int    $node_id The node ID.
+	 * @param string $nonce The nonce.
+	 * @return bool
+	 */
+	public static function check_nonce( $node_id, $nonce ) {
+		$nonces = get_option( self::NONCES_OPTIONS, [] );
+		if ( ! isset( $nonces[ $node_id ] ) ) {
+			return false;
+		}
+		$nonce_data = $nonces[ $node_id ];
+		if ( $nonce_data['nonce'] !== $nonce ) {
+			return false;
+		}
+		if ( time() - $nonce_data['time'] > 60 * 60 ) {
+			return false;
+		}
+		unset( $nonces[ $node_id ] );
+		update_option( self::NONCES_OPTIONS, $nonces );
+		return true;
+	}
+
+	/**
+	 * Register the REST route
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			'newspack-network/v1',
+			'/retrieve-key',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ __CLASS__, 'handle_retrieve_key' ],
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Handle retrieving the key
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_REST_Response
+	 */
+	public static function handle_retrieve_key( $request ) {
+		$site = $request['site'];
+		$nonce = $request['nonce'];
+
+		if ( empty( $site ) ||
+			empty( $nonce )
+		) {
+			return new WP_REST_Response( array( 'error' => 'Bad request.' ), 400 );
+		}
+
+		$node = Nodes::get_node_by_url( $site );
+
+		if ( ! $node ) {
+			return new WP_REST_Response( array( 'error' => 'Bad request. Site not registered in this Hub.' ), 403 );
+		}
+
+		$verified_nonce = self::check_nonce( $node->get_id(), $nonce );
+
+		if ( ! $verified_nonce ) {
+			return new WP_REST_Response( array( 'error' => 'Invalid link.' ), 403 );
+		}
+
+		$response_body = [
+			'secret_key' => $node->get_secret_key(),
+		];
+
+		return new WP_REST_Response( $response_body );
+	}
+}

--- a/includes/hub/class-connect-node.php
+++ b/includes/hub/class-connect-node.php
@@ -95,20 +95,16 @@ class Connect_Node {
 		$site = $request['site'];
 		$nonce = $request['nonce'];
 
-		if ( empty( $site ) ||
-			empty( $nonce )
-		) {
+		if ( empty( $site ) || empty( $nonce ) ) {
 			return new WP_REST_Response( array( 'error' => 'Bad request.' ), 400 );
 		}
 
 		$node = Nodes::get_node_by_url( $site );
-
 		if ( ! $node ) {
 			return new WP_REST_Response( array( 'error' => 'Bad request. Site not registered in this Hub.' ), 403 );
 		}
 
 		$verified_nonce = self::check_nonce( $node->get_id(), $nonce );
-
 		if ( ! $verified_nonce ) {
 			return new WP_REST_Response( array( 'error' => 'Invalid link.' ), 403 );
 		}
@@ -116,7 +112,6 @@ class Connect_Node {
 		$response_body = [
 			'secret_key' => $node->get_secret_key(),
 		];
-
 		return new WP_REST_Response( $response_body );
 	}
 }

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -100,6 +100,22 @@ class Node {
 	}
 
 	/**
+	 * Retrieves the link to connect this Node to the Hub
+	 *
+	 * @return string
+	 */
+	public function get_connect_link() {
+		return add_query_arg(
+			[
+				'page'          => \Newspack_Network\Node\Settings::PAGE_SLUG,
+				'connect_nonce' => Connect_Node::generate_nonce( $this->get_id() ),
+				'action'        => \Newspack_Network\Admin::LINK_ACTION_NAME,
+			],
+			$this->get_url() . '/wp-admin/admin.php'
+		);
+	}
+
+	/**
 	 * Gets a collection of bookmarks for this Node
 	 *
 	 * @return array

--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -188,24 +188,6 @@ class Nodes {
 	}
 
 	/**
-	 * Get linking URL.
-	 *
-	 * @param WP_Post $node_post The node post.
-	 */
-	private static function get_site_link_url( $node_post ) {
-		$node_url   = get_post_meta( $node_post->ID, 'node-url', true );
-		$secret_key = get_post_meta( $node_post->ID, 'secret-key', true );
-		return add_query_arg(
-			[
-				'page'       => \Newspack_Network\Node\Settings::PAGE_SLUG,
-				'secret_key' => $secret_key,
-				'action'     => \Newspack_Network\Admin::LINK_ACTION_NAME,
-			],
-			$node_url . '/wp-admin/admin.php'
-		);
-	}
-
-	/**
 	 * Outputs metabox content
 	 *
 	 * @param WP_Post $post The current post.
@@ -214,12 +196,12 @@ class Nodes {
 	public static function node_details_metabox_content( $post ) {
 		wp_nonce_field( 'newspack_hub_save_node', 'newspack_hub_save_node_nonce' );
 
-		$node_url   = get_post_meta( $post->ID, 'node-url', true );
-		$secret_key = get_post_meta( $post->ID, 'secret-key', true );
+		$node       = new Node( $post );
+		$secret_key = $node->get_secret_key();
 
 		?>
 		<div class="misc-pub-section">
-			Node URL: <input type="text" name="newspack-node-url" value="<?php echo esc_attr( $node_url ); ?>" />
+			Node URL: <input type="text" name="newspack-node-url" value="<?php echo esc_attr( $node->get_url() ); ?>" />
 		</div>
 
 		<?php if ( $secret_key ) : ?>
@@ -230,7 +212,7 @@ class Nodes {
 				<a
 					target="_blank"
 					class="button"
-					href="<?php echo esc_url( self::get_site_link_url( $post ) ); ?>"
+					href="<?php echo esc_url( $node->get_connect_link() ); ?>"
 				>
 					<?php esc_html_e( 'Link the site', 'newspack-network' ); ?>
 				</a>

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Node;
 
 use Newspack_Network\Admin;
 use Newspack_Network\Crypto;
+use WP_Error;
 
 /**
  * Class to handle Node settings page
@@ -255,7 +256,7 @@ class Settings {
 				<?php
 				printf(
 					/* translators: %s is the Hub URL */
-					esc_html__( 'Are you sure you want to connect this site as Node to the Hub in %s?', 'newspack-network' ),
+					esc_html__( 'Are you sure you want to connect this site as Node to the Hub at %s?', 'newspack-network' ),
 					esc_html( $referrer )
 				);
 				?>
@@ -264,7 +265,7 @@ class Settings {
 					<p>
 					<?php
 					printf(
-					/* translators: %s is the Hub URL */
+						/* translators: %s is the Hub URL */
 						esc_html__( 'WARNING: This will reset your current connection to %s.', 'newspack-network' ),
 						esc_html( $existing_hub_url )
 					);
@@ -541,7 +542,7 @@ class Settings {
 			<div class="misc-pub-section">
 				<a
 					class="button"
-					href="<?php echo esc_url( self::get_hub_url() ); ?>/wp-admin/edit.php?post_type=<?php echo esc_attr( \Newspack_Network\Hub\Nodes::POST_TYPE_SLUG ); ?>"
+					href="<?php echo esc_url( wp_unslash( self::get_hub_url() ) ); ?>/wp-admin/edit.php?post_type=<?php echo esc_attr( \Newspack_Network\Hub\Nodes::POST_TYPE_SLUG ); ?>"
 				>
 					<?php esc_html_e( 'Go back to the Hub', 'newspack-network' ); ?>
 				</a>

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -26,15 +26,27 @@ class Settings {
 	const PAGE_SLUG = 'newspack-network-node'; // Same as the main admin page slug, it will become the first menu item.
 
 	/**
+	 * The action name for the link-site functionality nonce.
+	 */
+	const CONNECTION_NONCE_ACTION = 'newspack-network-connect-node';
+
+	/**
+	 * The connection error message.
+	 *
+	 * @var string
+	 */
+	public static $connection_error;
+
+	/**
 	 * Initialize this class and register hooks
 	 *
 	 * @return void
 	 */
 	public static function init() {
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
-		add_action( 'admin_notices', [ __CLASS__, 'linking_interface_notice' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
+		add_action( 'admin_init', [ __CLASS__, 'process_connection_form' ] );
 	}
 
 	/**
@@ -61,7 +73,7 @@ class Settings {
 	 * @return void
 	 */
 	public static function add_menu() {
-		if ( \Newspack_Network\Site_Role::is_node() || self::is_updating_from_url() ) {
+		if ( \Newspack_Network\Site_Role::is_node() || self::is_updating_from_url() || self::is_processing_connection_form() ) {
 			Admin::add_submenu_page( __( 'Node Settings', 'newspack-network' ), self::PAGE_SLUG, [ __CLASS__, 'render' ] );
 		}
 	}
@@ -144,10 +156,6 @@ class Settings {
 	 */
 	public static function hub_url_callback() {
 		$content = get_option( 'newspack_node_hub_url' );
-		$referrer = self::get_referrer();
-		if ( self::is_updating_from_url() && $referrer ) {
-			$content = $referrer;
-		}
 		printf(
 			'<input type="text" name="%1$s" value="%2$s">',
 			'newspack_node_hub_url',
@@ -162,10 +170,6 @@ class Settings {
 	 */
 	public static function secret_key_callback() {
 		$content = get_option( 'newspack_node_secret_key' );
-		$secret_key = self::get_secret_key_from_url();
-		if ( self::is_updating_from_url() && $secret_key ) {
-			$content = $secret_key;
-		}
 		printf(
 			'<input type="text" name="%1$s" value="%2$s">',
 			'newspack_node_secret_key',
@@ -217,13 +221,6 @@ class Settings {
 	}
 
 	/**
-	 * Get secret key from URL.
-	 */
-	private static function get_secret_key_from_url() {
-		return filter_input( INPUT_GET, 'secret_key', FILTER_SANITIZE_SPECIAL_CHARS );
-	}
-
-	/**
 	 * Get referrer.
 	 */
 	private static function get_referrer() {
@@ -234,50 +231,50 @@ class Settings {
 	 * Render linking receiving interface.
 	 */
 	public static function linking_interface_notice() {
-		if ( ! self::is_updating_from_url() ) {
-			return;
-		}
 		$referrer = self::get_referrer();
-		if ( isset( $_REQUEST['settings-updated'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			// Remove the params from URL - settings were just saved.
-			if ( $referrer ) {
-				if ( ! \Newspack_Network\Site_Role::get() ) {
-					\Newspack_Network\Site_Role::set_as_node();
-				}
-				$referrer = remove_query_arg( [ 'secret_key', 'action' ], $referrer );
-				wp_safe_redirect( $referrer );
-				exit;
-			}
+
+		if ( ! $referrer ) {
 			return;
 		}
-		$secret_key = self::get_secret_key_from_url();
-		if ( ! $secret_key || ! $referrer ) {
-			return;
-		}
+
+		$existing_hub_url    = self::get_hub_url();
 		$existing_secret_key = self::get_secret_key();
-		$hub_url = self::get_hub_url();
-		if ( $existing_secret_key === $secret_key && $referrer === $hub_url ) {
-			?>
-			<div id="message" class="updated notice is-dismissible">
-				<p><?php esc_html_e( 'This site is already linked to this Hub.', 'newspack-network' ); ?></p>
-			</div>
-			<?php
-			return;
-		}
+		$form_action         = add_query_arg( 'page', self::PAGE_SLUG, admin_url( 'admin.php' ) );
+		$connect_nonce       = filter_input( INPUT_GET, 'connect_nonce', FILTER_SANITIZE_SPECIAL_CHARS );
+
 		?>
 		<div id="message" class="notice">
-			<h2>
-				<?php esc_html_e( 'Link this site to the Hub', 'newspack-network' ); ?>
-			</h2>
-			<p>
-			<?php
-			printf(
-				/* translators: %s is the Hub URL */
-				esc_html__( 'Click "Save Changes" below to link this site to the hub at %s.', 'newspack-network' ),
-				esc_html( $referrer )
-			);
-			?>
-			</p>
+			<form method="POST" action="<?php echo esc_url( $form_action ); ?>">
+				<input type="hidden" name="newspack_node_hub_url" value="<?php echo esc_attr( $referrer ); ?>">
+				<input type="hidden" name="connection_nonce" value="<?php echo esc_attr( $connect_nonce ); ?>">
+				<?php wp_nonce_field( self::CONNECTION_NONCE_ACTION ); ?>
+				<h2>
+					<?php esc_html_e( 'Link this site to the Hub', 'newspack-network' ); ?>
+				</h2>
+				<p>
+				<?php
+				printf(
+					/* translators: %s is the Hub URL */
+					esc_html__( 'Are you sure you want to connect this site as Node to the Hub in %s?', 'newspack-network' ),
+					esc_html( $referrer )
+				);
+				?>
+				</p>
+				<?php if ( $existing_hub_url && $existing_secret_key ) : ?>
+					<p>
+					<?php
+					printf(
+					/* translators: %s is the Hub URL */
+						esc_html__( 'WARNING: This will reset your current connection to %s.', 'newspack-network' ),
+						esc_html( $existing_hub_url )
+					);
+					?>
+				</p>
+				<?php endif; ?>
+				<p class='submit'>
+					<input name='submit' type='submit' id='submit' class='button-primary' value='<?php _e( 'Connect!' ); ?>' />
+				</p>
+			</form>
 		</div>
 		<?php
 	}
@@ -288,6 +285,10 @@ class Settings {
 	 * @return void
 	 */
 	public static function render() {
+		if ( self::is_updating_from_url() ) {
+			self::linking_interface_notice();
+			return;
+		}
 		?>
 		<div class='wrap'>
 			<?php settings_errors(); ?>
@@ -448,5 +449,118 @@ class Settings {
 	public static function is_updating_from_url() {
 		$action = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_SPECIAL_CHARS );
 		return $action === Admin::LINK_ACTION_NAME;
+	}
+
+	/**
+	 * Checks if we are currently processing the connection form
+	 */
+	public static function is_processing_connection_form() {
+		return ! empty( $_POST['connection_nonce'] ) && ! empty( $_POST['newspack_node_hub_url'] ); // phpcs:ignore
+	}
+
+	/**
+	 * Process the connection form
+	 */
+	public static function process_connection_form() {
+		if ( empty( $_POST['connection_nonce'] ) || empty( $_POST['newspack_node_hub_url'] ) ) {
+			return;
+		}
+
+		if ( ! check_admin_referer( self::CONNECTION_NONCE_ACTION ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$hub_url = sanitize_text_field( $_POST['newspack_node_hub_url'] );
+		$nonce = sanitize_text_field( $_POST['connection_nonce'] );
+
+		$secret_key = self::request_secret_key( $hub_url, $nonce );
+
+		if ( is_wp_error( $secret_key ) ) {
+			self::$connection_error = $secret_key->get_error_message();
+			add_action( 'admin_notices', [ __CLASS__, 'notice_connection_error' ] );
+			return;
+		}
+
+		\Newspack_Network\Site_Role::set_as_node();
+		update_option( 'newspack_node_hub_url', $hub_url );
+		update_option( 'newspack_node_secret_key', $secret_key );
+
+		add_action( 'admin_notices', [ __CLASS__, 'notice_connection_success' ] );
+	}
+
+	/**
+	 * Requests the secret key from the Hub
+	 *
+	 * @param string $hub_url The Hub URL.
+	 * @param string $nonce The connection nonce.
+	 * @return string|\WP_Error
+	 */
+	private static function request_secret_key( $hub_url, $nonce ) {
+		$url      = trailingslashit( $hub_url ) . 'wp-json/newspack-network/v1/retrieve-key';
+		$params   = [
+			'site'  => get_bloginfo( 'url' ),
+			'nonce' => $nonce,
+		];
+
+		$response = wp_remote_post(
+			$url,
+			[
+				'body' => $params,
+			]
+		);
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$response_code = wp_remote_retrieve_response_code( $response );
+		$response_body = wp_remote_retrieve_body( $response );
+		if ( 200 !== $response_code ) {
+			$error_message = __( 'Error connecting to the Hub', 'newspack-network' );
+			if ( $response_body ) {
+				$error_message .= ': ' . $response_body;
+			}
+			return new \WP_Error( 'newspack-network-node-connect-error', $error_message );
+		}
+
+		$body = json_decode( $response_body, true );
+		return $body['secret_key'] ?? new \WP_Error( 'newspack-network-node-connect-error', __( 'Invalid response from the Hub', 'newspack-network' ) );
+	}
+
+	/**
+	 * Displays a success notice
+	 *
+	 * @return void
+	 */
+	public static function notice_connection_success() {
+		?>
+			<div class="notice notice-success is-dismissible">
+			<p><?php esc_html_e( 'Site connected!', 'newspack-network' ); ?></p>
+			<div class="misc-pub-section">
+				<a
+					class="button"
+					href="<?php echo esc_url( self::get_hub_url() ); ?>/wp-admin/edit.php?post_type=<?php echo esc_attr( \Newspack_Network\Hub\Nodes::POST_TYPE_SLUG ); ?>"
+				>
+					<?php esc_html_e( 'Go back to the Hub', 'newspack-network' ); ?>
+				</a>
+			</div>
+			</div>
+		<?php
+	}
+
+	/**
+	 * Displays a success notice
+	 *
+	 * @return void
+	 */
+	public static function notice_connection_error() {
+		?>
+			<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'Error connecting the site', 'newspack-network' ); ?></p>
+			<p><?php echo esc_html( self::$connection_error ); ?></p>
+			</div>
+		<?php
 	}
 }


### PR DESCRIPTION
Refactors the connection link and makes the Node request the secret key from the Hub using a (real one time) nonce.

## Testing

Same as https://github.com/Automattic/newspack-network/pull/58. Follow the flow and confirm it works.

Edit `request_secret_key` method and force it to return a WP_Error so you can test the error notice on the UI

Check that the button to "Go back to Hub" works.

Check copy