### PR TITLE
Membership de-duplication CLI command

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -50,6 +50,7 @@ class Initializer {
 
 		Synchronize_All::init();
 		Data_Backfill::init();
+		Membership_Dedupe::init();
 
 		Woocommerce_Memberships\Admin::init();
 		Woocommerce_Memberships\Events::init();

--- a/includes/cli/class-membership-dedupe.php
+++ b/includes/cli/class-membership-dedupe.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Membership De-Duplication scripts.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+use WP_CLI;
+
+/**
+ * Membership De-Duplication class.
+ */
+class Membership_Dedupe {
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_commands' ] );
+	}
+
+	/**
+	 * Register the WP-CLI commands
+	 *
+	 * @return void
+	 */
+	public static function register_commands() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command(
+				'newspack-network clean-up-duplicate-memberships',
+				[ __CLASS__, 'clean_duplicate_memberships' ],
+				[
+					'shortdesc' => __( 'Clean up users with multiple of the same membership' ),
+					'synopsis'  => [
+						[
+							'type'     => 'assoc',
+							'name'     => 'plan-id',
+							'optional' => false,
+						],
+						[
+							'type'     => 'flag',
+							'name'     => 'dry-run',
+							'optional' => true,
+						],
+						[
+							'type'     => 'flag',
+							'name'     => 'csv',
+							'optional' => true,
+						],
+					],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Handler for the CLI command.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args and flags.
+	 */
+	public static function clean_duplicate_memberships( $args, $assoc_args ) {
+		$dry_run = isset( $assoc_args['dry-run'] );
+		$csv     = isset( $assoc_args['csv'] );
+
+		$plan_id = $assoc_args['plan-id'];
+		if ( ! is_numeric( $plan_id ) ) {
+			WP_CLI::error( 'Membership plan ID must be numeric' );
+		}
+		$plan_id = (int) $plan_id;
+
+		$user_ids = self::get_users_with_duplicate_membership( $plan_id );
+		WP_CLI::line( sprintf( '%d users found with duplicate memberships', count( $user_ids ) ) );
+
+		$duplicates = [];
+		foreach ( $user_ids as $user_id ) {
+			$memberships = get_posts( 
+				[
+					'author'      => $user_id,
+					'post_type'   => 'wc_user_membership',
+					'post_status' => 'any',
+					'post_parent' => $plan_id,
+				] 
+			);
+
+			foreach ( $memberships as $membership ) {
+				$user = get_user_by( 'id', $membership->post_author );
+				$duplicates[] = [
+					'user'         => $membership->post_author,
+					'email'        => $user->user_email,
+					'membership'   => $membership->ID,
+					'subscription' => get_post_meta( $membership->ID, '_subscription_id', true ),
+					'status'       => $membership->post_status,
+					'remote'       => get_post_meta( $membership->ID, '_remote_site_url', true ),
+				];
+			}
+		}
+
+		if ( $csv && ! empty( $duplicates ) ) {
+			WP_CLI::line( 'COPY AND PASTE THIS CSV: ' );
+			WP_CLI::line();
+			WP_CLI\Utils\format_items( 'csv', $duplicates, array_keys( $duplicates[0] ) );
+			WP_CLI::line();
+		}
+
+		if ( ! $dry_run ) {
+			WP_CLI::line( 'Deleting duplicates' );
+			self::deduplecate_memberships( $duplicates );
+		}
+
+		WP_CLI::success( 'Done' );
+	}
+
+	/**
+	 * Find users that have duplicate memberships.
+	 *
+	 * @param int $plan_id WC Memberships membership plan ID.
+	 * @return array Array of user IDs that have more than one membership of the input plan.
+	 */
+	private static function get_users_with_duplicate_membership( $plan_id ) {
+		global $wpdb;
+
+		$query_results = $wpdb->get_results( $wpdb->prepare( "SELECT count(*), post_author FROM $wpdb->posts WHERE post_type = 'wc_user_membership' AND post_parent = %d GROUP BY post_author", $plan_id ), ARRAY_A ); // phpcs:ignore
+
+		$users_with_duplicates = [];
+		foreach ( $query_results as $query_result ) {
+			if ( (int) $query_result['count(*)'] > 1 ) {
+				$users_with_duplicates[] = $query_result['post_author'];
+			}
+		}
+
+		return $users_with_duplicates;
+	}
+
+	/**
+	 * De-duplicate memberships so that users only have one membership of a plan.
+	 *
+	 * @param array $duplicates Analyzed data from ::clean_duplicate_memberships.
+	 */
+	private static function deduplecate_memberships( $duplicates ) {
+		$userdata = [];
+
+		foreach ( $duplicates as $duplicate ) {
+			if ( ! isset( $userdata[ $duplicate['email'] ] ) ) {
+				$userdata[ $duplicate['email'] ] = [];
+			}
+
+			$userdata[ $duplicate['email'] ][] = $duplicate;
+		}
+
+		foreach ( $userdata as $email => $duplicates ) {
+			WP_CLI::line( sprintf( 'Processing %s', $email ) );
+			if ( count( $duplicates ) < 2 ) {
+				WP_CLI::line( '  - User does not have too many memberships' );
+			}
+
+			$memberships_to_delete = array_slice( $duplicates, 1 );
+			foreach ( $memberships_to_delete as $duplicate ) {
+				wp_delete_post( $duplicate['membership'], true );
+				WP_CLI::line( sprintf( '  - Deleted extra membership %d', $duplicate['membership'] ) );
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a CLI command that can analyze a database for users that have more than one membership of the same plan as well as clean that situation up.

Usage: `wp newspack-network clean-up-duplicate-memberships --plan-id=1234 --csv --dry-run`

The `--csv` flag outputs all the data as a CSV (to the screen) for easier QA/analysis either visually or by copy+pasting into a spreadsheet.

**To test:**

The WC Memberships admin interface won't let you create 2 memberships of the same plan for a user, so you gotta get a little crafty.

1. Create 2 **different** memberships for a user.
2. Update the `post_parent` of one of those Membership post objects using `wp post update 1234 --post_parent=4321` so that both of the membership posts on the user have the same `post_parent`.