### PR TITLE
feat: add Network-specific custom metadata to ESP syncs

### DIFF
--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -50,8 +50,6 @@ class Esp_Metadata_Sync {
 			$metadata['network_registration_site'] = \esc_url( \get_site_url() );
 		}
 
-		error_log( print_r( $metadata, true ) );
-
 		return $metadata;
 	}
 }

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Newspack Hub ESP Metadata settings
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+/**
+ * Class to handle Node settings page
+ */
+class Esp_Metadata_Sync {
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		\add_filter( 'newspack_ras_metadata_keys', [ __CLASS__, 'add_custom_metadata_fields' ] );
+		\add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
+	}
+
+	/**
+	 * Adds Network-specific metadata fields to the list of ESP metadata fields.
+	 *
+	 * @param array $metadata_fields The list of ESP metadata fields.
+	 *
+	 * @return array The updated list of ESP metadata fields.
+	 */
+	public static function add_custom_metadata_fields( $metadata_fields ) {
+		if ( ! isset( $metadata_fields['network_registration_site'] ) ) {
+			$metadata_fields['network_registration_site'] = 'Network Registration Site';
+		}
+
+		return $metadata_fields;
+	}
+
+	/**
+	 * Add handling for custom metadata fields. Only fire for newly created users.
+	 *
+	 * @param array     $metadata The contact metadata data.
+	 * @param int|false $user_id Created user ID, or false if the user already exists.
+	 *
+	 * @return array The updated contact data.
+	 */
+	public static function handle_custom_metadata_fields( $metadata, $user_id ) {
+		if ( $user_id ) {
+			$metadata['network_registration_site'] = \esc_url( \get_site_url() );
+		}
+
+		error_log( print_r( $metadata, true ) );
+
+		return $metadata;
+	}
+}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -47,6 +47,7 @@ class Initializer {
 		User_Update_Watcher::init();
 		User_Manual_Sync::init();
 		Distributor_Customizations::init();
+		Esp_Metadata_Sync::init();
 
 		Synchronize_All::init();
 		Data_Backfill::init();


### PR DESCRIPTION
Using a filter introduced in https://github.com/Automattic/newspack-plugin/pull/2989, creates a class that lets us add custom contact metadata fields for sites using the Network plugin. The first and only field we're adding so far is `Network Registration Site`, which shows which site in the network the registration originated from.

I'm not 100% certain this field is needed because upon testing, I saw that the `Registration Page` field contains the URL of the site that originated the registration, and this field is not overwritten after the user is propagated throughout the network. But even if we decide not to keep the `Network Registration Site` field, the infrastructure for adding custom fields seems useful enough to retain.

To test:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/2989.
2. Visit **Newspack > Engagement > Reader Activation > Advanced Settings** and confirm you see the new `Network Registration Site` field as an option in the Metadata Field Settings section:

<img width="1047" alt="Screenshot 2024-03-19 at 4 13 43 PM" src="https://github.com/Automattic/newspack-network/assets/2230142/2c3f18a1-e60c-44ea-ad1c-b75383dc7981">

3. Leave it selected and register as a new reader on one of the sites in your network.
4. Confirm that the contact is synced with the new field to the connected ESP.
5. Visit the **Newspack Network > Event Log** in the Hub site and confirm that the `Network Registration Site` field is appended to the data that propagates the user throughout the network.

<img width="2346" alt="Screenshot 2024-03-19 at 4 17 30 PM" src="https://github.com/Automattic/newspack-network/assets/2230142/ae5bac7f-e7e4-4c08-b020-a4615599c1d3">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206844902666878