### PR TITLE
Fix/backfill duplicate handling

### DIFF
--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -66,7 +66,6 @@ class Reader_Registered extends Abstract_Backfiller {
 
 			$incoming_event = new \Newspack_Network\Incoming_Events\Reader_Registered( get_bloginfo( 'url' ), $user_data, strtotime( $user->user_registered ) );
 			$events[] = $incoming_event;
-
 		}
 
 		return $events;

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -53,6 +53,22 @@ class Reader_Registered extends Abstract_Backfiller {
 
 		$events = [];
 
+		// Disregard `current_page_url` metadata when checking for duplicates of reader registrations.
+		// This metadata is unavailable for backfilled events, so it's not possible to check for duplicates with it.
+		add_filter(
+			'newspack_network_event_log_get_args',
+			function( $args ) {
+				if ( $args['action_name'] === 'reader_registered' && isset( $args['data'] ) ) {
+					$data = json_decode( $args['data'], true );
+					if ( isset( $data['metadata']['current_page_url'] ) ) {
+						unset( $data['metadata']['current_page_url'] );
+					}
+					$args['data'] = wp_json_encode( $data );
+				}
+				return $args;
+			}
+		);
+
 		foreach ( $users as $user ) {
 			$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
 			$user_data = [

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -53,17 +53,13 @@ class Reader_Registered extends Abstract_Backfiller {
 
 		$events = [];
 
-		// Disregard `current_page_url` metadata when checking for duplicates of reader registrations.
-		// This metadata is unavailable for backfilled events, so it's not possible to check for duplicates with it.
+		// Disregard any attached data when checking for duplicates of reader registrations.
+		// Only the email address and the date are relevant in this case.
 		add_filter(
 			'newspack_network_event_log_get_args',
 			function( $args ) {
 				if ( $args['action_name'] === 'reader_registered' && isset( $args['data'] ) ) {
-					$data = json_decode( $args['data'], true );
-					if ( isset( $data['metadata']['current_page_url'] ) ) {
-						unset( $data['metadata']['current_page_url'] );
-					}
-					$args['data'] = wp_json_encode( $data );
+					unset( $args['data'] );
 				}
 				return $args;
 			}

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -151,12 +151,12 @@ class Data_Backfill {
 			}
 			$backfiller = new $class_name( $start, $end, $live, $verbose );
 			$backfiller->process_events();
-
 		}
 
 		if ( self::$progress ) {
 			self::$progress->finish();
 		}
+
 		if ( $live ) {
 			WP_CLI::line( '' );
 			foreach ( self::$results as $action_key => $result ) {

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -139,7 +139,7 @@ class Node {
 			],
 			[
 				'label' => 'WooCommerce',
-				'url'   => $base_url . 'wp-admin?page=wc-admin',
+				'url'   => $base_url . 'wp-admin/admin.php?page=wc-admin',
 			],
 			[
 				'label' => __( 'Posts', 'newspack-network' ),

--- a/includes/hub/stores/class-event-log.php
+++ b/includes/hub/stores/class-event-log.php
@@ -39,6 +39,7 @@ class Event_Log {
 
 		$query = $wpdb->prepare( "SELECT * FROM $table_name WHERE 1=1 [args] $order_string LIMIT %d OFFSET %d", $per_page, $offset ); //phpcs:ignore
 
+		$args = apply_filters( 'newspack_network_event_log_get_args', $args );
 		$query = str_replace( '[args]', self::build_where_clause( $args ), $query );
 
 		$db = $wpdb->get_results( $query ); //phpcs:ignore

--- a/includes/hub/stores/class-event-log.php
+++ b/includes/hub/stores/class-event-log.php
@@ -145,7 +145,13 @@ class Event_Log {
 		}
 
 		if ( ! empty( $args['timestamp'] ) ) {
-			$where .= $wpdb->prepare( ' AND timestamp = %s', $args['timestamp'] );
+			// The logged event timestamp and the actual timestamp of the event can differ by a few seconds,
+			// so we need to search for a range of timestamps. For example, when a user registered at time T,
+			// the event will have a timestamp of e.g. T+10ms. Then, when a backfill script (or other code) is looking
+			// for the event, it will miss it since it's looking for the exact timestamp T.
+			$timestamp = $args['timestamp'];
+			$range     = 3; // seconds.
+			$where     .= $wpdb->prepare( ' AND timestamp >= %s AND timestamp <= %s', $timestamp - $range, $timestamp + $range );
 		}
 
 		if ( ! empty( $args['data'] ) ) {

--- a/includes/hub/stores/class-event-log.php
+++ b/includes/hub/stores/class-event-log.php
@@ -150,7 +150,7 @@ class Event_Log {
 			// the event will have a timestamp of e.g. T+10ms. Then, when a backfill script (or other code) is looking
 			// for the event, it will miss it since it's looking for the exact timestamp T.
 			$timestamp = $args['timestamp'];
-			$range     = 3; // seconds.
+			$range     = 10; // milliseconds.
 			$where     .= $wpdb->prepare( ' AND timestamp >= %s AND timestamp <= %s', $timestamp - $range, $timestamp + $range );
 		}
 

--- a/includes/incoming-events/class-abstract-incoming-event.php
+++ b/includes/incoming-events/class-abstract-incoming-event.php
@@ -80,12 +80,14 @@ class Abstract_Incoming_Event {
 	 */
 	public function process_in_hub() {
 		Debugger::log( 'Processing event' );
-		Event_Log::persist( $this );
-		// only invoke post_process_in_hub if the event was triggered in a Node.
-		if ( 0 < $this->get_node_id() ) {
-			$this->post_process_in_hub();
+		$event_id = Event_Log::persist( $this );
+		if ( $event_id ) {
+			// only invoke post_process_in_hub if the event was triggered in a Node.
+			if ( 0 < $this->get_node_id() ) {
+				$this->post_process_in_hub();
+			}
+			$this->always_process_in_hub();
 		}
-		$this->always_process_in_hub();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two issues:

1. If and event is not persisted in the event log, it should not be processed. 
2. When backfilling `reader_registration` events, disregard `current_page_url` metadata.

By accident this branch also contains #71, but it won't hurt to add that to the `alpha` release.

### How to test the changes in this Pull Request:

0. On `alpha`,
1. Trigger a new `reader_registered` event by registering as a new reader on the site
4. Observe in the Event Log that the event has a `metadata.current_page_url` key in the `data` property
5. Run the backfill for `reader_registered` events (e.g. `wp newspack-network data-backfill reader_registered --start=2024-02-26 --end=2024-12-31 --verbose`)
6. Observe a new `reader_registered` event added, even though a `reader_registered` for this reader is already present
7. Observe that the new event does not have the `metadata.current_page_url` key
8. Switch to this branch, repeat the testing steps, observe the duplicate event is not added 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->