### PR TITLE
feat(manual-user-sync): sync user login

### DIFF
--- a/includes/class-user-manual-sync.php
+++ b/includes/class-user-manual-sync.php
@@ -58,11 +58,12 @@ class User_Manual_Sync {
 		}
 
 		return [
-			'email'   => $user_data->user_email,
-			'role'    => array_shift( $user_data->roles ),
-			'user_id' => $user_data->ID,
-			'meta'    => $synced_metadata,
-			'prop'    => $synced_props,
+			'email'      => $user_data->user_email,
+			'role'       => array_shift( $user_data->roles ),
+			'user_id'    => $user_data->ID,
+			'meta'       => $synced_metadata,
+			'prop'       => $synced_props,
+			'user_login' => $user_data->user_login,
 		];
 	}
 

--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -66,7 +66,7 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 			$user = User_Utils::get_or_create_user_by_email(
 				$email,
 				$this->get_site(),
-				$this->data->user_id ?? '',
+				$this->data->user_id ?? ''
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Amends the manual user sync feature (#53), so that the user login is synced, too. 

### How to test the changes in this Pull Request:

1. On the Hub site, create an `editor`-role* user
2. Click "Sync user across network" button on the WP Admin user view
3. After the user is propageated**, verify the user login is the same on both sites

\* just a role that would not be sync'd automatically
\** can be expedited by running `wp newspack-network sync-all` on a Node site

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->