### PR TITLE
feat: sync all and sync check commands

### DIFF
--- a/includes/cli/class-synchronize-all.php
+++ b/includes/cli/class-synchronize-all.php
@@ -39,7 +39,6 @@ class Synchronize_All {
 	public static function register_commands() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'newspack-network sync-all', [ __CLASS__, 'sync_all' ] );
-			WP_CLI::add_command( 'newspack-network sync-check', [ __CLASS__, 'sync_check' ] );
 		}
 	}
 
@@ -47,7 +46,6 @@ class Synchronize_All {
 	 * Process events received from the Hub.
 	 */
 	private static function process_events() {
-
 		$response = self::make_request();
 		WP_CLI::line( 'Received ' . count( $response['data'] ) . ' events, processing…' );
 
@@ -62,7 +60,6 @@ class Synchronize_All {
 		if ( self::$events_left > 0 ) {
 			self::process_events();
 		}
-		WP_CLI::success( 'Sync complete.' );
 	}
 
 	/**
@@ -90,21 +87,21 @@ class Synchronize_All {
 		if ( ! Site_Role::is_node() ) {
 			WP_CLI::error( 'This command can only be run on a Node site.' );
 		}
-		WP_CLI::line( 'Syncing all data from the Hub can take a long time and will write data to the site.' );
-		WP_CLI::line( 'Consider running wp newspack-network sync-check first to check the size of the queue.' );
-		WP_CLI::confirm( 'Are you sure you want to sync all data?' );
+		self::print_sync_status();
+		WP_CLI::line( '' );
+		WP_CLI::line( 'Pulling all data from the Hub will write data to this site. This will proceed incrementally, so the process can be picked up later.' );
+		WP_CLI::line( '' );
+		WP_CLI::confirm( 'Are we good to go?' );
+		WP_CLI::line( '' );
 		self::process_events();
+		WP_CLI::success( 'Sync complete.' );
 	}
 
 	/**
-	 * Checks the current state of the sync
+	 * Print the current status of the sync
 	 */
-	public static function sync_check() {
-		WP_CLI::line( '' );
-		if ( ! Site_Role::is_node() ) {
-			WP_CLI::error( 'This command can only be run on a Node site.' );
-		}
-		WP_CLI::line( 'Checking the sync queue' );
+	public static function print_sync_status() {
+		WP_CLI::line( 'Checking the sync queue…' );
 
 		$response = self::make_request();
 		$events_on_the_hub = (int) $response['total'];

--- a/includes/cli/class-synchronize-all.php
+++ b/includes/cli/class-synchronize-all.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Data Backfill scripts.
+ * Sync all scripts.
  *
  * @package Newspack
  */
@@ -8,11 +8,13 @@
 namespace Newspack_Network;
 
 use WP_CLI;
+use Newspack_Network\Node\Pulling;
 
 /**
- * Data Backfill class.
+ * Sync all class.
  */
 class Synchronize_All {
+
 	/**
 	 * Number of events left to fetch.
 	 *
@@ -37,14 +39,39 @@ class Synchronize_All {
 	public static function register_commands() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'newspack-network sync-all', [ __CLASS__, 'sync_all' ] );
+			WP_CLI::add_command( 'newspack-network sync-check', [ __CLASS__, 'sync_check' ] );
 		}
 	}
 
 	/**
-	 * Get events from the Hub.
+	 * Process events received from the Hub.
 	 */
-	private static function get_events() {
-		$response = \Newspack_Network\Node\Pulling::make_request();
+	private static function process_events() {
+
+		$response = self::make_request();
+		WP_CLI::line( 'Received ' . count( $response['data'] ) . ' events, processing…' );
+
+		Pulling::process_pulled_data( $response['data'] );
+
+		self::$events_left = (int) $response['total'] - \Newspack_Network\Hub\Pull_Endpoint::get_pull_limit();
+		if ( 0 > self::$events_left ) {
+			self::$events_left = 0;
+		}
+		WP_CLI::line( 'Events left to fetch: ' . self::$events_left );
+
+		if ( self::$events_left > 0 ) {
+			self::process_events();
+		}
+		WP_CLI::success( 'Sync complete.' );
+	}
+
+	/**
+	 * Makes a request to pull events from the Hub
+	 *
+	 * @return array
+	 */
+	private static function make_request() {
+		$response = Pulling::make_request();
 		if ( is_wp_error( $response ) ) {
 			WP_CLI::error( 'Error fetching events from the Hub: ' . $response->get_error_message() );
 		}
@@ -52,27 +79,42 @@ class Synchronize_All {
 		if ( ! isset( $response['data'] ) ) {
 			WP_CLI::error( 'Missing data in response.' );
 		}
-
-		WP_CLI::line( 'Received ' . count( $response['data'] ) . ' events, processing…' );
-
-		\Newspack_Network\Node\Pulling::process_pulled_data( $response['data'] );
-
-		self::$events_left = $response['more_items_count'];
-		WP_CLI::line( 'Events left to fetch: ' . self::$events_left );
-
-		if ( self::$events_left > 0 ) {
-			self::get_events();
-		}
+		return $response;
 	}
 
 	/**
-	 * Sync all data.
+	 * Syncs all data, pulling all events from the Hub.
 	 */
 	public static function sync_all() {
 		WP_CLI::line( '' );
 		if ( ! Site_Role::is_node() ) {
 			WP_CLI::error( 'This command can only be run on a Node site.' );
 		}
-		self::get_events();
+		WP_CLI::line( 'Syncing all data from the Hub can take a long time and will write data to the site.' );
+		WP_CLI::line( 'Consider running wp newspack-network sync-check first to check the size of the queue.' );
+		WP_CLI::confirm( 'Are you sure you want to sync all data?' );
+		self::process_events();
+	}
+
+	/**
+	 * Checks the current state of the sync
+	 */
+	public static function sync_check() {
+		WP_CLI::line( '' );
+		if ( ! Site_Role::is_node() ) {
+			WP_CLI::error( 'This command can only be run on a Node site.' );
+		}
+		WP_CLI::line( 'Checking the sync queue' );
+
+		$response = self::make_request();
+		$events_on_the_hub = (int) $response['total'];
+		$last_processed_id = Pulling::get_last_processed_id();
+
+		WP_CLI::line( 'Last processed event ID: ' . $last_processed_id );
+		if ( $events_on_the_hub === 0 ) {
+			WP_CLI::success( 'Sync is up to date. Nothing to pull.' );
+		} else {
+			WP_CLI::line( 'Events left to sync: ' . ( $events_on_the_hub ) );
+		}
 	}
 }

--- a/includes/cli/class-synchronize-all.php
+++ b/includes/cli/class-synchronize-all.php
@@ -51,7 +51,7 @@ class Synchronize_All {
 
 		Pulling::process_pulled_data( $response['data'] );
 
-		self::$events_left = (int) $response['total'] - \Newspack_Network\Hub\Pull_Endpoint::get_pull_limit();
+		self::$events_left = (int) $response['total'] - count( $response['data'] );
 		if ( 0 > self::$events_left ) {
 			self::$events_left = 0;
 		}

--- a/includes/hub/stores/class-event-log.php
+++ b/includes/hub/stores/class-event-log.php
@@ -96,22 +96,6 @@ class Event_Log {
 	}
 
 	/**
-	 * Get count of items between the given event ID and the latest event.
-	 *
-	 * @param int $event_id The event ID to start from.
-	 * @return int
-	 */
-	public static function get_events_count_between( $event_id ) {
-		if ( $event_id === 0 ) {
-			return 0;
-		}
-		global $wpdb;
-		$table_name = Database::get_table_name();
-		$query = $wpdb->prepare( "SELECT COUNT(*) FROM $table_name WHERE id > %d", $event_id ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return $wpdb->get_var( $query ); //phpcs:ignore
-	}
-
-	/**
 	 * Build the WHERE clause for the query
 	 *
 	 * @param array $args {


### PR DESCRIPTION
This is a review for https://github.com/Automattic/newspack-network/pull/65

The logic to calculate how many events are left needs to take into account the whole query.

A Node can be 1000 events behind from what's on the Hub, but that not necessarily means that there are still 1000 events to process.

From those 1000 events, 200 can be events from the Node itself, that there's no need to pull. Also, there are some events that Nodes don't pull, like Woo Orders and Subscriptions updates.

I added a second command to check the sync to make it easier to test. I think it's useful