### PR TITLE
Improve display name handling on propagated users

### DIFF
--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -32,10 +32,13 @@ class Users {
 			return $existing_user;
 		}
 
+		$nicename = self::generate_user_nicename( $email );
+
 		$user_array = [
 			'user_login'    => substr( $email, 0, 60 ),
 			'user_email'    => $email,
-			'user_nicename' => substr( $email, 0, 50 ),
+			'user_nicename' => $nicename,
+			'display_name'  => $nicename,
 			'user_pass'     => wp_generate_password(),
 			'role'          => NEWSPACK_NETWORK_READER_ROLE,
 		];
@@ -57,6 +60,29 @@ class Users {
 		update_user_meta( $user_id, self::USER_META_REMOTE_ID, $remote_id );
 
 		return get_user_by( 'id', $user_id );
+	}
+
+	/**
+	 * Generate a URL-sanitized version of the given string for a new reader account.
+	 *
+	 * @param string $name User's display name, or email if not available.
+	 * @return string
+	 */
+	public static function generate_user_nicename( $name ) {
+		$name = self::strip_email_domain( $name ); // If an email address, strip the domain.
+
+		return substr( \sanitize_title( \sanitize_user( $name, true ) ), 0, 50 );
+	}
+
+	/**
+	 * Strip the domain part of an email address string.
+	 * If not an email address, just return the string.
+	 *
+	 * @param string $str String to check.
+	 * @return string
+	 */
+	public static function strip_email_domain( $str ) {
+		return trim( explode( '@', $str, 2 )[0] );
 	}
 
 	/**


### PR DESCRIPTION
Note: Merges into `data-integrity-improvements` branch

This PR adjusts the display name and nicename handling [to match the RAS logic](https://github.com/Automattic/newspack-plugin/blob/e267ad71832648f285399a55b36a30735c0fd769/includes/reader-activation/class-reader-activation.php#L1726-L1730) so that display names are never emails on propagated users. I didn't simply reference that method in this PR because I didn't want to add extra dependencies, but LMK if you think that's the way to go.

To test:
1. `wp shell`
2. `Newspack_Network\Utils\Users::get_or_create_user_by_email( 'displaynametest211@gmail.com', 'https://example.com', 123 );`
In the response you should see `public $display_name => string(18) "displaynametest211"`
