### PR TITLE
feat(node): added wp cli command - process pending requests

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -104,6 +104,8 @@ Available CLI commands are (add `--help` flag to learn more about each command):
 
 ### `wp np-network process`
 * Will process `pending` `np_webhook_request`s and delete after processing.
+* `--per-page=1000` to process x amount of requests. Default is `-1`.
+* `--status='killed'` to process requests of a different status. Default is `'pending'`
 * `--dry-run` enabled. Will run through process without deleting.
 * `--yes` enabled. Will bypass confirmations.
 

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -98,6 +98,14 @@ Depending on what you want to do with the event, and where, implement these 2 me
 
 If you want to customize how this new event looks in the `Event Log`, go to `hub/stores/event-log-items` and create a new class named after the class you informed in `ACCEPTED_ACTIONS`. Implement the `get_summary` method to display the information the way you need.
 
+## WP CLI
+
+Available CLI commands are (add `--help` flag to learn more about each command):
+
+### `wp np-network process`
+* Will process `pending` `np_webhook_request`s and delete after processing.
+* `--dry-run` enabled. Will run through process without deleting.
+* `--yes` enabled. Will bypass confirmations.
 
 ## Troubleshooting
 
@@ -132,3 +140,4 @@ Pulls are scheduled in CRON for every 5 minutes. If you want to trigger a pull n
 In the Node's log you will see detailed information about the pull attempt, starting with a `Pulling data` message.
 
 In the Hub's log, you will also see detailed information about the pull request, starting with a `Pull request received` message.
+

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -140,4 +140,3 @@ Pulls are scheduled in CRON for every 5 minutes. If you want to trigger a pull n
 In the Node's log you will see detailed information about the pull attempt, starting with a `Pulling data` message.
 
 In the Hub's log, you will also see detailed information about the pull request, starting with a `Pull request received` message.
-

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -113,7 +113,7 @@ If you want to customize how this new event looks in the `Event Log`, go to `hub
 
 Available CLI commands are (add `--help` flag to learn more about each command):
 
-### `wp np-network process`
+### `wp newspack-network process-webhooks`
 * Will process `pending` `np_webhook_request`s and delete after processing.
 * `--per-page=1000` to process x amount of requests. Default is `-1`.
 * `--status='killed'` to process requests of a different status. Default is `'pending'`

--- a/includes/node/class-webhook.php
+++ b/includes/node/class-webhook.php
@@ -116,6 +116,7 @@ class Webhook {
 	 * 
 	 * @param array $args Indexed array of args.
 	 * @param array $assoc_args Associative array of args.
+	 * @return void
 	 *
 	 * ## OPTIONS
 	 *

--- a/includes/node/class-webhook.php
+++ b/includes/node/class-webhook.php
@@ -7,6 +7,9 @@
 
 namespace Newspack_Network\Node;
 
+use WP_CLI;
+use WP_CLI\Utils as WP_CLI_Utils;
+
 use Newspack_Network\Accepted_Actions;
 use Newspack_Network\Crypto;
 use Newspack\Data_Events\Webhooks as Newspack_Webhooks;
@@ -38,6 +41,9 @@ class Webhook {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_endpoint' ] );
 		add_filter( 'newspack_webhooks_request_body', [ __CLASS__, 'filter_webhook_body' ], 10, 2 );
+		if(defined('WP_CLI') && WP_CLI){
+			WP_CLI::add_command('np-network process', [__CLASS__, 'cli_process']);
+		}
 	}
 
 	/**
@@ -107,4 +113,94 @@ class Webhook {
 
 	}
 
+	/**
+     * Process network requests
+     *
+     * ## OPTIONS
+     *
+     * [--per-page=<number>]
+     * : How many requests to process.
+     * ---
+     * default: -1
+     * ---
+     *
+     * [--status=<string>]
+     * : Filters requests to process by status.
+     * ---
+     * default: 'pending'
+     * ---
+     *
+     * [--dry-run]
+     * : Run the command in dry run mode. No requests (with status killed) will be processed.
+     * 
+     * [--yes]
+     * : Run the command without confirmations, use with caution.
+     *
+     * ## EXAMPLES
+     *
+     *     wp np-network process
+     *     wp np-network process --per-page=200
+	 *     wp np-network process --per-page=200 --status='killed' --dry-run
+     *     wp np-network process --per-page=200 --status='killed' --dry-run --yes
+     * 
+     * @when after_wp_load
+     */
+    public function cli_process(array $args, array $assoc_args): void
+    {
+        $per_page = (int) ($assoc_args['per-page'] ?? -1);
+        $dry_run = isset($assoc_args['dry-run']);
+        $status = $assoc_args['status'] ?? 'pending';
+
+		// Only process pending requests
+		$requests = array_filter(
+			Newspack_Webhooks::get_endpoint_requests(static::ENDPOINT_ID, $per_page),
+			fn ($r) => $r['status'] === $status
+		);
+        usort(
+            $requests,
+            // OrderBy: id, Order: ASC
+            fn ($a, $b) => $a['id'] <=> $b['id']
+        );
+
+        if (empty($requests)) {
+            WP_CLI::error("No '{$status}' requests exist, exiting!");
+        }
+
+        $request_ids = array_column($requests, 'id');
+        $requests_count = count($requests);
+        $processed_count = 0;
+        $unprocessed_request_ids = [];
+
+        if ($dry_run) {
+            WP_CLI::log("==== DRY - RUN ====");
+        } else {
+            WP_CLI::confirm("Confirm processing of {$requests_count} requests?", $assoc_args);
+        }
+
+        $progress = WP_CLI_Utils\make_progress_bar('Processing requests', $requests_count);
+
+        foreach ($request_ids as $k => $request_id) {
+            if (!$dry_run) {
+                Newspack_Webhooks::process_request($request_id);
+                if ('finished' !== get_post_meta($request_id, 'status', true)) {
+                    array_push($unprocessed_request_ids, $request_id);
+                    continue;
+                }
+                // Cleanup processed requests
+                $deleted = wp_delete_post($request_id, true);
+                if (false === $deleted || null === $deleted) {
+                    WP_CLI::warning("There was an error deleting {$request_id}!");
+                }
+            }
+            ++$processed_count;
+            $progress->tick();
+        }
+
+        $progress->finish();
+
+        if (!empty($unprocessed_request_ids)) {
+            WP_CLI::warning("The following requests could not be deleted:\n" . json_encode($unprocessed_request_ids));
+        }
+        WP_CLI::success("Successfully processed {$processed_count}/{$requests_count} pending requests.");
+    }
 }

--- a/includes/node/class-webhook.php
+++ b/includes/node/class-webhook.php
@@ -165,7 +165,7 @@ class Webhook {
 			fn ( $a, $b ) => $a['id'] <=> $b['id']
 		);
 
-		// No requests, bail
+		// No requests, bail.
 		if ( empty( $requests ) ) {
 			WP_CLI::error( "No '{$status}' requests exist, exiting!" );
 		}
@@ -192,11 +192,11 @@ class Webhook {
 			if ( ! $dry_run ) {
 				Newspack_Webhooks::process_request( $request_id );
 				if ( 'finished' !== get_post_meta( $request_id, 'status', true ) ) {
-					$errors[$request_id] = "<unknown_error>";
-					// Get last stored error
+					$errors[ $request_id ] = '<unknown_error>';
+					// Get last stored error.
 					$request_errors = get_post_meta( $request_id, 'errors', true );
-					if ((array) $request_errors === $request_errors) {
-						$errors[$request_id] = end($request_errors);
+					if ( (array) $request_errors === $request_errors ) {
+						$errors[ $request_id ] = end( $request_errors );
 					}
 					++$counts['failed'];
 					continue;
@@ -212,20 +212,20 @@ class Webhook {
 		}
 
 		$progress->finish();
-		WP_CLI::log("");
+		WP_CLI::log( '' );
 
 		/**
 		 * If all requests have been processed, output success and return.
 		 */
-		if( $counts['success'] === $counts['total'] ){
+		if ( $counts['success'] === $counts['total'] ) {
 			WP_CLI::success( "Successfully processed {$counts['success']}/{$counts['total']} '{$status}' requests.\n" );
 			return;
 		}
 		/**
 		 * All request processing failed.
 		 */
-		// Last 100 errors
-		$errors = wp_json_encode(array_slice($errors, -100, 100, true), JSON_PRETTY_PRINT);
+		// Last 100 errors.
+		$errors = wp_json_encode( array_slice( $errors, -100, 100, true ), JSON_PRETTY_PRINT );
 		if ( $counts['failed'] === $counts['total'] ) {
 			WP_CLI::error( "0/{$counts['total']} '{$status}' request were processed. \nErrors: {$errors}\n" );
 			return;
@@ -235,6 +235,5 @@ class Webhook {
 		WP_CLI::log( "- Success: {$counts['success']}/{$counts['total']}" );
 		WP_CLI::log( "- Failed: {$counts['success']}/{$counts['failed']}" );
 		WP_CLI::log( "- Errors: {$errors}\n" );
-
 	}
 }

--- a/includes/node/class-webhook.php
+++ b/includes/node/class-webhook.php
@@ -200,8 +200,9 @@ class Webhook {
 		$progress->finish();
 
 		if ( ! empty( $unprocessed_request_ids ) ) {
-			WP_CLI::warning( "The following requests could not be deleted:\n" . wp_json_encode( $unprocessed_request_ids ) );
+			WP_CLI::error( "The following requests could not be processed:\n" . wp_json_encode( $unprocessed_request_ids ) );
+			return;
 		}
-		WP_CLI::success( "Successfully processed {$processed_count}/{$requests_count} pending requests." );
+		WP_CLI::success( "Successfully processed {$processed_count}/{$requests_count} '{$status}' requests." );
 	}
 }

--- a/includes/node/class-webhook.php
+++ b/includes/node/class-webhook.php
@@ -114,8 +114,8 @@ class Webhook {
 	/**
 	 * Process network requests
 	 * 
-	 * @param array $args Args sent to command.
-	 * @param array $assoc_args Key value pair of arguments sent to command.
+	 * @param array $args Indexed array of args.
+	 * @param array $assoc_args Associative array of args.
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR introduces a WP CLI command for processing `np_webhook_request`s with post-meta status in `pending` state. 

### How to test the changes in this Pull Request:

1. Ensure a Hub and Node relationship exists and is configured correctly.
2. Node: Add incorrect "Hub URL" - WP Admin > Newspack Network > Node Settings
3. Node: Perform individual (as many as you can, the more the better) user related updates i.e. update; name, lastname etc.
4. Node: Add correct "Hub URL" - WP Admin > Newspack Network > Node Settings
5. Open terminal and run `wp newspack-network process-webhooks` to process and delete pending requests

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?