### PR TITLE
Experimental auditing features

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -194,6 +194,8 @@ class Admin {
 
 	/**
 	 * Has experimental auditing features?
+	 *
+	 * @return bool True if experimental auditing features are enabled.
 	 */
 	public static function use_experimental_auditing_features() {
 		$user_slug = defined( 'NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_USER' ) ? NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_USER : false;

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -32,7 +32,6 @@ class Admin {
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu' ) );
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
-		add_filter( 'users_list_table_query_args', [ __CLASS__, 'users_list_table_query_args' ] );
 	}
 
 	/**
@@ -191,20 +190,5 @@ class Admin {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
-	}
-
-	/**
-	 * Handle the filtering of users by multiple roles.
-	 * Unfortunatelly, `get_views` and `get_views_links` are not filterable, so "All" will
-	 * be displayed as the active filter.
-	 *
-	 * @param array $args The current query args.
-	 */
-	public static function users_list_table_query_args( $args ) {
-		if ( isset( $_REQUEST['role__in'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$args['role__in'] = explode( ',', sanitize_text_field( $_REQUEST['role__in'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			unset( $args['role'] );
-		}
-		return $args;
 	}
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -191,4 +191,16 @@ class Admin {
 	 */
 	public static function enqueue_scripts() {
 	}
+
+	/**
+	 * Has experimental auditing features?
+	 */
+	public static function use_experimental_auditing_features() {
+		$user_slug = defined( 'NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_USER' ) ? NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_USER : false;
+		if ( ! $user_slug ) {
+			return false;
+		}
+		$user = get_user_by( 'login', $user_slug );
+		return $user && get_current_user_id() === $user->ID;
+	}
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -32,6 +32,7 @@ class Admin {
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu' ) );
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
+		add_filter( 'users_list_table_query_args', [ __CLASS__, 'users_list_table_query_args' ] );
 	}
 
 	/**
@@ -190,5 +191,20 @@ class Admin {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
+	}
+
+	/**
+	 * Handle the filtering of users by multiple roles.
+	 * Unfortunatelly, `get_views` and `get_views_links` are not filterable, so "All" will
+	 * be displayed as the active filter.
+	 *
+	 * @param array $args The current query args.
+	 */
+	public static function users_list_table_query_args( $args ) {
+		if ( isset( $_REQUEST['role__in'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$args['role__in'] = explode( ',', sanitize_text_field( $_REQUEST['role__in'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			unset( $args['role'] );
+		}
+		return $args;
 	}
 }

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -17,6 +17,7 @@ class Initializer {
 	 */
 	public static function init() {
 		Admin::init();
+		Users::init();
 
 		if ( Site_Role::is_hub() ) {
 			Hub\Admin::init();

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -37,6 +37,7 @@ class Initializer {
 		if ( Site_Role::is_node() ) {
 			if ( Node\Settings::get_hub_url() ) {
 				Node\Webhook::init();
+				Node\Info_Endpoints::init();
 				Node\Pulling::init();
 				Rest_Authenticaton::init_node_filters();
 			}

--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -31,6 +31,7 @@ class Users {
 		if ( Site_Role::is_hub() ) {
 			$columns['newspack_network_activity'] = __( 'Newspack Network Activity', 'newspack-network' );
 		}
+		$columns['newspack_network_user'] = __( 'Network Original User', 'newspack-network' );
 		return $columns;
 	}
 
@@ -43,6 +44,18 @@ class Users {
 	 * @return string
 	 */
 	public static function manage_users_custom_column( $value, $column_name, $user_id ) {
+		if ( 'newspack_network_user' === $column_name ) {
+			$remote_site = get_user_meta( $user_id, \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE, true );
+			$remote_id = (int) get_user_meta( $user_id, \Newspack_Network\Utils\Users::USER_META_REMOTE_ID, true );
+			if ( $remote_site ) {
+				return sprintf(
+					'<a href="%swp-admin/user-edit.php?user_id=%d">%s</a>',
+					trailingslashit( esc_url( $remote_site ) ),
+					$remote_id,
+					sprintf( '%s (#%d)', $remote_site, $remote_id )
+				);
+			}
+		}
 		if ( 'newspack_network_activity' === $column_name && Site_Role::is_hub() ) {
 			$user = get_user_by( 'id', $user_id );
 			if ( ! $user ) {

--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -31,7 +31,9 @@ class Users {
 		if ( Site_Role::is_hub() ) {
 			$columns['newspack_network_activity'] = __( 'Newspack Network Activity', 'newspack-network' );
 		}
-		$columns['newspack_network_user'] = __( 'Network Original User', 'newspack-network' );
+		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+			$columns['newspack_network_user'] = __( 'Network Original User', 'newspack-network' );
+		}
 		return $columns;
 	}
 

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Network\Backfillers;
 
+use WP_CLI;
+
 /**
  * Backfiller class.
  */
@@ -29,10 +31,14 @@ class Reader_Registered extends Abstract_Backfiller {
 	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
 	 */
 	public function get_events() {
+		$roles_to_sync = \Newspack_Network\Utils\Users::get_synced_user_roles();
+		if ( $roles_to_sync === [] ) {
+			WP_CLI::error( 'Incompatible Newspack plugin version or no roles to sync.' );
+		}
 		// Get all users registered between this-> and $end.
 		$users = get_users(
 			[
-				'role__in'   => \Newspack\Reader_Activation::get_reader_roles(),
+				'role__in'   => $roles_to_sync,
 				'date_query' => [
 					'after'     => $this->start,
 					'before'    => $this->end,
@@ -48,6 +54,8 @@ class Reader_Registered extends Abstract_Backfiller {
 				],
 			]
 		);
+
+		WP_CLI::line( sprintf( 'Found %s users eligible for sync.', count( $users ) ) );
 
 		$this->maybe_initialize_progress_bar( 'Processing users', count( $users ) );
 

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -32,7 +32,7 @@ class Reader_Registered extends Abstract_Backfiller {
 	 */
 	public function get_events() {
 		$roles_to_sync = \Newspack_Network\Utils\Users::get_synced_user_roles();
-		if ( $roles_to_sync === [] ) {
+		if ( empty( $roles_to_sync ) ) {
 			WP_CLI::error( 'Incompatible Newspack plugin version or no roles to sync.' );
 		}
 		// Get all users registered between this-> and $end.
@@ -55,7 +55,7 @@ class Reader_Registered extends Abstract_Backfiller {
 			]
 		);
 
-		WP_CLI::line( sprintf( 'Found %s users eligible for sync.', count( $users ) ) );
+		WP_CLI::line( sprintf( 'Found %s user(s) eligible for sync.', count( $users ) ) );
 
 		$this->maybe_initialize_progress_bar( 'Processing users', count( $users ) );
 

--- a/includes/cli/class-data-backfill.php
+++ b/includes/cli/class-data-backfill.php
@@ -118,9 +118,6 @@ class Data_Backfill {
 		}
 		WP_CLI::line( '' );
 
-		if ( ! method_exists( '\Newspack\Reader_Activation', 'get_reader_roles' ) ) {
-			WP_CLI::error( 'Incompatible Newspack plugin version.' );
-		}
 		if ( $live ) {
 			WP_CLI::line( '⚡️ Heads up! Running live, data will be updated.' );
 		} else {

--- a/includes/hub/admin/class-membership-plans-table.php
+++ b/includes/hub/admin/class-membership-plans-table.php
@@ -56,15 +56,19 @@ class Membership_Plans_Table extends \WP_List_Table {
 		}
 		if ( $column_name === 'network_pass_discrepancies' && isset( $item['network_pass_discrepancies'] ) && $item['network_pass_id'] ) {
 			$discrepancies = $item['network_pass_discrepancies'];
+			$count = count( $discrepancies );
+			if ( $count === 0 ) {
+				return esc_html__( 'None', 'newspack-network' );
+			}
 			return sprintf(
 				/* translators: %d is the number of members */
 				_n(
 					'%d member doesn\'t match the shared member pool',
 					'%d members don\'t match the shared member pool',
-					count( $discrepancies ),
+					$count,
 					'newspack-plugin'
 				),
-				count( $discrepancies )
+				$count
 			);
 		}
 		if ( $column_name === 'links' ) {

--- a/includes/hub/admin/class-membership-plans-table.php
+++ b/includes/hub/admin/class-membership-plans-table.php
@@ -48,6 +48,7 @@ class Membership_Plans_Table extends \WP_List_Table {
 			$columns['node_url'] = __( 'Node URL', 'newspack-network' );
 		}
 		$columns['network_pass_id'] = __( 'Network ID', 'newspack-network' );
+		$columns['active_members_count'] = __( 'Active Members', 'newspack-network' );
 		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;
 	}

--- a/includes/hub/admin/class-membership-plans-table.php
+++ b/includes/hub/admin/class-membership-plans-table.php
@@ -25,10 +25,10 @@ class Membership_Plans_Table extends \WP_List_Table {
 			'id'   => __( 'ID', 'newspack-network' ),
 			'name' => __( 'Name', 'newspack-network' ),
 		];
-		$columns['node_url'] = __( 'Site URL', 'newspack-network' );
+		$columns['site_url'] = __( 'Site URL', 'newspack-network' );
 		$columns['network_pass_id'] = __( 'Network ID', 'newspack-network' );
-		$columns['active_members_count'] = __( 'Active Members', 'newspack-network' );
-		if ( Membership_Plans::use_experimental_auditing_features() ) {
+		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+			$columns['active_members_count'] = __( 'Active Members', 'newspack-network' );
 			$columns['network_pass_discrepancies'] = __( 'Discrepancies', 'newspack-network' );
 		}
 		$columns['links'] = __( 'Links', 'newspack-network' );
@@ -68,11 +68,12 @@ class Membership_Plans_Table extends \WP_List_Table {
 			);
 		}
 		if ( $column_name === 'links' ) {
-			$edit_url = get_edit_post_link( $item['id'] );
-			if ( isset( $item['node_url'] ) ) {
-				$edit_url = sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $item['node_url'], $item['id'] );
-			}
+			$edit_url = sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $item['site_url'], $item['id'] );
 			return sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), esc_html__( 'Edit', 'newspack-network' ) );
+		}
+		if ( $column_name === 'active_members_count' && $item[ $column_name ] ) {
+			$list_url = sprintf( '%s/wp-admin/edit.php?s&post_status=wcm-active&post_type=wc_user_membership&post_parent=%d', $item['site_url'], $item['id'] );
+			return sprintf( '<a href="%s">%s</a>', esc_url( $list_url ), $item[ $column_name ] );
 		}
 		return isset( $item[ $column_name ] ) ? $item[ $column_name ] : '';
 	}

--- a/includes/hub/admin/class-membership-plans-table.php
+++ b/includes/hub/admin/class-membership-plans-table.php
@@ -51,6 +51,8 @@ class Membership_Plans_Table extends \WP_List_Table {
 	 * @return string
 	 */
 	public function column_default( $item, $column_name ) {
+		$memberships_list_url = sprintf( '%s/wp-admin/edit.php?s&post_status=wcm-active&post_type=wc_user_membership&post_parent=%d', $item['site_url'], $item['id'] );
+
 		if ( $column_name === 'network_pass_id' && $item[ $column_name ] ) {
 			return sprintf( '<code>%s</code>', $item[ $column_name ] );
 		}
@@ -60,7 +62,13 @@ class Membership_Plans_Table extends \WP_List_Table {
 			if ( $count === 0 ) {
 				return esc_html__( 'None', 'newspack-network' );
 			}
-			return sprintf(
+
+			$memberships_list_url_with_emails_url = add_query_arg(
+				\Newspack_Network\Woocommerce_Memberships\Admin::MEMBERSHIPS_TABLE_EMAILS_QUERY_PARAM,
+				implode( ',', $discrepancies ),
+				$memberships_list_url
+			);
+			$message = sprintf(
 				/* translators: %d is the number of members */
 				_n(
 					'%d member doesn\'t match the shared member pool',
@@ -70,14 +78,14 @@ class Membership_Plans_Table extends \WP_List_Table {
 				),
 				$count
 			);
+			return sprintf( '<a href="%s">%s</a>', esc_url( $memberships_list_url_with_emails_url ), esc_html( $message ) );
 		}
 		if ( $column_name === 'links' ) {
 			$edit_url = sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $item['site_url'], $item['id'] );
 			return sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), esc_html__( 'Edit', 'newspack-network' ) );
 		}
 		if ( $column_name === 'active_members_count' && $item[ $column_name ] ) {
-			$list_url = sprintf( '%s/wp-admin/edit.php?s&post_status=wcm-active&post_type=wc_user_membership&post_parent=%d', $item['site_url'], $item['id'] );
-			return sprintf( '<a href="%s">%s</a>', esc_url( $list_url ), $item[ $column_name ] );
+			return sprintf( '<a href="%s">%s</a>', esc_url( $memberships_list_url ), $item[ $column_name ] );
 		}
 		return isset( $item[ $column_name ] ) ? $item[ $column_name ] : '';
 	}

--- a/includes/hub/admin/class-membership-plans.php
+++ b/includes/hub/admin/class-membership-plans.php
@@ -124,10 +124,11 @@ abstract class Membership_Plans {
 					}
 				}
 				$membership_plans[] = [
-					'id'              => $plan->id,
-					'node_url'        => $node->get_url(),
-					'name'            => $plan->name,
-					'network_pass_id' => $network_pass_id,
+					'id'                   => $plan->id,
+					'node_url'             => $node->get_url(),
+					'name'                 => $plan->name,
+					'network_pass_id'      => $network_pass_id,
+					'active_members_count' => $plan->active_members_count,
 				];
 			}
 		}
@@ -149,9 +150,10 @@ abstract class Membership_Plans {
 		}
 		foreach ( wc_memberships_get_membership_plans() as $plan ) {
 			$membership_plans[] = [
-				'id'              => $plan->post->ID,
-				'name'            => $plan->post->post_title,
-				'network_pass_id' => get_post_meta( $plan->post->ID, \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true ),
+				'id'                   => $plan->post->ID,
+				'name'                 => $plan->post->post_title,
+				'network_pass_id'      => get_post_meta( $plan->post->ID, \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true ),
+				'active_members_count' => $plan->get_memberships_count( 'active' ),
 			];
 		}
 		return $membership_plans;

--- a/includes/hub/admin/class-membership-plans.php
+++ b/includes/hub/admin/class-membership-plans.php
@@ -78,7 +78,7 @@ abstract class Membership_Plans {
 	 */
 	public static function fetch_collection_from_api( $node, $collection_endpoint, $collection_endpoint_id ) {
 		$endpoint = sprintf( '%s/wp-json/%s', $node->get_url(), $collection_endpoint );
-		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+		if ( Network_Admin::use_experimental_auditing_features() ) {
 			$endpoint = add_query_arg( 'include_active_members_emails', 1, $endpoint );
 		}
 		$response = wp_remote_get( // phpcs:ignore
@@ -112,7 +112,7 @@ abstract class Membership_Plans {
 		$by_network_pass_id = [];
 		$membership_plans = [];
 
-		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+		if ( Network_Admin::use_experimental_auditing_features() ) {
 			$local_membership_plans = self::get_local_membership_plans();
 			foreach ( $local_membership_plans as $local_plan ) {
 				if ( $local_plan['network_pass_id'] ) {
@@ -132,7 +132,7 @@ abstract class Membership_Plans {
 						$network_pass_id = $meta->value;
 					}
 				}
-				if ( $network_pass_id && \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+				if ( $network_pass_id && Network_Admin::use_experimental_auditing_features() ) {
 					if ( ! isset( $by_network_pass_id[ $network_pass_id ] ) ) {
 						$by_network_pass_id[ $network_pass_id ] = [];
 					}
@@ -148,7 +148,7 @@ abstract class Membership_Plans {
 			}
 		}
 
-		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+		if ( Network_Admin::use_experimental_auditing_features() ) {
 			$discrepancies = [];
 			foreach ( $by_network_pass_id as $plan_network_pass_id => $by_site ) {
 				$shared_emails = array_intersect( ...array_values( $by_site ) );
@@ -194,7 +194,7 @@ abstract class Membership_Plans {
 				'network_pass_id'      => get_post_meta( $plan->post->ID, \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true ),
 				'active_members_count' => $plan->get_memberships_count( 'active' ),
 			];
-			if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+			if ( Network_Admin::use_experimental_auditing_features() ) {
 				$plan_data['active_members_emails'] = \Newspack_Network\Woocommerce_Memberships\Admin::get_active_members_emails( $plan );
 			}
 			$membership_plans[] = $plan_data;

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -36,6 +36,16 @@ class Nodes_List {
 	public static function posts_columns( $columns ) {
 		unset( $columns['date'] );
 		unset( $columns['stats'] );
+		$sync_users_info = sprintf(
+			' <span class="dashicons dashicons-info-outline" title="%s"></span>',
+			sprintf(
+				/* translators: list of user roles which will entail synchronization */
+				esc_attr__( 'Users with the following roles: %1$s (%2$d on the Hub)', 'newspack-network' ),
+				implode( ', ', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
+				\Newspack_Network\Utils\Users::get_synchronized_users_count()
+			)
+		);
+		$columns['sync_users'] = __( 'Synchronized Users', 'newspack-network' ) . $sync_users_info;
 		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;
 	}
@@ -48,8 +58,8 @@ class Nodes_List {
 	 * @return void
 	 */
 	public static function posts_columns_values( $column, $post_id ) {
+		$node = new Node( $post_id );
 		if ( 'links' === $column ) {
-			$node         = new Node( $post_id );
 			$links        = array_map(
 				function ( $bookmark ) {
 					return sprintf( '<a href="%s" target="_blank">%s</a>', esc_url( $bookmark['url'] ), esc_html( $bookmark['label'] ) );
@@ -66,6 +76,17 @@ class Nodes_List {
 				<p>
 					<?php echo wp_kses( implode( ' | ', $links ), $allowed_tags ); ?>
 				</p>
+			<?php
+		}
+		if ( 'sync_users' === $column ) {
+			$users_link = add_query_arg(
+				[
+					'role__in' => implode( ',', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
+				],
+				trailingslashit( $node->get_url() ) . 'wp-admin/users.php'
+			);
+			?>
+				<a href="<?php echo esc_url( $users_link ); ?>"><?php echo esc_html( $node->get_sync_users_count() ); ?></a>
 			<?php
 		}
 	}

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -36,16 +36,18 @@ class Nodes_List {
 	public static function posts_columns( $columns ) {
 		unset( $columns['date'] );
 		unset( $columns['stats'] );
-		$sync_users_info = sprintf(
-			' <span class="dashicons dashicons-info-outline" title="%s"></span>',
-			sprintf(
-				/* translators: list of user roles which will entail synchronization */
-				esc_attr__( 'Users with the following roles: %1$s (%2$d on the Hub)', 'newspack-network' ),
-				implode( ', ', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
-				\Newspack_Network\Utils\Users::get_synchronized_users_count()
-			)
-		);
-		$columns['sync_users'] = __( 'Synchronized Users', 'newspack-network' ) . $sync_users_info;
+		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+			$sync_users_info = sprintf(
+				' <span class="dashicons dashicons-info-outline" title="%s"></span>',
+				sprintf(
+					/* translators: list of user roles which will entail synchronization */
+					esc_attr__( 'Users with the following roles: %1$s (%2$d on the Hub)', 'newspack-network' ),
+					implode( ', ', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
+					\Newspack_Network\Utils\Users::get_synchronized_users_count()
+				)
+			);
+			$columns['sync_users'] = __( 'Synchronized Users', 'newspack-network' ) . $sync_users_info;
+		}
 		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;
 	}

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -46,7 +46,7 @@ class Nodes_List {
 					\Newspack_Network\Utils\Users::get_synchronized_users_count()
 				)
 			);
-			$columns['sync_users'] = __( 'Synchronized Users', 'newspack-network' ) . $sync_users_info;
+			$columns['sync_users'] = __( 'Synchronizable Users', 'newspack-network' ) . $sync_users_info;
 		}
 		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;

--- a/includes/hub/admin/class-woo.php
+++ b/includes/hub/admin/class-woo.php
@@ -39,7 +39,7 @@ abstract class Woo {
 		$class_name         = get_called_class();
 		$db_class_name      = str_replace( 'Admin', 'Database', $class_name );
 		self::$post_types[] = $db_class_name::POST_TYPE_SLUG;
-		
+
 		// Removes the Bulk actions dropdown.
 		add_filter( 'bulk_actions-edit-' . $db_class_name::POST_TYPE_SLUG, '__return_empty_array' );
 
@@ -158,7 +158,7 @@ abstract class Woo {
 		if ( 'edit.php' !== $pagenow || ! in_array( $post_type, self::$post_types, true ) || ! is_admin() || ! $query->is_main_query() ) {
 			return null;
 		}
-		
+
 		if ( ! isset( $_GET['node_id'] ) || ! is_numeric( $_GET['node_id'] ) ) { // zero is a valid value.
 			return null;
 		}
@@ -178,7 +178,6 @@ abstract class Woo {
 	 */
 	public static function parse_query( $query ) {
 		global $pagenow;
-
 		if ( ! is_admin() || 'edit.php' !== $pagenow || empty( $query->query_vars['s'] ) || ! in_array( $query->query_vars['post_type'], self::$post_types, true ) ) {
 			return;
 		}

--- a/includes/hub/admin/css/nodes-list.css
+++ b/includes/hub/admin/css/nodes-list.css
@@ -3,3 +3,7 @@
     width: 40%;
     text-align: left;
 }
+.dashicons-info-outline{
+    cursor: help;
+    opacity: 0.8;
+}

--- a/includes/hub/class-admin.php
+++ b/includes/hub/class-admin.php
@@ -20,7 +20,6 @@ class Admin {
 		Admin\Subscriptions::init();
 		Admin\Orders::init();
 		Admin\Membership_Plans::init();
-		Admin\Users::init();
 		Admin\Nodes_List::init();
 		Distributor_Settings::init();
 	}

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -170,4 +170,25 @@ class Node {
 
 		return self::generate_bookmarks( $base_url );
 	}
+
+	/**
+	 * Get site info.
+	 */
+	private function get_site_info() {
+		$response = wp_remote_get( // phpcs:ignore
+			$this->get_url() . '/wp-json/newspack-network/v1/info',
+			[
+				'headers' => $this->get_authorization_headers( 'info' ),
+			]
+		);
+		return json_decode( wp_remote_retrieve_body( $response ) );
+	}
+
+	/**
+	 * Get synchronized users count.
+	 */
+	public function get_sync_users_count() {
+		$site_info = $this->get_site_info();
+		return $site_info->sync_users_count ?? 0;
+	}
 }

--- a/includes/node/class-info-endpoints.php
+++ b/includes/node/class-info-endpoints.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Newspack Network Node site info handler.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Node;
+
+use Newspack_Network\Accepted_Actions;
+use Newspack_Network\Crypto;
+
+/**
+ * Class that register the webhook endpoint that will send events to the Hub
+ */
+class Info_Endpoints {
+	/**
+	 * Runs the initialization.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+	}
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			'newspack-network/v1',
+			'/info',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_info_request' ],
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Handles the info request.
+	 */
+	public static function handle_info_request() {
+		return rest_ensure_response(
+			[
+				'sync_users_count' => \Newspack_Network\Utils\Users::get_synchronized_users_count(),
+			]
+		);
+	}
+}

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -114,4 +114,28 @@ class Users {
 		Debugger::log( 'No avatar found in user data' );
 		return false;
 	}
+
+	/**
+	 * Get synchronization-entailing user roles.
+	 */
+	public static function get_synced_user_roles() {
+		if ( ! method_exists( '\Newspack\Reader_Activation', 'get_reader_roles' ) ) {
+			return [];
+		}
+		return \Newspack\Reader_Activation::get_reader_roles();
+	}
+
+	/**
+	 * Get synchronized users count.
+	 */
+	public static function get_synchronized_users_count() {
+		$users = get_users(
+			[
+				'role__in' => self::get_synced_user_roles(),
+				'fields'   => [ 'id' ],
+				'number'   => -1,
+			]
+		);
+		return count( $users );
+	}
 }

--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -62,6 +62,22 @@ class Admin {
 	}
 
 	/**
+	 * Get active members' emails.
+	 *
+	 * @param \WC_Memberships_Membership_Plan $plan the membership plan.
+	 */
+	public static function get_active_members_emails( $plan ) {
+		$active_memberships = $plan->get_memberships( [ 'post_status' => 'wcm-active' ] );
+		return array_map(
+			function ( $membership ) {
+				$user = get_user_by( 'id', $membership->get_user_id() );
+				return $user->user_email;
+			},
+			$active_memberships
+		);
+	}
+
+	/**
 	 * Filter membership plans to add user count.
 	 *
 	 * @param array                           $data associative array of membership plan data.
@@ -71,6 +87,9 @@ class Admin {
 	public static function add_data_to_membership_plan_response( $data, $plan, $request ) {
 		if ( $request && isset( $request->get_headers()['x_np_network_signature'] ) ) {
 			$data['active_members_count'] = $plan->get_memberships_count( 'active' );
+			if ( $request->get_param( 'include_active_members_emails' ) ) {
+				$data['active_members_emails'] = self::get_active_members_emails( $plan );
+			}
 		}
 		return $data;
 	}

--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -58,6 +58,21 @@ class Admin {
 		add_filter( 'get_edit_post_link', array( __CLASS__, 'get_edit_post_link' ), 10, 2 );
 		add_filter( 'post_row_actions', array( __CLASS__, 'post_row_actions' ), 99, 2 ); // After the Memberships plugin.
 		add_filter( 'map_meta_cap', array( __CLASS__, 'map_meta_cap' ), 20, 4 );
+		add_filter( 'wc_memberships_rest_api_membership_plan_data', [ __CLASS__, 'add_data_to_membership_plan_response' ], 2, 3 );
+	}
+
+	/**
+	 * Filter membership plans to add user count.
+	 *
+	 * @param array                           $data associative array of membership plan data.
+	 * @param \WC_Memberships_Membership_Plan $plan the membership plan.
+	 * @param null|\WP_REST_Request           $request The request object.
+	 */
+	public static function add_data_to_membership_plan_response( $data, $plan, $request ) {
+		if ( $request && isset( $request->get_headers()['x_np_network_signature'] ) ) {
+			$data['active_members_count'] = $plan->get_memberships_count( 'active' );
+		}
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A few auditing features, for now restricted to a specific WP user. 

1. In the Membership Plans view, the tables are now unified. Two columns are added to help with auditing the synchronisation:

<img width="1214" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/3249809c-e798-4867-b7cc-19d9b3848d03">

2. New column in the WP Users view, featuring origin site URL and User ID on that site (the text is a link to the user edit screen):

<img width="1974" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/4ce3bbc5-af95-4584-b871-3ef29d8f9246">

4. New column in the Nodes table, displaying synchronisable users count:

<img width="1122" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/cf1abd07-c742-4e20-b6b3-7e63875d4149">

### How to test the changes in this Pull Request:

1. Verify none of the features are visible until the next step is done
2. Set `NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_USER` wp-config variable, with the value of the admin user you're using (e.g. `admin`)
1. Visit **WP Users** tables (`/wp-admin?users.php`) on the Hub and Node sites, verify the new column features correct data and links
1. Visit the **"Nodes" view** on the Hub site
    1. Click the user counts, observe the links point to WP Users table filtered by synchronized roles
    1. Visit the corresponding Node sites, confirm the numbers are correct
1. Visit the **"Membership Plans" view** on the Hub site 
    1. observe a new "Active Members" column
    1. Observe a new "Discrepancies" column and verify the discrepancies between synchronised plan members*
    2. Click the link to view the discrepant members

\* to create some discrepancies, add plan members and then quickly remove the corresponding event (`wp_newspack_hub_event_log` table) or webhook (`np_webhook_request` post type), if on hub or node, respectively

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->