### PR TITLE
fix(event-log): only show users filter with environment constant

### DIFF
--- a/includes/hub/admin/class-event-log-list-table.php
+++ b/includes/hub/admin/class-event-log-list-table.php
@@ -22,8 +22,8 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
  * The Event Log List Table
  */
 class Event_Log_List_Table extends \WP_List_Table {
-	
-	
+
+
 	/**
 	 * Get the table columns
 	 *
@@ -56,14 +56,14 @@ class Event_Log_List_Table extends \WP_List_Table {
 			$args['action_name'] = sanitize_text_field( $_GET['action_name'] );
 		}
 
-		if ( isset( $_GET['node_id'] ) ) { 
+		if ( isset( $_GET['node_id'] ) ) {
 			$args['node_id'] = sanitize_text_field( $_GET['node_id'] );
 		}
 
-		if ( isset( $_GET['email'] ) ) { 
+		if ( isset( $_GET['email'] ) ) {
 			$args['email'] = sanitize_text_field( $_GET['email'] );
 		}
-		
+
 		$columns               = $this->get_columns();
 		$primary               = 'id';
 		$this->_column_headers = array( $columns, [], [], $primary );
@@ -106,12 +106,14 @@ class Event_Log_List_Table extends \WP_List_Table {
 			<?php endforeach; ?>
 		</select>
 
+		<?php if ( defined( 'NEWSPACK_NETWORK_EVENT_LOG_SHOW_USERS_FILTER' ) && NEWSPACK_NETWORK_EVENT_LOG_SHOW_USERS_FILTER ) : ?>
 		<select name="email" id="email">
 			<option value=""><?php _e( 'All users', 'newspack-network' ); ?></option>
 			<?php foreach ( $all_emails as $email ) : ?>
 				<option value="<?php echo esc_attr( $email ); ?>" <?php selected( $current_email, $email ); ?>><?php echo esc_html( $email ); ?></option>
 			<?php endforeach; ?>
 		</select>
+		<?php endif; ?>
 
 		<?php Nodes::nodes_dropdown( $current_node ); ?>
 


### PR DESCRIPTION
On production sites, the list of users in the event log filter can get very, very long and cause significant slowdowns when viewing the Event Log admin page. This change simply hides the Users filter on this page unless a `NEWSPACK_NETWORK_EVENT_LOG_SHOW_USERS_FILTER` constant is set in wp-config.php.

To test:

1. On a Hub site, visit **Newspack Network > Event Log** and confirm that the Users select dropdown is no longer shown.
2. Add `define( 'NEWSPACK_NETWORK_EVENT_LOG_SHOW_USERS_FILTER', true );` to wp-config.php and confirm that it reappears