### PR TITLE
Feat/user counts

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -32,7 +32,6 @@ class Admin {
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu' ) );
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
-		add_filter( 'users_list_table_query_args', [ __CLASS__, 'users_list_table_query_args' ] );
 	}
 
 	/**
@@ -191,20 +190,5 @@ class Admin {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
-	}
-
-	/**
-	 * Handle the filtering of users by multiple roles.
-	 * Unfortunatelly, `get_views` and `get_views_links` are not filterable, so "All" will
-	 * be displayed as the active filter.
-	 *
-	 * @param array $args The current query args.
-	 */
-	public static function users_list_table_query_args( $args ) {
-		if ( isset( $_REQUEST['role__in'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$args['role__in'] = explode( ',', sanitize_text_field( $_REQUEST['role__in'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			unset( $args['role'] );
-		}
-		return $args;
 	}
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -32,6 +32,7 @@ class Admin {
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu' ) );
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
+		add_filter( 'users_list_table_query_args', [ __CLASS__, 'users_list_table_query_args' ] );
 	}
 
 	/**
@@ -190,5 +191,20 @@ class Admin {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
+	}
+
+	/**
+	 * Handle the filtering of users by multiple roles.
+	 * Unfortunatelly, `get_views` and `get_views_links` are not filterable, so "All" will
+	 * be displayed as the active filter.
+	 *
+	 * @param array $args The current query args.
+	 */
+	public static function users_list_table_query_args( $args ) {
+		if ( isset( $_REQUEST['role__in'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$args['role__in'] = explode( ',', sanitize_text_field( $_REQUEST['role__in'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			unset( $args['role'] );
+		}
+		return $args;
 	}
 }

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -17,6 +17,7 @@ class Initializer {
 	 */
 	public static function init() {
 		Admin::init();
+		Users::init();
 
 		if ( Site_Role::is_hub() ) {
 			Hub\Admin::init();

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -37,6 +37,7 @@ class Initializer {
 		if ( Site_Role::is_node() ) {
 			if ( Node\Settings::get_hub_url() ) {
 				Node\Webhook::init();
+				Node\Info_Endpoints::init();
 				Node\Pulling::init();
 				Rest_Authenticaton::init_node_filters();
 			}

--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -31,6 +31,7 @@ class Users {
 		if ( Site_Role::is_hub() ) {
 			$columns['newspack_network_activity'] = __( 'Newspack Network Activity', 'newspack-network' );
 		}
+		$columns['newspack_network_user'] = __( 'Network Original User', 'newspack-network' );
 		return $columns;
 	}
 
@@ -43,6 +44,18 @@ class Users {
 	 * @return string
 	 */
 	public static function manage_users_custom_column( $value, $column_name, $user_id ) {
+		if ( 'newspack_network_user' === $column_name ) {
+			$remote_site = get_user_meta( $user_id, \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE, true );
+			$remote_id = (int) get_user_meta( $user_id, \Newspack_Network\Utils\Users::USER_META_REMOTE_ID, true );
+			if ( $remote_site ) {
+				return sprintf(
+					'<a href="%swp-admin/user-edit.php?user_id=%d">%s</a>',
+					trailingslashit( esc_url( $remote_site ) ),
+					$remote_id,
+					sprintf( '%s (#%d)', $remote_site, $remote_id )
+				);
+			}
+		}
 		if ( 'newspack_network_activity' === $column_name && Site_Role::is_hub() ) {
 			$user = get_user_by( 'id', $user_id );
 			if ( ! $user ) {

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Network\Backfillers;
 
+use WP_CLI;
+
 /**
  * Backfiller class.
  */
@@ -29,10 +31,14 @@ class Reader_Registered extends Abstract_Backfiller {
 	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
 	 */
 	public function get_events() {
+		$roles_to_sync = \Newspack_Network\Utils\Users::get_synced_user_roles();
+		if ( $roles_to_sync === [] ) {
+			WP_CLI::error( 'Incompatible Newspack plugin version or no roles to sync.' );
+		}
 		// Get all users registered between this-> and $end.
 		$users = get_users(
 			[
-				'role__in'   => \Newspack\Reader_Activation::get_reader_roles(),
+				'role__in'   => $roles_to_sync,
 				'date_query' => [
 					'after'     => $this->start,
 					'before'    => $this->end,
@@ -48,6 +54,8 @@ class Reader_Registered extends Abstract_Backfiller {
 				],
 			]
 		);
+
+		WP_CLI::line( sprintf( 'Found %s users eligible for sync.', count( $users ) ) );
 
 		$this->maybe_initialize_progress_bar( 'Processing users', count( $users ) );
 

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -118,9 +118,6 @@ class Data_Backfill {
 		}
 		WP_CLI::line( '' );
 
-		if ( ! method_exists( '\Newspack\Reader_Activation', 'get_reader_roles' ) ) {
-			WP_CLI::error( 'Incompatible Newspack plugin version.' );
-		}
 		if ( $live ) {
 			WP_CLI::line( '⚡️ Heads up! Running live, data will be updated.' );
 		} else {

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -36,6 +36,16 @@ class Nodes_List {
 	public static function posts_columns( $columns ) {
 		unset( $columns['date'] );
 		unset( $columns['stats'] );
+		$sync_users_info = sprintf(
+			' <span class="dashicons dashicons-info-outline" title="%s"></span>',
+			sprintf(
+				/* translators: list of user roles which will entail synchronization */
+				esc_attr__( 'Users with the following roles: %1$s (%2$d on the Hub)', 'newspack-network' ),
+				implode( ', ', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
+				\Newspack_Network\Utils\Users::get_synchronized_users_count()
+			)
+		);
+		$columns['sync_users'] = __( 'Synchronized Users', 'newspack-network' ) . $sync_users_info;
 		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;
 	}
@@ -48,8 +58,8 @@ class Nodes_List {
 	 * @return void
 	 */
 	public static function posts_columns_values( $column, $post_id ) {
+		$node = new Node( $post_id );
 		if ( 'links' === $column ) {
-			$node         = new Node( $post_id );
 			$links        = array_map(
 				function ( $bookmark ) {
 					return sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $bookmark['url'] ), esc_html( $bookmark['label'] ) );
@@ -66,6 +76,17 @@ class Nodes_List {
 				<p>
 					<?php echo wp_kses( implode( ' | ', $links ), $allowed_tags ); ?>
 				</p>
+			<?php
+		}
+		if ( 'sync_users' === $column ) {
+			$users_link = add_query_arg(
+				[
+					'role__in' => implode( ',', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
+				],
+				trailingslashit( $node->get_url() ) . 'wp-admin/users.php'
+			);
+			?>
+				<a href="<?php echo esc_url( $users_link ); ?>"><?php echo esc_html( $node->get_sync_users_count() ); ?></a>
 			<?php
 		}
 	}

--- a/includes/hub/admin/css/nodes-list.css
+++ b/includes/hub/admin/css/nodes-list.css
@@ -3,3 +3,7 @@
     width: 40%;
     text-align: left;
 }
+.dashicons-info-outline{
+    cursor: help;
+    opacity: 0.8;
+}

--- a/includes/hub/class-admin.php
+++ b/includes/hub/class-admin.php
@@ -20,7 +20,6 @@ class Admin {
 		Admin\Subscriptions::init();
 		Admin\Orders::init();
 		Admin\Membership_Plans::init();
-		Admin\Users::init();
 		Admin\Nodes_List::init();
 		Distributor_Settings::init();
 	}

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -170,4 +170,25 @@ class Node {
 
 		return self::generate_bookmarks( $base_url );
 	}
+
+	/**
+	 * Get site info.
+	 */
+	private function get_site_info() {
+		$response = wp_remote_get( // phpcs:ignore
+			$this->get_url() . '/wp-json/newspack-network/v1/info',
+			[
+				'headers' => $this->get_authorization_headers( 'info' ),
+			]
+		);
+		return json_decode( wp_remote_retrieve_body( $response ) );
+	}
+
+	/**
+	 * Get synchronized users count.
+	 */
+	public function get_sync_users_count() {
+		$site_info = $this->get_site_info();
+		return $site_info->sync_users_count ?? 0;
+	}
 }

--- a/includes/node/class-info-endpoints.php
+++ b/includes/node/class-info-endpoints.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Newspack Network Node site info handler.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Node;
+
+use Newspack_Network\Accepted_Actions;
+use Newspack_Network\Crypto;
+
+/**
+ * Class that register the webhook endpoint that will send events to the Hub
+ */
+class Info_Endpoints {
+	/**
+	 * Runs the initialization.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+	}
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			'newspack-network/v1',
+			'/info',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_info_request' ],
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Handles the info request.
+	 */
+	public static function handle_info_request() {
+		return rest_ensure_response(
+			[
+				'sync_users_count' => \Newspack_Network\Utils\Users::get_synchronized_users_count(),
+			]
+		);
+	}
+}

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -114,4 +114,28 @@ class Users {
 		Debugger::log( 'No avatar found in user data' );
 		return false;
 	}
+
+	/**
+	 * Get synchronization-entailing user roles.
+	 */
+	public static function get_synced_user_roles() {
+		if ( ! method_exists( '\Newspack\Reader_Activation', 'get_reader_roles' ) ) {
+			return [];
+		}
+		return \Newspack\Reader_Activation::get_reader_roles();
+	}
+
+	/**
+	 * Get synchronized users count.
+	 */
+	public static function get_synchronized_users_count() {
+		$users = get_users(
+			[
+				'role__in' => self::get_synced_user_roles(),
+				'fields'   => [ 'id' ],
+				'number'   => -1,
+			]
+		);
+		return count( $users );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds two features, which will be useful when auditing user synchronisation:

1. New column in the WP Users view, featuring origin site URL and User ID on that site (the text is a link to the user edit screen):

<img width="1974" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/4ce3bbc5-af95-4584-b871-3ef29d8f9246">

2. New column in the Nodes table, displaying synchronisable users count:

<img width="1124" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/77d6ccff-9542-4bea-93bf-86a6b704d89d"> 

### How to test the changes in this Pull Request:

1. Visit WP Users tables on the Hub and Node sites, verify the new column features correct data and links
4. Visit the Nodes table on the Hub site, verify the user counts match 
5. Click the user counts, observe the links point to WP Users table filtered by synchronized roles

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->