### PR TITLE
CLI: sync all events from the Hub

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -43,6 +43,7 @@ class Initializer {
 		User_Update_Watcher::init();
 		User_Manual_Sync::init();
 		Distributor_Customizations::init();
+		Synchronize_All::init();
 
 		Woocommerce_Memberships\Admin::init();
 		Woocommerce_Memberships\Events::init();

--- a/includes/cli/class-synchronize-all.php
+++ b/includes/cli/class-synchronize-all.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Data Backfill scripts.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+use WP_CLI;
+
+/**
+ * Data Backfill class.
+ */
+class Synchronize_All {
+	/**
+	 * Number of events left to fetch.
+	 *
+	 * @var int
+	 */
+	private static $events_left = 0;
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_commands' ] );
+	}
+
+	/**
+	 * Register the WP-CLI commands
+	 *
+	 * @return void
+	 */
+	public static function register_commands() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'newspack-network sync-all', [ __CLASS__, 'sync_all' ] );
+		}
+	}
+
+	/**
+	 * Get events from the Hub.
+	 */
+	private static function get_events() {
+		$response = \Newspack_Network\Node\Pulling::make_request();
+		if ( is_wp_error( $response ) ) {
+			WP_CLI::error( 'Error fetching events from the Hub: ' . $response->get_error_message() );
+		}
+		$response = json_decode( $response, true );
+		if ( ! isset( $response['data'] ) ) {
+			WP_CLI::error( 'Missing data in response.' );
+		}
+
+		WP_CLI::line( 'Received ' . count( $response['data'] ) . ' events, processing…' );
+
+		\Newspack_Network\Node\Pulling::process_pulled_data( $response['data'] );
+
+		self::$events_left = $response['more_items_count'];
+		WP_CLI::line( 'Events left to fetch: ' . self::$events_left );
+
+		if ( self::$events_left > 0 ) {
+			self::get_events();
+		}
+	}
+
+	/**
+	 * Sync all data.
+	 */
+	public static function sync_all() {
+		WP_CLI::line( '' );
+		if ( ! Site_Role::is_node() ) {
+			WP_CLI::error( 'This command can only be run on a Node site.' );
+		}
+		self::get_events();
+	}
+}

--- a/includes/cli/class-synchronize-all.php
+++ b/includes/cli/class-synchronize-all.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Data Backfill scripts.
+ * Sync all scripts.
  *
  * @package Newspack
  */
@@ -8,11 +8,13 @@
 namespace Newspack_Network;
 
 use WP_CLI;
+use Newspack_Network\Node\Pulling;
 
 /**
- * Data Backfill class.
+ * Sync all class.
  */
 class Synchronize_All {
+
 	/**
 	 * Number of events left to fetch.
 	 *
@@ -41,10 +43,32 @@ class Synchronize_All {
 	}
 
 	/**
-	 * Get events from the Hub.
+	 * Process events received from the Hub.
 	 */
-	private static function get_events() {
-		$response = \Newspack_Network\Node\Pulling::make_request();
+	private static function process_events() {
+		$response = self::make_request();
+		WP_CLI::line( 'Received ' . count( $response['data'] ) . ' events, processing…' );
+
+		Pulling::process_pulled_data( $response['data'] );
+
+		self::$events_left = (int) $response['total'] - count( $response['data'] );
+		if ( 0 > self::$events_left ) {
+			self::$events_left = 0;
+		}
+		WP_CLI::line( 'Events left to fetch: ' . self::$events_left );
+
+		if ( self::$events_left > 0 ) {
+			self::process_events();
+		}
+	}
+
+	/**
+	 * Makes a request to pull events from the Hub
+	 *
+	 * @return array
+	 */
+	private static function make_request() {
+		$response = Pulling::make_request();
 		if ( is_wp_error( $response ) ) {
 			WP_CLI::error( 'Error fetching events from the Hub: ' . $response->get_error_message() );
 		}
@@ -52,27 +76,42 @@ class Synchronize_All {
 		if ( ! isset( $response['data'] ) ) {
 			WP_CLI::error( 'Missing data in response.' );
 		}
-
-		WP_CLI::line( 'Received ' . count( $response['data'] ) . ' events, processing…' );
-
-		\Newspack_Network\Node\Pulling::process_pulled_data( $response['data'] );
-
-		self::$events_left = $response['more_items_count'];
-		WP_CLI::line( 'Events left to fetch: ' . self::$events_left );
-
-		if ( self::$events_left > 0 ) {
-			self::get_events();
-		}
+		return $response;
 	}
 
 	/**
-	 * Sync all data.
+	 * Syncs all data, pulling all events from the Hub.
 	 */
 	public static function sync_all() {
 		WP_CLI::line( '' );
 		if ( ! Site_Role::is_node() ) {
 			WP_CLI::error( 'This command can only be run on a Node site.' );
 		}
-		self::get_events();
+		self::print_sync_status();
+		WP_CLI::line( '' );
+		WP_CLI::line( 'Pulling all data from the Hub will write data to this site. This will proceed incrementally, so the process can be picked up later.' );
+		WP_CLI::line( '' );
+		WP_CLI::confirm( 'Are we good to go?' );
+		WP_CLI::line( '' );
+		self::process_events();
+		WP_CLI::success( 'Sync complete.' );
+	}
+
+	/**
+	 * Print the current status of the sync
+	 */
+	public static function print_sync_status() {
+		WP_CLI::line( 'Checking the sync queue…' );
+
+		$response = self::make_request();
+		$events_on_the_hub = (int) $response['total'];
+		$last_processed_id = Pulling::get_last_processed_id();
+
+		WP_CLI::line( 'Last processed event ID: ' . $last_processed_id );
+		if ( $events_on_the_hub === 0 ) {
+			WP_CLI::success( 'Sync is up to date. Nothing to pull.' );
+		} else {
+			WP_CLI::line( 'Events left to sync: ' . ( $events_on_the_hub ) );
+		}
 	}
 }

--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -101,7 +101,7 @@ class Pull_Endpoint {
 
 		Debugger::log( count( $events ) . ' events found' );
 
-		$response_body = array_map(
+		$events_formatted = array_map(
 			function( $event ) {
 				return [
 					'id'        => $event->get_id(),
@@ -113,7 +113,11 @@ class Pull_Endpoint {
 			},
 			$events
 		);
-
+		$highest_returned_id = empty( $events_formatted ) ? 0 : max( array_column( $events_formatted, 'id' ) );
+		$response_body = [
+			'data'             => $events_formatted,
+			'more_items_count' => Event_Log::get_events_count_between( $highest_returned_id ),
+		];
 		return new WP_REST_Response( $response_body );
 	}
 }

--- a/includes/hub/stores/class-event-log.php
+++ b/includes/hub/stores/class-event-log.php
@@ -96,22 +96,6 @@ class Event_Log {
 	}
 
 	/**
-	 * Get count of items between the given event ID and the latest event.
-	 *
-	 * @param int $event_id The event ID to start from.
-	 * @return int
-	 */
-	public static function get_events_count_between( $event_id ) {
-		if ( $event_id === 0 ) {
-			return 0;
-		}
-		global $wpdb;
-		$table_name = Database::get_table_name();
-		$query = $wpdb->prepare( "SELECT COUNT(*) FROM $table_name WHERE id > %d", $event_id ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $wpdb->get_var( $query ); //phpcs:ignore
-	}
-
-	/**
 	 * Build the WHERE clause for the query
 	 *
 	 * @param array $args {

--- a/includes/hub/stores/class-event-log.php
+++ b/includes/hub/stores/class-event-log.php
@@ -86,13 +86,29 @@ class Event_Log {
 	 * @param array $args See {@see self::build_where_clause()} for supported arguments.
 	 * @return int
 	 */
-	public static function get_total_items( $args ) {
+	public static function get_total_items( $args = [] ) {
 		global $wpdb;
 		$table_name = Database::get_table_name();
 		$query      = "SELECT COUNT(*) FROM $table_name WHERE 1=1 [args]";
 		$query      = str_replace( '[args]', self::build_where_clause( $args ), $query );
 		$result     = $wpdb->get_var( $query ); //phpcs:ignore
 		return $result;
+	}
+
+	/**
+	 * Get count of items between the given event ID and the latest event.
+	 *
+	 * @param int $event_id The event ID to start from.
+	 * @return int
+	 */
+	public static function get_events_count_between( $event_id ) {
+		if ( $event_id === 0 ) {
+			return 0;
+		}
+		global $wpdb;
+		$table_name = Database::get_table_name();
+		$query = $wpdb->prepare( "SELECT COUNT(*) FROM $table_name WHERE id > %d", $event_id ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return $wpdb->get_var( $query ); //phpcs:ignore
 	}
 
 	/**

--- a/includes/node/class-pulling.php
+++ b/includes/node/class-pulling.php
@@ -227,11 +227,11 @@ class Pulling {
 			update_option( self::LAST_ERROR_OPTION_NAME, '' );
 		}
 		$response = json_decode( $response, true );
-		if ( ! is_array( $response ) ) {
+		if ( ! is_array( $response['data'] ) ) {
 			return;
 		}
 
-		foreach ( $response as $event ) {
+		foreach ( $response['data'] as $event ) {
 			$action    = $event['action'] ?? false;
 			$site      = $event['site'] ?? false;
 			$data      = $event['data'] ?? false;

--- a/includes/node/class-pulling.php
+++ b/includes/node/class-pulling.php
@@ -211,27 +211,12 @@ class Pulling {
 	}
 
 	/**
-	 * Pulls data from the Hub and processes it
+	 * Process pulled data.
 	 *
-	 * @return void
+	 * @param array $events The events to process.
 	 */
-	public static function pull() {
-		Debugger::log( 'Pulling data' );
-		$response = self::make_request();
-		Debugger::log( 'Pulled data response:' );
-		Debugger::log( $response );
-		if ( is_wp_error( $response ) ) {
-			self::handle_error( $response );
-			return;
-		} else {
-			update_option( self::LAST_ERROR_OPTION_NAME, '' );
-		}
-		$response = json_decode( $response, true );
-		if ( ! is_array( $response['data'] ) ) {
-			return;
-		}
-
-		foreach ( $response['data'] as $event ) {
+	public static function process_pulled_data( $events ) {
+		foreach ( $events as $event ) {
 			$action    = $event['action'] ?? false;
 			$site      = $event['site'] ?? false;
 			$data      = $event['data'] ?? false;
@@ -254,5 +239,28 @@ class Pulling {
 
 			self::set_last_processed_id( $id );
 		}
+	}
+
+	/**
+	 * Pulls data from the Hub and processes it
+	 *
+	 * @return void
+	 */
+	public static function pull() {
+		Debugger::log( 'Pulling data' );
+		$response = self::make_request();
+		Debugger::log( 'Pulled data response:' );
+		Debugger::log( $response );
+		if ( is_wp_error( $response ) ) {
+			self::handle_error( $response );
+			return;
+		} else {
+			update_option( self::LAST_ERROR_OPTION_NAME, '' );
+		}
+		$response = json_decode( $response, true );
+		if ( ! is_array( $response['data'] ) ) {
+			return;
+		}
+		self::process_pulled_data( $response['data'] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The "Synchronize data" button in Node Settings will only sync 20 (by default) events from Hub's event log. If there are more missing events for any reason, there's no way to do a full sync currently. This PR adds a CLI command to sync all remaining events. 

See 1206331646877121-as-1206636623422189/f

### How to test the changes in this Pull Request:

1. Set `NEWSPACK_NETWORK_EVENTS_PULL_LIMIT` environment variable (on the Hub site) to `2`, so the batching of events is more easily visible
2. Deactivate this plugin on the Node site, so it won't fetch events for the moment
3. Register three or more users on the Hub site
4. Activate this plugin on the Node site and run `wp newspack-network sync-all` and observe in the output that events are processed in batches of 2
5. Verify on the Node site that the events have been processed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->