### PR TITLE
Fix/error processing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 	"autoload": {
 		"classmap": [
 			"./includes"
-		]
+		],
+		"files": ["./includes/constants.php"]
 	},
 	"config": {
 		"allow-plugins": {

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -11,7 +11,7 @@ namespace Newspack_Network\constants;
  * Webhook error responses map.
  */
 const WEBHOOK_RESPONSE_ERRORS = [
-    // Encryption verification failure.
-    'INVALID_SIGNATURE'   => 'Invalid Signature.',
-    'INVALID_DATA'        => 'Bad request. Invalid Data.',
+	// Encryption verification failure.
+	'INVALID_SIGNATURE' => 'Invalid Signature.',
+	'INVALID_DATA'      => 'Bad request. Invalid Data.',
 ];

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Newspack Network related constants
+ * 
+ * @package Newspack
+ */
+
+namespace Newspack_Network\constants;
+
+/**
+ * Webhook error responses map.
+ */
+const WEBHOOK_RESPONSE_ERRORS = [
+    // Encryption verification failure.
+    'INVALID_SIGNATURE'   => 'Invalid Signature.',
+    'INVALID_DATA'        => 'Bad request. Invalid Data.',
+];

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -139,7 +139,7 @@ class Node {
 			],
 			[
 				'label' => 'WooCommerce',
-				'url'   => $base_url . 'wp-admin?page=wc-admin',
+				'url'   => $base_url . 'wp-admin/admin.php?page=wc-admin',
 			],
 			[
 				'label' => __( 'Posts', 'newspack-network' ),

--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -92,7 +92,7 @@ class Pull_Endpoint {
 
 		if ( ! $verified || ! is_object( $verified_message ) || (int) $last_processed_id !== (int) $verified_message->last_processed_id ) {
 			Debugger::log( 'Signature check failed' );
-			return new WP_REST_Response( array( 'error' => 'Invalid Signature.' ), 403 );
+			return new WP_REST_Response( array( 'error' => 'INVALID_SIGNATURE' ), 403 );
 		}
 
 		Debugger::log( 'Successfully verified request' );

--- a/includes/hub/class-webhook.php
+++ b/includes/hub/class-webhook.php
@@ -11,7 +11,6 @@ use Newspack_Network\Accepted_Actions;
 use Newspack_Network\Debugger;
 use WP_REST_Response;
 use WP_REST_Request;
-use WP_REST_Server;
 
 /**
  * Class to handle the Webhook
@@ -85,7 +84,7 @@ class Webhook {
 		$verified_data = $node->decrypt_message( $data, $nonce );
 		if ( ! $verified_data ) {
 			Debugger::log( 'Signature check failed' );
-			return new WP_REST_Response( array( 'error' => 'Invalid Signature.' ), 403 );
+			return new WP_REST_Response( array( 'error' => 'INVALID_SIGNATURE' ), 403 );
 		}
 
 		$verified_data = json_decode( $verified_data );

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -13,6 +13,8 @@ use Newspack_Network\Hub\Node as Hub_Node;
 use Newspack_Network\Hub\Nodes as Hub_Nodes;
 use WP_Error;
 
+use const Newspack_Network\constants\WEBHOOK_RESPONSE_ERRORS;
+
 /**
  * Class to handle Node settings page
  */
@@ -401,7 +403,15 @@ class Settings {
 				<tr>
 					<td><?php echo esc_html( $date ); ?> (#<?php echo esc_html( $r['request_id'] ); ?>)</td>
 					<td><?php echo esc_html( $r['action'] ); ?></td>
+					<?php if ( false === $data ) : ?>
+						<td>
+							🚫 <strong><?php _e( 'Decryption Error!', 'newspack-network' ); ?></strong><br>
+							<?php _e( 'The below is unencrypted and cannot be processed.', 'newspack-network' ); ?><br><br>
+							<code><?php echo esc_html( wp_json_encode( $r['data'] ) ); ?></code>
+						</td>
+					<?php else : ?>
 					<td><code><?php echo esc_html( $data ); ?></code></td>
+					<?php endif; ?>
 					<td>
 						<?php echo esc_html( $icon . ' ' . $status_label ); ?>.
 						<?php
@@ -432,7 +442,7 @@ class Settings {
 								echo '<ul>';
 							foreach ( $request['errors'] as $error ) {
 								echo '<li><code>';
-								echo esc_html( $error );
+								echo esc_html( WEBHOOK_RESPONSE_ERRORS[ $error ] ?? $error );
 								echo '</code></li>';
 							}
 								echo '</ul>';

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -406,7 +406,10 @@ class Settings {
 					<?php if ( false === $data ) : ?>
 						<td>
 							🚫 <strong><?php _e( 'Decryption Error!', 'newspack-network' ); ?></strong><br>
-							<?php _e( 'The below is unencrypted and cannot be processed.', 'newspack-network' ); ?><br><br>
+							<?php if ( 'finished' !== $request['status'] ) : ?>
+									<?php _e( 'Data is unencrypted and cannot be processed.', 'newspack-network' ); ?>
+								<?php endif; ?>
+								<br><br>
 							<code><?php echo esc_html( wp_json_encode( $r['data'] ) ); ?></code>
 						</td>
 					<?php else : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Currently there is no way to recover from a request that have been generated using a "faulty" secret. This PR introduces enhancements to that utilize the new `newspack_webhooks_process_request_errors` action (currently in review too - https://github.com/Automattic/newspack-plugin/pull/2955)

Ancillary changes:
- A new centralized error map `WEBHOOK_RESPONSE_ERRORS` for mapping error ids to error messages.

### How to test the changes in this Pull Request:

1. Newspack Network - `git checkout fix/error-processing`
2. Newspack Plugin - `git checkout `feat/process-request-errors`
3. On a Node site, navigate to Newspack Network > Node Settings i.e. `/wp-admin/admin.php?page=newspack-network-node`.
4. Update "Secret key" to something incorrect i.e. cut (paste somewhere safe, you'll use in No.7) the first five letters off of the secret and replace with the word `wrong`.
![Screenshot 2024-02-28 at 21 11 17](https://github.com/Automattic/newspack-network/assets/3676975/12d67e33-3ec0-4cd3-abaa-559ac8bcf6aa)
5. Navigate to a users profile page, update "First Name" and click Save (or hit return/enter while still focused on the input)
6. Navigate back to Node Settings and observe that a Webhook Request has been generated (notice the "🚫 Decryption Error"
![Screenshot 2024-02-28 at 20 52 46](https://github.com/Automattic/newspack-network/assets/3676975/47cf558c-e64c-44e9-a257-d2bc0416059f)
7. Fix "Secret Key" to original state i.e. undo No.4.
8. Allow the first cron to run, you'll know this has happened when an error appears as "Invalid Signature".
![Screenshot 2024-02-28 at 20 53 19](https://github.com/Automattic/newspack-network/assets/3676975/0b409b1b-0d2a-40f9-8a16-9b26ec92a5c1)
9. The next cron that runs should process the request correctly.
![Screenshot 2024-02-28 at 20 54 16](https://github.com/Automattic/newspack-network/assets/3676975/7663063a-bb2f-46e7-9226-7a433fc0453c)
10. Also confirm it has been received on the Hub.
![Screenshot 2024-02-28 at 20 55 05](https://github.com/Automattic/newspack-network/assets/3676975/1359389d-154c-4e22-9fc1-b5a4c428b017)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?