### PR TITLE
Assorted changes 2

### DIFF
--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Network;
 
+use const Newspack_Network\constants\EVENT_LOG_PAGE_SLUG;
+
 /**
  * Class to handle the Users admin page
  */
@@ -75,7 +77,7 @@ class Users {
 			$summary       = $last_activity->get_summary();
 			$event_log_url = add_query_arg(
 				[
-					'page'  => \Newspack_Network\Hub\Admin\Event_Log::PAGE_SLUG,
+					'page'  => EVENT_LOG_PAGE_SLUG,
 					'email' => $user->user_email,
 				],
 				admin_url( 'admin.php' )

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Newspack Network related constants
- * 
+ *
  * @package Newspack
  */
 
@@ -15,3 +15,5 @@ const WEBHOOK_RESPONSE_ERRORS = [
 	'INVALID_SIGNATURE' => 'Invalid Signature.',
 	'INVALID_DATA'      => 'Bad request. Invalid Data.',
 ];
+
+const EVENT_LOG_PAGE_SLUG = 'newspack-network-event-log';

--- a/includes/hub/admin/class-event-log.php
+++ b/includes/hub/admin/class-event-log.php
@@ -8,13 +8,12 @@
 namespace Newspack_Network\Hub\Admin;
 
 use Newspack_Network\Admin as Network_Admin;
+use const Newspack_Network\constants\EVENT_LOG_PAGE_SLUG;
 
 /**
  * Class to handle the Event log admin page
  */
 class Event_Log {
-
-	const PAGE_SLUG = 'newspack-network-event-log';
 
 	/**
 	 * Runs the initialization.
@@ -30,7 +29,7 @@ class Event_Log {
 	 * @return void
 	 */
 	public static function add_admin_menu() {
-		Network_Admin::add_submenu_page( __( 'Event Log', 'newspack-network' ), self::PAGE_SLUG, [ __CLASS__, 'render_page' ] );
+		Network_Admin::add_submenu_page( __( 'Event Log', 'newspack-network' ), EVENT_LOG_PAGE_SLUG, [ __CLASS__, 'render_page' ] );
 	}
 
 	/**
@@ -39,7 +38,7 @@ class Event_Log {
 	 * @return void
 	 */
 	public static function admin_enqueue_scripts() {
-		$page_slug = Network_Admin::PAGE_SLUG . '_page_' . self::PAGE_SLUG;
+		$page_slug = Network_Admin::PAGE_SLUG . '_page_' . EVENT_LOG_PAGE_SLUG;
 		if ( get_current_screen()->id !== $page_slug ) {
 			return;
 		}
@@ -62,7 +61,7 @@ class Event_Log {
 
 		echo '<div class="wrap"><h2>', esc_html( __( 'Event Log', 'newspack-network' ) ), '</h2>';
 		echo '<form method="get">';
-		echo '<input type="hidden" name="page" value="' . esc_attr( self::PAGE_SLUG ) . '" />';
+		echo '<input type="hidden" name="page" value="' . esc_attr( EVENT_LOG_PAGE_SLUG ) . '" />';
 
 		$table->prepare_items();
 

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -12,7 +12,7 @@ use Newspack_Network\Admin as Network_Admin;
 use Newspack_Network\Debugger;
 
 /**
- * Class to handle the ubscriptions post type registration
+ * Class to handle the Orders post type registration
  */
 class Orders {
 

--- a/includes/incoming-events/class-reader-registered.php
+++ b/includes/incoming-events/class-reader-registered.php
@@ -50,6 +50,15 @@ class Reader_Registered extends Abstract_Incoming_Event {
 
 		User_Update_Watcher::$enabled = false;
 
-		$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
+		// If a user exists, but has a non-synchronizable role, add a synchronizable role.
+		$existing_user = get_user_by( 'email', $email );
+		if ( $existing_user ) {
+			$synced_roles = \Newspack_Network\Utils\Users::get_synced_user_roles();
+			if ( ! array_intersect( $existing_user->roles, $synced_roles ) ) {
+				$existing_user->add_role( $synced_roles[0] );
+			}
+		} else {
+			$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '', (array) $this->data );
+		}
 	}
 }

--- a/includes/node/class-pulling.php
+++ b/includes/node/class-pulling.php
@@ -132,49 +132,17 @@ class Pulling {
 	}
 
 	/**
-	 * Gets the request parameters for the pull request
-	 *
-	 * @return array
-	 */
-	public static function get_request_params() {
-		$params = [
-			'last_processed_id' => self::get_last_processed_id(),
-			'actions'           => Accepted_Actions::ACTIONS_THAT_NODES_PULL,
-			'site'              => get_bloginfo( 'url' ),
-		];
-		return self::sign_params( $params );
-	}
-
-	/**
-	 * Signs the request parameters with the Node's secret key
-	 *
-	 * @param array $params The request parameters.
-	 * @return array The params array with an additional signature key.
-	 */
-	public static function sign_params( $params ) {
-		$message             = wp_json_encode( $params );
-		$secret_key          = Settings::get_secret_key();
-		$nonce               = Crypto::generate_nonce();
-		$signature           = Crypto::encrypt_message( $message, $secret_key, $nonce );
-		$params['signature'] = $signature;
-		$params['nonce']     = $nonce;
-		return $params;
-	}
-
-	/**
 	 * Makes a request to the Hub to pull data
 	 *
 	 * @return array|\WP_Error
 	 */
 	public static function make_request() {
-		$url      = trailingslashit( Settings::get_hub_url() ) . 'wp-json/newspack-network/v1/pull';
-		$params   = self::get_request_params();
-		$response = wp_remote_post(
-			$url,
-			[
-				'body' => $params,
-			]
-		);
+		$params = [
+			'last_processed_id' => self::get_last_processed_id(),
+			'actions'           => Accepted_Actions::ACTIONS_THAT_NODES_PULL,
+			'site'              => get_bloginfo( 'url' ),
+		];
+		$response = \Newspack_Network\Utils\Requests::request_to_hub( 'wp-json/newspack-network/v1/pull', $params );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/includes/utils/class-requests.php
+++ b/includes/utils/class-requests.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Newspack Network Requests methods.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Utils;
+
+use Newspack_Network\Crypto;
+use Newspack_Network\Node\Settings;
+use WP_Error;
+
+/**
+ * Requests.
+ */
+class Requests {
+
+	/**
+	 * Make a request to the Hub.
+	 *
+	 * @param string $endpoint The endpoint to request.
+	 * @param array  $params The parameters to send.
+	 * @param string $method The request method.
+	 */
+	public static function request_to_hub( $endpoint, $params, $method = 'POST' ) {
+		$url = trailingslashit( Settings::get_hub_url() ) . $endpoint;
+		return wp_remote_request(
+			$url,
+			[
+				'method'  => $method,
+				'body'    => self::sign_params( $params ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+	}
+
+	/**
+	 * Signs the request parameters with the Node's secret key
+	 *
+	 * @param array $params The request parameters.
+	 * @return array The params array with an additional signature key.
+	 */
+	public static function sign_params( $params ) {
+		$message             = wp_json_encode( $params );
+		$secret_key          = Settings::get_secret_key();
+		$nonce               = Crypto::generate_nonce();
+		$signature           = Crypto::encrypt_message( $message, $secret_key, $nonce );
+		$params['signature'] = $signature;
+		$params['nonce']     = $nonce;
+		return $params;
+	}
+
+	/**
+	 * Validate a request.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return bool|WP_Error True if the request is valid, WP_Error otherwise.
+	 */
+	public static function get_request_to_hub_errors( $request ) {
+		$site      = $request['site'];
+		$signature = $request['signature'];
+		$nonce     = $request['nonce'];
+
+		if ( empty( $site ) ||
+			empty( $nonce ) ||
+			empty( $signature )
+		) {
+			return new WP_Error( 'newspack_network_bad_request', __( 'Bad request.', 'newspack-network' ) );
+		}
+
+		$node = \Newspack_Network\Hub\Nodes::get_node_by_url( $site );
+
+		if ( ! $node ) {
+			\Newspack_Network\Debugger::log( 'Node not found.' );
+			return new WP_Error( 'newspack_network_bad_request_node_not_found', __( 'Bad request. Site not registered in this Hub', 'newspack-network' ) );
+		}
+
+		$verified         = $node->decrypt_message( $signature, $nonce );
+		$verified_message = json_decode( $verified );
+		if ( ! $verified || ! is_object( $verified_message ) ) {
+			\Newspack_Network\Debugger::log( 'Signature check failed' );
+			return new WP_Error( 'newspack_network_bad_request_signature', __( 'Bad request. Invalid signature.', 'newspack-network' ) );
+		}
+
+		return true;
+	}
+}

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -26,7 +26,6 @@ class Users {
 	 * @return WP_User|WP_Error
 	 */
 	public static function get_or_create_user_by_email( $email, $remote_site_url, $remote_id, $insert_array = [] ) {
-
 		$existing_user = get_user_by( 'email', $email );
 
 		if ( $existing_user ) {
@@ -40,10 +39,13 @@ class Users {
 			return $existing_user;
 		}
 
+		$nicename = self::generate_user_nicename( $email );
+
 		$user_array = [
-			'user_login'    => $email,
+			'user_login'    => substr( $email, 0, 60 ),
 			'user_email'    => $email,
-			'user_nicename' => $email,
+			'user_nicename' => $nicename,
+			'display_name'  => $nicename,
 			'user_pass'     => wp_generate_password(),
 			'role'          => NEWSPACK_NETWORK_READER_ROLE,
 		];
@@ -74,6 +76,29 @@ class Users {
 		do_action( 'newspack_network_new_network_reader', $new_user );
 
 		return $new_user;
+	}
+
+	/**
+	 * Generate a URL-sanitized version of the given string for a new reader account.
+	 *
+	 * @param string $name User's display name, or email if not available.
+	 * @return string
+	 */
+	public static function generate_user_nicename( $name ) {
+		$name = self::strip_email_domain( $name ); // If an email address, strip the domain.
+
+		return substr( \sanitize_title( \sanitize_user( $name, true ) ), 0, 50 );
+	}
+
+	/**
+	 * Strip the domain part of an email address string.
+	 * If not an email address, just return the string.
+	 *
+	 * @param string $str String to check.
+	 * @return string
+	 */
+	public static function strip_email_domain( $str ) {
+		return trim( explode( '@', $str, 2 )[0] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Tweaks to the memberships deduplication CLI command, added in #84
2. A fix to username generation, to ensure too-long usernames are not used
3. Adds handling of syncing of users who already exist on the other site, but have a non-synchronizable role 
4. Some refactoring

(Note: this is a part of integrating the changes from the `data-integrity-improvements` branch (https://github.com/Automattic/newspack-network/pull/89))

### How to test the changes in this Pull Request:

1. Test membership deduplication command, as described in #84, but instead of a `--dry-run` flag observe it will dry run by default, making any changes only with `--live` flag provided. This brings it in line with other CLI command in this repository. 
2. On one network site, using CLI (front-end won't let you!), create a Subscriber user with an email address that exceeds 60 characters. 
    1. Wait for the user to sync, or trigger a sync
    2. Observe that the user's username on the other network sites is based on the email address, but cut to not exceed 60 characters
4. Create two users on two different network sites, with the same email address, but different roles: 
    1. Create an Editor (a non-synchronizable role) using WP Admin or WP CLI
    2. Register using the Registration block (or the auth modal) on the second site
    1. Run the reader-registered-event backfill (`wp newspack-network data-backfill reader_registered --start=2020-01-01 --end=2024-12-31 --live`) from the second site
    3. Wait for the user to sync, or trigger a sync
    4. Observe that on the first site, the user has both roles now 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->