### PR TITLE
fix: correct typo in manual sync description

### DIFF
--- a/includes/class-user-manual-sync.php
+++ b/includes/class-user-manual-sync.php
@@ -105,7 +105,7 @@ class User_Manual_Sync {
 							<?php esc_html_e( 'Sync user across network', 'newspack-network' ); ?>
 						</a>
 						<p class="description">
-							<?php esc_html_e( 'Manually sync this user\'s information across all sites in your network, including their role. If this is a new user, clicking this button will also propigate the user account across your network.', 'newspack-network' ); ?>
+							<?php esc_html_e( 'Manually sync this user\'s information across all sites in your network, including their role. If this is a new user, clicking this button will also propagate the user account across your network.', 'newspack-network' ); ?>
 						</p>
 					</td>
 				</tr>


### PR DESCRIPTION
This PR fixes a small typo in the Manual Sync section. 

## Steps to test:

1. Double-check Laurel's horrible, horrible spelling. 