### PR TITLE
feat(membership-plans): display active memberships count

### DIFF
--- a/includes/hub/admin/class-membership-plans-table.php
+++ b/includes/hub/admin/class-membership-plans-table.php
@@ -48,6 +48,7 @@ class Membership_Plans_Table extends \WP_List_Table {
 			$columns['node_url'] = __( 'Node URL', 'newspack-network' );
 		}
 		$columns['network_pass_id'] = __( 'Network ID', 'newspack-network' );
+		$columns['active_members_count'] = __( 'Active Members', 'newspack-network' );
 		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;
 	}

--- a/includes/hub/admin/class-membership-plans.php
+++ b/includes/hub/admin/class-membership-plans.php
@@ -124,10 +124,11 @@ abstract class Membership_Plans {
 					}
 				}
 				$membership_plans[] = [
-					'id'              => $plan->id,
-					'node_url'        => $node->get_url(),
-					'name'            => $plan->name,
-					'network_pass_id' => $network_pass_id,
+					'id'                   => $plan->id,
+					'node_url'             => $node->get_url(),
+					'name'                 => $plan->name,
+					'network_pass_id'      => $network_pass_id,
+					'active_members_count' => $plan->active_members_count,
 				];
 			}
 		}
@@ -149,9 +150,10 @@ abstract class Membership_Plans {
 		}
 		foreach ( wc_memberships_get_membership_plans() as $plan ) {
 			$membership_plans[] = [
-				'id'              => $plan->post->ID,
-				'name'            => $plan->post->post_title,
-				'network_pass_id' => get_post_meta( $plan->post->ID, \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true ),
+				'id'                   => $plan->post->ID,
+				'name'                 => $plan->post->post_title,
+				'network_pass_id'      => get_post_meta( $plan->post->ID, \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true ),
+				'active_members_count' => $plan->get_memberships_count( 'active' ),
 			];
 		}
 		return $membership_plans;

--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -58,6 +58,21 @@ class Admin {
 		add_filter( 'get_edit_post_link', array( __CLASS__, 'get_edit_post_link' ), 10, 2 );
 		add_filter( 'post_row_actions', array( __CLASS__, 'post_row_actions' ), 99, 2 ); // After the Memberships plugin.
 		add_filter( 'map_meta_cap', array( __CLASS__, 'map_meta_cap' ), 20, 4 );
+		add_filter( 'wc_memberships_rest_api_membership_plan_data', [ __CLASS__, 'add_data_to_membership_plan_response' ], 2, 3 );
+	}
+
+	/**
+	 * Filter membership plans to add user count.
+	 *
+	 * @param array                           $data associative array of membership plan data.
+	 * @param \WC_Memberships_Membership_Plan $plan the membership plan.
+	 * @param null|\WP_REST_Request           $request The request object.
+	 */
+	public static function add_data_to_membership_plan_response( $data, $plan, $request ) {
+		if ( $request && isset( $request->get_headers()['x_np_network_signature'] ) ) {
+			$data['active_members_count'] = $plan->get_memberships_count( 'active' );
+		}
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an "Active Members" column in Membership Plans table:

<img width="971" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/7e6df9e1-0a3a-4425-a353-6b8952ff37d4">

### How to test the changes in this Pull Request:

1. On the Hub site, visit the "Membership Plans" view, observe a new "Active Members" column
2. Visit the corresponding Node sites, confirm the numbers are correct

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->