### PR TITLE
fix: add new filter callback for Network Registration Site field

### DIFF
--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -20,6 +20,7 @@ class Esp_Metadata_Sync {
 	public static function init() {
 		\add_filter( 'newspack_ras_metadata_keys', [ __CLASS__, 'add_custom_metadata_fields' ] );
 		\add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
+		\add_filter( 'newspack_data_events_reader_registered_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
Along with https://github.com/Automattic/newspack-plugin/pull/3030, adds a new `newspack_data_events_reader_registered_metadata` filter to Data Events connectors which allow the custom `Network Registration Site` meta field to be added to contact metadata in all registration scenarios. Previously, registrations via Mailchimp that did not involve signing up for any newsletter lists were not adding the custom field.

### Testing

1. On `release`, using a site with RAS + Mailchimp enabled, register a new reader account without signing up for newsletters (either via Registration block without checking any list boxes, or by purchasing a product).
2. Observe that the `NP_Network Registration Site` meta field added by #83 did not get added to the contact metadata.
3. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/3030 and repeat with a new account.
4. This time confirm that `NP_Network Registration Site` gets added to the contact metadata no matter how you register for an account.