### PR TITLE
Refactor/backfillers

### DIFF
--- a/includes/cli/backfillers/class-abstract-backfiller.php
+++ b/includes/cli/backfillers/class-abstract-backfiller.php
@@ -109,12 +109,12 @@ abstract class Abstract_Backfiller {
 					$event->process_in_hub();
 					Data_Backfill::increment_results_counter( $event->get_action_name(), $event->is_persisted ? 'processed' : 'duplicate' );
 				} else {
-					$requests = $this->find_webhook_requests( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					$requests = $this->find_webhook_requests( $event->get_action_name(), $event->get_timestamp(), $event->get_data() );
 					if ( count( $requests ) > 0 ) {
 						Data_Backfill::increment_results_counter( $event->get_action_name(), 'duplicate' );
 						return;
 					}
-					\Newspack\Data_Events\Webhooks::handle_dispatch( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					\Newspack\Data_Events\Webhooks::handle_dispatch( $event->get_action_name(), $event->get_timestamp(), $event->get_data() );
 					Data_Backfill::increment_results_counter( $event->get_action_name(), 'processed' );
 				}
 			}

--- a/includes/cli/backfillers/class-abstract-backfiller.php
+++ b/includes/cli/backfillers/class-abstract-backfiller.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Data Backfiller abstract class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+use Newspack_Network\Data_Backfill;
+use Newspack_Network\Site_Role;
+use WP_CLI;
+
+/**
+ * Abstract class for backfillers.
+ */
+abstract class Abstract_Backfiller {
+
+	/**
+	 * Whether to run the backfiller in live mode.
+	 *
+	 * @var bool
+	 */
+	protected $live;
+
+	/**
+	 * Whether to run the backfiller in verbose mode.
+	 *
+	 * @var bool
+	 */
+	protected $verbose;
+
+	/**
+	 * The progress bar object if not in verbose mode.
+	 *
+	 * @var ?object
+	 */
+	protected $progress = null;
+
+	/**
+	 * The start date to process data from
+	 *
+	 * @var string
+	 */
+	protected $start;
+
+	/**
+	 * The end date to process data to
+	 *
+	 * @var string
+	 */
+	protected $end;
+
+	/**
+	 * Object contructor
+	 *
+	 * @param string $start The start date.
+	 * @param string $end The end date.
+	 * @param bool   $live Whether to run the backfiller in live mode.
+	 * @param bool   $verbose Whether to run the backfiller in verbose mode.
+	 */
+	public function __construct( $start, $end, $live, $verbose ) {
+		$this->start = $start;
+		$this->end = $end;
+		$this->live     = $live;
+		$this->verbose  = $verbose;
+	}
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	abstract protected function get_processed_item_output( $event );
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	abstract public function get_events();
+
+	/**
+	 * Initializes the WP CLI progress bar if in verbose mode
+	 *
+	 * @param string $label The progress bar label.
+	 * @param int    $total The total number of items to be processed.
+	 * @return void
+	 */
+	protected function maybe_initialize_progress_bar( $label, $total ) {
+		if ( ! $this->verbose ) {
+			Data_Backfill::$progress = \WP_CLI\Utils\make_progress_bar( $label, $total );
+		}
+	}
+
+	/**
+	 * Process the events.
+	 */
+	public function process_events() {
+
+		$events = $this->get_events();
+
+		foreach ( $events as $event ) {
+
+			if ( $this->live ) {
+				if ( Site_Role::is_hub() ) {
+					$event->process_in_hub();
+					Data_Backfill::increment_results_counter( $event->get_action_name(), $event->is_persisted ? 'processed' : 'duplicate' );
+				} else {
+					$requests = $this->find_webhook_requests( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					if ( count( $requests ) > 0 ) {
+						Data_Backfill::increment_results_counter( $event->get_action_name(), 'duplicate' );
+						return;
+					}
+					\Newspack\Data_Events\Webhooks::handle_dispatch( $event->get_action_name(), $$event->get_timestamp(), $event->get_data() );
+					Data_Backfill::increment_results_counter( $event->get_action_name(), 'processed' );
+				}
+			}
+
+			if ( $this->verbose ) {
+				WP_CLI::line( '👉 ' . $this->get_processed_item_output( $event ) );
+			}
+
+			if ( ! $this->verbose ) {
+				Data_Backfill::$progress->tick();
+			}
+		}
+	}
+
+	/**
+	 * Find existing webhook requests for a given action and data.
+	 *
+	 * @param string $action The action name.
+	 * @param int    $timestamp The timestamp.
+	 * @param array  $data The data.
+	 */
+	private function find_webhook_requests( $action, $timestamp, $data ) {
+		return get_posts(
+			[
+				'post_type'   => \Newspack\Data_Events\Webhooks::REQUEST_POST_TYPE,
+				'post_title'  => $action,
+				'post_status' => 'any',
+				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'AND',
+					[
+						'key'     => 'timestamp',
+						'value'   => $timestamp,
+						'compare' => '=',
+					],
+					[
+						'key'     => 'action_name',
+						'value'   => $action,
+						'compare' => '=',
+					],
+					[
+						'key'     => 'data',
+						'value'   => wp_json_encode( $data ),
+						'compare' => '=',
+					],
+				],
+			]
+		);
+	}
+}

--- a/includes/cli/backfillers/class-donation-new.php
+++ b/includes/cli/backfillers/class-donation-new.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Data Backfiller for donation_new events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+/**
+ * Backfiller class.
+ */
+class Donation_New extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Order #%d completed on %s.', $event->get_data()->platform_data['order_id'], $event->get_formatted_date() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		$orders = wc_get_orders(
+			[
+				'status'       => 'completed',
+				'date_created' => $this->start . '...' . $this->end,
+				'limit'        => -1,
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing orders', count( $orders ) );
+
+		$events = [];
+
+		foreach ( $orders as $order ) {
+			$order_id = $order->get_id();
+			$order_data = \Newspack\Data_Events\Utils::get_order_data( $order_id );
+			if ( ! $order_data ) {
+				continue;
+			}
+			$timestamp = strtotime( $order->get_date_completed() );
+
+			$event = new \Newspack_Network\Incoming_Events\Donation_New( get_bloginfo( 'url' ), $order_data, $timestamp );
+
+			$events[] = $event;
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-donation-subscription-cancelled.php
+++ b/includes/cli/backfillers/class-donation-subscription-cancelled.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Data Backfiller for donation_subcription_cancelled events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+/**
+ * Backfiller class.
+ */
+class Donation_Subscription_Cancelled extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Subscription #%d cancelled on %s.', $event->get_data()->subscription_id, $event->get_formatted_date() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		$subscriptions = wcs_get_subscriptions(
+			[
+				'subscription_status'    => 'cancelled',
+				'subscriptions_per_page' => -1,
+				'meta_query'             => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'AND',
+					[
+						'key'     => wcs_get_date_meta_key( 'cancelled' ),
+						'compare' => '>=',
+						'value'   => $this->start,
+					],
+					[
+						'key'     => wcs_get_date_meta_key( 'cancelled' ),
+						'compare' => '<=',
+						'value'   => $this->end,
+					],
+				],
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing subscriptions', count( $subscriptions ) );
+
+		$events = [];
+
+		foreach ( $subscriptions as $subscription ) {
+			$subscription_data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
+			if ( ! $subscription_data ) {
+				continue;
+			}
+			$timestamp = strtotime( $subscription->get_date( 'cancelled' ) );
+
+			$event = new \Newspack_Network\Incoming_Events\Donation_Subscription_Cancelled( get_bloginfo( 'url' ), $subscription_data, $timestamp );
+
+			$events[] = $event;
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Data Backfiller for reader_registered events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+/**
+ * Backfiller class.
+ */
+class Reader_Registered extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'User %s (#%d) registered on %s.', $event->get_email(), $event->get_data()->user_id, $event->get_formatted_date() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		// Get all users registered between this-> and $end.
+		$users = get_users(
+			[
+				'role__in'   => \Newspack\Reader_Activation::get_reader_roles(),
+				'date_query' => [
+					'after'     => $this->start,
+					'before'    => $this->end,
+					'inclusive' => true,
+				],
+				'fields'     => [ 'id', 'user_email', 'user_registered' ],
+				'number'     => -1,
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE,
+						'compare' => 'NOT EXISTS',
+					],
+				],
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing users', count( $users ) );
+
+		$events = [];
+
+		foreach ( $users as $user ) {
+			$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
+			$user_data = [
+				'user_id'  => $user->ID,
+				'email'    => $user->user_email,
+				'metadata' => [
+					// 'current_page_url' is not saved, can't be backfilled.
+					'registration_method' => empty( $registration_method ) ? 'backfill-script' : $registration_method,
+				],
+			];
+
+			$incoming_event = new \Newspack_Network\Incoming_Events\Reader_Registered( get_bloginfo( 'url' ), $user_data, strtotime( $user->user_registered ) );
+			$events[] = $incoming_event;
+
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -57,7 +57,7 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 			$status = $membership->get_status();
 			$plan_network_id = get_post_meta( $membership->get_plan()->get_id(), \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true );
 			if ( ! $plan_network_id ) {
-				if ( $verbose ) {
+				if ( $this->verbose ) {
 					WP_CLI::line( sprintf( 'Skipping membership #%d with status %s, the plan has no network ID.', $membership->get_id(), $status ) );
 				}
 				Data_Backfill::increment_results_counter( 'newspack_network_woo_membership_updated', 'skipped' );

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Data Backfiller for newspack_network_woo_membership_updated events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+use Newspack_Network\Data_Backfill;
+use WP_Cli;
+
+/**
+ * Backfiller class.
+ */
+class Woocommerce_Membership_Updated extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Membership #%d with status %s on %s, linked with network ID "%s".', $event->get_membership_id(), $event->get_new_status(), $event->get_formatted_date(), $event->get_plan_network_id() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		// Get all memberships created or updated between $start and $end.
+		$membership_posts_ids = get_posts(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+				'date_query'  => [
+					'column'    => 'post_modified_gmt',
+					'after'     => $this->start,
+					'before'    => $this->end,
+					'inclusive' => true,
+				],
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing memberships', count( $membership_posts_ids ) );
+
+		$events = [];
+
+		foreach ( $membership_posts_ids as $post_id ) {
+			$membership = new \WC_Memberships_User_Membership( $post_id );
+			$status = $membership->get_status();
+			$plan_network_id = get_post_meta( $membership->get_plan()->get_id(), \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true );
+			if ( ! $plan_network_id ) {
+				if ( $verbose ) {
+					WP_CLI::line( sprintf( 'Skipping membership #%d with status %s, the plan has no network ID.', $membership->get_id(), $status ) );
+				}
+				Data_Backfill::increment_results_counter( 'newspack_network_woo_membership_updated', 'skipped' );
+				continue;
+			}
+			$membership_data = [
+				'email'           => $membership->get_user()->user_email,
+				'user_id'         => $membership->get_user()->ID,
+				'plan_network_id' => $plan_network_id,
+				'membership_id'   => $membership->get_id(),
+				'new_status'      => $status,
+			];
+			if ( $status === 'active' ) {
+				$timestamp = strtotime( $membership->get_start_date() );
+			} else {
+				$timestamp = strtotime( $membership->get_end_date() );
+			}
+
+			$events[] = new \Newspack_Network\Incoming_Events\Woocommerce_Membership_Updated( get_bloginfo( 'url' ), $membership_data, $timestamp );
+
+		}
+
+		return $events;
+	}
+}

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Backfillers;
 
 use Newspack_Network\Data_Backfill;
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
 use WP_Cli;
 
 /**
@@ -44,6 +45,12 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 					'after'     => $this->start,
 					'before'    => $this->end,
 					'inclusive' => true,
+				],
+				'meta_query'  => [ // phpcs:ignore
+					[
+						'key'     => Memberships_Admin::NETWORK_MANAGED_META_KEY,
+						'compare' => 'NOT EXISTS',
+					],
 				],
 			]
 		);

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -25,7 +25,7 @@ class Data_Backfill {
 	 *
 	 * @var class
 	 */
-	private static $progress = false;
+	public static $progress = false;
 
 	/**
 	 * Initialize this class and register hooks
@@ -44,182 +44,6 @@ class Data_Backfill {
 	public static function register_commands() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'newspack-network data-backfill', [ __CLASS__, 'data_backfill' ] );
-		}
-	}
-
-	/**
-	 * Find existing webhook requests for a given action and data.
-	 *
-	 * @param string $action The action name.
-	 * @param int    $timestamp The timestamp.
-	 * @param array  $data The data.
-	 */
-	private static function find_webhook_requests( $action, $timestamp, $data ) {
-		return get_posts(
-			[
-				'post_type'   => \Newspack\Data_Events\Webhooks::REQUEST_POST_TYPE,
-				'post_title'  => $action,
-				'post_status' => 'any',
-				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					'relation' => 'AND',
-					[
-						'key'     => 'timestamp',
-						'value'   => $timestamp,
-						'compare' => '=',
-					],
-					[
-						'key'     => 'action_name',
-						'value'   => $action,
-						'compare' => '=',
-					],
-					[
-						'key'     => 'data',
-						'value'   => wp_json_encode( $data ),
-						'compare' => '=',
-					],
-				],
-			]
-		);
-	}
-
-	/**
-	 * Process reader_registered events.
-	 *
-	 * @param string $start The start date.
-	 * @param string $end The end date.
-	 * @param bool   $live Whether to run in live mode.
-	 * @param bool   $verbose Whether to output verbose information.
-	 */
-	private static function process_reader_registered( $start, $end, $live, $verbose ) {
-		// Get all users registered between $start and $end.
-		$users = get_users(
-			[
-				'role__in'   => \Newspack\Reader_Activation::get_reader_roles(),
-				'date_query' => [
-					'after'     => $start,
-					'before'    => $end,
-					'inclusive' => true,
-				],
-				'fields'     => [ 'id', 'user_email', 'user_registered' ],
-				'number'     => -1,
-				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					[
-						'key'     => \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE,
-						'compare' => 'NOT EXISTS',
-					],
-				],
-			]
-		);
-		if ( ! $verbose ) {
-			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing users', count( $users ) );
-		}
-
-		foreach ( $users as $user ) {
-			$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
-			$user_data = [
-				'user_id'  => $user->ID,
-				'email'    => $user->user_email,
-				'metadata' => [
-					// 'current_page_url' is not saved, can't be backfilled.
-					'registration_method' => empty( $registration_method ) ? 'backfill-script' : $registration_method,
-				],
-			];
-			if ( $live ) {
-				self::process_event_entity( $user_data, strtotime( $user->user_registered ), 'reader_registered' );
-			}
-			if ( $verbose ) {
-				WP_CLI::line( '👉 ' . sprintf( 'User %s (#%d) registered on %s.', $user->user_email, $user->ID, $user->user_registered ) );
-			}
-			if ( self::$progress ) {
-				self::$progress->tick();
-			}
-		}
-	}
-
-	/**
-	 * Process donation_new events.
-	 *
-	 * @param string $start The start date.
-	 * @param string $end The end date.
-	 * @param bool   $live Whether to run in live mode.
-	 * @param bool   $verbose Whether to output verbose information.
-	 */
-	private static function process_donation_new( $start, $end, $live, $verbose ) {
-		$orders = wc_get_orders(
-			[
-				'status'       => 'completed',
-				'date_created' => $start . '...' . $end,
-				'limit'        => -1,
-			]
-		);
-		if ( ! $verbose ) {
-			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing orders', count( $orders ) );
-		}
-		foreach ( $orders as $order ) {
-			$order_id = $order->get_id();
-			$order_data = \Newspack\Data_Events\Utils::get_order_data( $order_id );
-			if ( ! $order_data ) {
-				continue;
-			}
-			$timestamp = strtotime( $order->get_date_completed() );
-			if ( $live ) {
-				self::process_event_entity( $order_data, $timestamp, 'donation_new' );
-			}
-			if ( $verbose ) {
-				WP_CLI::line( '👉 ' . sprintf( 'Order #%d completed on %s.', $order_id, gmdate( 'Y-m-d H:i:s', $timestamp ) ) );
-			}
-			if ( self::$progress ) {
-				self::$progress->tick();
-			}
-		}
-	}
-
-	/**
-	 * Process donation_subscription_cancelled events.
-	 *
-	 * @param string $start The start date.
-	 * @param string $end The end date.
-	 * @param bool   $live Whether to run in live mode.
-	 * @param bool   $verbose Whether to output verbose information.
-	 */
-	private static function process_donation_subscription_cancelled( $start, $end, $live, $verbose ) {
-		$subscriptions = wcs_get_subscriptions(
-			[
-				'subscription_status'    => 'cancelled',
-				'subscriptions_per_page' => -1,
-				'meta_query'             => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					'relation' => 'AND',
-					[
-						'key'     => wcs_get_date_meta_key( 'cancelled' ),
-						'compare' => '>=',
-						'value'   => $start,
-					],
-					[
-						'key'     => wcs_get_date_meta_key( 'cancelled' ),
-						'compare' => '<=',
-						'value'   => $end,
-					],
-				],
-			]
-		);
-		if ( ! $verbose ) {
-			self::$progress = \WP_CLI\Utils\make_progress_bar( 'Processing subscriptions', count( $subscriptions ) );
-		}
-		foreach ( $subscriptions as $subscription ) {
-			$subscription_data = \Newspack\Data_Events\Utils::get_recurring_donation_data( $subscription );
-			if ( ! $subscription_data ) {
-				continue;
-			}
-			$timestamp = strtotime( $subscription->get_date( 'cancelled' ) );
-			if ( $live ) {
-				self::process_event_entity( $subscription_data, $timestamp, 'donation_subscription_cancelled' );
-			}
-			if ( $verbose ) {
-				WP_CLI::line( '👉 ' . sprintf( 'Subscription #%d cancelled on %s.', $subscription->get_id(), gmdate( 'Y-m-d H:i:s', $timestamp ) ) );
-			}
-			if ( self::$progress ) {
-				self::$progress->tick();
-			}
 		}
 	}
 
@@ -302,33 +126,7 @@ class Data_Backfill {
 		self::$results[ $action ][ $counter ]++;
 	}
 
-	/**
-	 * Process a WooCommerce entity.
-	 *
-	 * @param array  $data The data.
-	 * @param int    $timestamp The ti;mestamp.
-	 * @param string $action The action.
-	 */
-	private static function process_event_entity( $data, $timestamp, $action ) {
-		if ( Site_Role::is_hub() ) {
-			$event = new \Newspack_Network\Incoming_Events\Abstract_Incoming_Event(
-				get_bloginfo( 'url' ),
-				$data,
-				$timestamp,
-				$action
-			);
-			$event->process_in_hub();
-			self::increment_results_counter( $action, $event->is_persisted ? 'processed' : 'duplicate' );
-		} else {
-			$requests = self::find_webhook_requests( $action, $timestamp, $data );
-			if ( count( $requests ) > 0 ) {
-				self::increment_results_counter( $action, 'duplicate' );
-				return;
-			}
-			\Newspack\Data_Events\Webhooks::handle_dispatch( $action, $timestamp, $data );
-			self::increment_results_counter( $action, 'processed' );
-		}
-	}
+
 
 	/**
 	 * Backfill data for a specific action.
@@ -362,8 +160,8 @@ class Data_Backfill {
 		$action = $args[0];
 		$start = isset( $assoc_args['start'] ) ? $assoc_args['start'] : null;
 		$end = isset( $assoc_args['end'] ) ? $assoc_args['end'] : null;
-		$live = isset( $assoc_args['live'] ) ? $assoc_args['live'] : null;
-		$verbose = isset( $assoc_args['verbose'] ) ? $assoc_args['verbose'] : null;
+		$live = isset( $assoc_args['live'] ) ? true : false;
+		$verbose = isset( $assoc_args['verbose'] ) ? true : false;
 
 		WP_CLI::line( '' );
 
@@ -401,28 +199,23 @@ class Data_Backfill {
 		}
 		WP_CLI::line( '' );
 
-		switch ( $action ) {
-			case 'reader_registered':
-				self::process_reader_registered( $start, $end, $live, $verbose );
-				break;
-			case 'donation_new':
-				self::process_donation_new( $start, $end, $live, $verbose );
-				break;
-			case 'donation_subscription_cancelled':
-				self::process_donation_subscription_cancelled( $start, $end, $live, $verbose );
-				break;
-			case 'newspack_network_woo_membership_updated':
-				self::process_newspack_network_woo_membership_updated( $start, $end, $live, $verbose );
-				break;
-			case 'all':
-				self::process_reader_registered( $start, $end, $live, $verbose );
-				self::process_donation_new( $start, $end, $live, $verbose );
-				self::process_donation_subscription_cancelled( $start, $end, $live, $verbose );
-				self::process_newspack_network_woo_membership_updated( $start, $end, $live, $verbose );
-				break;
-			default:
-				WP_CLI::error( 'Backfilling data for this action is not supported yet.' );
-				break;
+		if ( 'all' === $action ) {
+			$actions = array_keys( Accepted_Actions::ACTIONS );
+		} else {
+			$actions = [ $action ];
+		}
+
+		foreach ( $actions as $action_name ) {
+			$class_name = 'Newspack_Network\\Backfillers\\' . Accepted_Actions::ACTIONS[ $action_name ];
+			if ( ! class_exists( $class_name ) ) {
+				if ( 'all' !== $action ) {
+					WP_CLI::error( sprintf( 'Backfilling data for %s is not supported yet.', $action_name ) );
+				}
+				continue;
+			}
+			$backfiller = new $class_name( $start, $end, $live, $verbose );
+			$backfiller->process_events();
+
 		}
 
 		if ( self::$progress ) {
@@ -430,18 +223,16 @@ class Data_Backfill {
 		}
 		if ( $live ) {
 			WP_CLI::line( '' );
-			foreach ( [ 'reader_registered', 'donation_new', 'donation_subscription_cancelled', 'newspack_network_woo_membership_updated' ] as $action_key ) {
-				if ( isset( self::$results[ $action_key ] ) ) {
-					WP_CLI::success(
-						sprintf(
-							'Processed %d %s events, ignored %d as duplicates and skipped %d.',
-							self::$results[ $action_key ]['processed'],
-							$action_key,
-							self::$results[ $action_key ]['duplicate'],
-							self::$results[ $action_key ]['skipped']
-						)
-					);
-				}
+			foreach ( self::$results as $action_key => $result ) {
+				WP_CLI::success(
+					sprintf(
+						'Processed %d %s events, ignored %d as duplicates and skipped %d.',
+						$result['processed'],
+						$action_key,
+						$result['duplicate'],
+						$result['skipped']
+					)
+				);
 			}
 		}
 		WP_CLI::line( '' );

--- a/includes/incoming-events/class-abstract-incoming-event.php
+++ b/includes/incoming-events/class-abstract-incoming-event.php
@@ -128,6 +128,16 @@ class Abstract_Incoming_Event {
 	}
 
 	/**
+	 * Returns the formatted date for this event based on its timestamp
+	 *
+	 * @param string $format The date format.
+	 * @return string
+	 */
+	public function get_formatted_date( $format = 'Y-m-d H:i:s' ) {
+		return gmdate( $format, $this->timestamp );
+	}
+
+	/**
 	 * Returns the action name for this event
 	 *
 	 * @return string

--- a/includes/incoming-events/class-reader-registered.php
+++ b/includes/incoming-events/class-reader-registered.php
@@ -10,6 +10,7 @@ namespace Newspack_Network\Incoming_Events;
 use Newspack_Network\Debugger;
 use Newspack_Network\Hub\Node;
 use Newspack_Network\Hub\Stores\Event_Log;
+use Newspack_Network\User_Update_Watcher;
 use Newspack_Network\Utils\Users as User_Utils;
 
 /**
@@ -46,6 +47,8 @@ class Reader_Registered extends Abstract_Incoming_Event {
 		if ( ! $email ) {
 			return;
 		}
+
+		User_Update_Watcher::$enabled = false;
 
 		$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
 	}

--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Incoming_Events;
 
 use Newspack_Network\User_Manual_Sync;
 use Newspack_Network\Debugger;
+use Newspack_Network\User_Update_Watcher;
 use Newspack_Network\Utils\Users as User_Utils;
 
 /**
@@ -47,6 +48,8 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 		if ( ! $email ) {
 			return;
 		}
+
+		User_Update_Watcher::$enabled = false;
 
 		$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
 


### PR DESCRIPTION
Refactors backfill CLI class as suggested in https://github.com/Automattic/newspack-network/pull/51#pullrequestreview-1889233317

Also finishes the implementation of user memberships

Also fixes a small issue where some events were triggering other the `user_updated`event.

For example, when a site received a `reader_registered` event and created the user, the `user_updated` event was being triggered, and this is not necessary.