### PR TITLE
fix: added admin.php to woo links in wp admin bar

### DIFF
--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -139,7 +139,7 @@ class Node {
 			],
 			[
 				'label' => 'WooCommerce',
-				'url'   => $base_url . 'wp-admin?page=wc-admin',
+				'url'   => $base_url . 'wp-admin/admin.php?page=wc-admin',
 			],
 			[
 				'label' => __( 'Posts', 'newspack-network' ),


### PR DESCRIPTION
"Woocommerce" links in WP Admin bar are broken and resulting in a 403 "Sorry, you are not allowed to access this page." 

Screenshot:
![Screenshot 2024-02-23 at 16 38 02](https://github.com/Automattic/newspack-network/assets/3676975/8d8156ef-09d6-40ba-839f-6ddc81425453)

Current: /wp-admin/?page=wc-admin
Should be /wp-admin/admin.php?page=wc-admin

How to test:
* Open either hub or node site
* Ensure you're logged in
* In the wp admin bar under "Site Name" menu item, hover over Hub or node until the "Woocommerce" item is visible

![Screenshot 2024-02-23 at 16 45 24](https://github.com/Automattic/newspack-network/assets/3676975/4f4526ce-7cfa-47e9-8524-e6b5b8764ce4)
![Screenshot 2024-02-23 at 16 45 11](https://github.com/Automattic/newspack-network/assets/3676975/c881d76f-1031-4bd7-b3f7-fd1756adc7de)

* Click this link and confirm it navigates to the correct (respective) Woocommerce admin page.