### PR TITLE
Feat/user discrepancies display

### DIFF
--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -134,7 +134,7 @@ class Nodes_List {
 						<?php
 							echo esc_html(
 								/* translators: %d - users on the Hub only, %d on the Node only */
-								sprintf( __( '%1$d on the Hub only, %2$d on the Node only', 'newspack-network' ), count( $not_on_hub ), count( $not_on_node ) )
+								sprintf( __( '%1$d on the Hub only, %2$d on the Node only', 'newspack-network' ), count( $not_on_node ), count( $not_on_hub ) )
 							);
 						?>
 					</span>

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -28,6 +28,20 @@ class Nodes_List {
 	}
 
 	/**
+	 * Cache for site info responses.
+	 *
+	 * @var array
+	 */
+	private static $node_site_info_cache = [];
+
+	/**
+	 * Cache for Hub site info.
+	 *
+	 * @var array
+	 */
+	private static $hub_site_info = false;
+
+	/**
 	 * Modify columns on post type table
 	 *
 	 * @param array $columns Registered columns.
@@ -37,16 +51,32 @@ class Nodes_List {
 		unset( $columns['date'] );
 		unset( $columns['stats'] );
 		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
+			$sync_users_count = \Newspack_Network\Utils\Users::get_synchronized_users_count();
 			$sync_users_info = sprintf(
 				' <span class="dashicons dashicons-info-outline" title="%s"></span>',
 				sprintf(
 					/* translators: list of user roles which will entail synchronization */
 					esc_attr__( 'Users with the following roles: %1$s (%2$d on the Hub)', 'newspack-network' ),
 					implode( ', ', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
-					\Newspack_Network\Utils\Users::get_synchronized_users_count()
+					$sync_users_count
 				)
 			);
-			$columns['sync_users'] = __( 'Synchronizable Users', 'newspack-network' ) . $sync_users_info;
+			/* translators: %d is the synchronizable users count. */
+			$columns['sync_users'] = sprintf( __( 'Synchronizable Users (%d)', 'newspack-network' ), $sync_users_count ) . $sync_users_info;
+			if ( isset( $_GET['_newspack_user_discrepancies'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$columns['user_discrepancies'] = __( 'Discrepancies in Sync. Users', 'newspack-network' );
+			}
+
+			$not_sync_users_info = sprintf(
+				' <span class="dashicons dashicons-info-outline" title="%s"></span>',
+				sprintf(
+					/* translators: list of user roles which will entail synchronization */
+					esc_attr__( 'Users with roles different than the following roles: %1$s (%2$d on the Hub)', 'newspack-network' ),
+					implode( ', ', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
+					\Newspack_Network\Utils\Users::get_not_synchronized_users_count()
+				)
+			);
+			$columns['not_sync_users'] = __( 'Non-synchronizable Users', 'newspack-network' ) . $not_sync_users_info;
 		}
 		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;
@@ -80,6 +110,38 @@ class Nodes_List {
 				</p>
 			<?php
 		}
+		if ( ! isset( self::$node_site_info_cache[ $post_id ] ) ) {
+			self::$node_site_info_cache[ $post_id ] = $node->get_site_info();
+		}
+		$node_site_info = self::$node_site_info_cache[ $post_id ];
+
+		if ( isset( $_GET['_newspack_user_discrepancies'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ! self::$hub_site_info ) {
+				self::$hub_site_info = [
+					'sync_user_emails' => \Newspack_Network\Utils\Users::get_synchronized_users_emails(),
+				];
+			}
+
+			// Display user discrepancies.
+			$node_users_emails = $node_site_info->sync_users_emails ?? [];
+			// Users who are on the Hub but not on the Node.
+			$not_on_node = array_diff( self::$hub_site_info['sync_user_emails'], $node_users_emails );
+			// Users who are not on the Node but are on the Hub.
+			$not_on_hub = array_diff( $node_users_emails, self::$hub_site_info['sync_user_emails'] );
+			if ( 'user_discrepancies' === $column ) {
+				?>
+					<span>
+						<?php
+							echo esc_html(
+								/* translators: %d - users on the Hub only, %d on the Node only */
+								sprintf( __( '%1$d on the Hub only, %2$d on the Node only', 'newspack-network' ), count( $not_on_hub ), count( $not_on_node ) )
+							);
+						?>
+					</span>
+				<?php
+			}
+		}
+
 		if ( 'sync_users' === $column ) {
 			$users_link = add_query_arg(
 				[
@@ -88,7 +150,18 @@ class Nodes_List {
 				trailingslashit( $node->get_url() ) . 'wp-admin/users.php'
 			);
 			?>
-				<a href="<?php echo esc_url( $users_link ); ?>"><?php echo esc_html( $node->get_sync_users_count() ); ?></a>
+				<a href="<?php echo esc_url( $users_link ); ?>"><?php echo esc_html( $node_site_info->sync_users_count ?? 0 ); ?></a>
+			<?php
+		}
+		if ( 'not_sync_users' === $column ) {
+			$users_link = add_query_arg(
+				[
+					'role__not_in' => implode( ',', \Newspack_Network\Utils\Users::get_synced_user_roles() ),
+				],
+				trailingslashit( $node->get_url() ) . 'wp-admin/users.php'
+			);
+			?>
+				<a href="<?php echo esc_url( $users_link ); ?>"><?php echo esc_html( $node_site_info->not_sync_users_count ?? 0 ); ?></a>
 			<?php
 		}
 	}

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -174,7 +174,7 @@ class Node {
 	/**
 	 * Get site info.
 	 */
-	private function get_site_info() {
+	public function get_site_info() {
 		$response = wp_remote_get( // phpcs:ignore
 			$this->get_url() . '/wp-json/newspack-network/v1/info',
 			[
@@ -182,13 +182,5 @@ class Node {
 			]
 		);
 		return json_decode( wp_remote_retrieve_body( $response ) );
-	}
-
-	/**
-	 * Get synchronized users count.
-	 */
-	public function get_sync_users_count() {
-		$site_info = $this->get_site_info();
-		return $site_info->sync_users_count ?? 0;
 	}
 }

--- a/includes/node/class-info-endpoints.php
+++ b/includes/node/class-info-endpoints.php
@@ -46,7 +46,11 @@ class Info_Endpoints {
 	public static function handle_info_request() {
 		return rest_ensure_response(
 			[
-				'sync_users_count' => \Newspack_Network\Utils\Users::get_synchronized_users_count(),
+				'sync_users_count'      => \Newspack_Network\Utils\Users::get_synchronized_users_count(),
+				'sync_users_emails'     => \Newspack_Network\Utils\Users::get_synchronized_users_emails(),
+				'not_sync_users_count'  => \Newspack_Network\Utils\Users::get_not_synchronized_users_count(),
+				'not_sync_users_emails' => \Newspack_Network\Utils\Users::get_not_synchronized_users_emails(),
+				'no_role_users_emails'  => \Newspack_Network\Utils\Users::get_no_role_users_emails(),
 			]
 		);
 	}

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -174,13 +174,68 @@ class Users {
 	 * Get synchronized users count.
 	 */
 	public static function get_synchronized_users_count() {
-		$users = get_users(
+		return count( self::get_synchronized_users( [ 'id' ] ) );
+	}
+
+	/**
+	 * Get synchronized users emails.
+	 */
+	public static function get_synchronized_users_emails() {
+		return array_map( 'strtolower', array_column( self::get_synchronized_users( [ 'user_email' ] ), 'user_email' ) );
+	}
+
+	/**
+	 * Get no-role users emails.
+	 */
+	public static function get_no_role_users_emails() {
+		global $wpdb;
+		$no_role_users_emails = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			"SELECT user_email FROM wp_users WHERE ID IN (SELECT user_id FROM wp_usermeta WHERE meta_key = 'wp_capabilities' AND (meta_value = 'a:0:{}' OR meta_value = '')) OR ID NOT IN (SELECT user_id FROM wp_usermeta WHERE meta_key = 'wp_capabilities')"
+		);
+		return array_map( 'strtolower', array_column( $no_role_users_emails, 'user_email' ) );
+	}
+
+	/**
+	 * Get synchronized users.
+	 *
+	 * @param array $fields Fields to return.
+	 */
+	public static function get_synchronized_users( $fields = [] ) {
+		return get_users(
 			[
 				'role__in' => self::get_synced_user_roles(),
-				'fields'   => [ 'id' ],
+				'fields'   => $fields,
 				'number'   => -1,
 			]
 		);
-		return count( $users );
+	}
+
+	/**
+	 * Get not synchronized users count.
+	 *
+	 * @param array $fields Fields to return.
+	 */
+	public static function get_not_synchronized_users( $fields = [] ) {
+		return get_users(
+			[
+				'role__not_in' => self::get_synced_user_roles(),
+				'fields'       => $fields,
+				'number'       => -1,
+			]
+		);
+	}
+
+	/**
+	 * Get synchronized users emails.
+	 */
+	public static function get_not_synchronized_users_emails() {
+		return array_map( 'strtolower', array_column( self::get_not_synchronized_users( [ 'user_email' ] ), 'user_email' ) );
+	}
+
+	/**
+	 * Get not synchronized users count.
+	 */
+	public static function get_not_synchronized_users_count() {
+		return count( self::get_not_synchronized_users( [ 'id' ] ) );
 	}
 }

--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -74,14 +74,18 @@ class Admin {
 	/**
 	 * Get active members' emails.
 	 *
-	 * @param \WC_Memberships_Membership_Plan $plan the membership plan.
+	 * @param \WC_Memberships_Membership_Plan $plan The membership plan.
 	 */
 	public static function get_active_members_emails( $plan ) {
 		$active_memberships = $plan->get_memberships( [ 'post_status' => 'wcm-active' ] );
 		return array_map(
 			function ( $membership ) {
 				$user = get_user_by( 'id', $membership->get_user_id() );
-				return $user->user_email;
+				if ( $user ) {
+					return strtolower( $user->user_email );
+				} else {
+					return '';
+				}
 			},
 			$active_memberships
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Enables the "Newspack Network Activity" user column on nodes (previously it was only displayed on the hub)
2. Enhances user count discrepancies debugging columns in the nodes list:

<img width="752" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/82f8ef7c-ade7-4cc7-a12b-7266ca7f1610"> 

(Note: this is a part of integrating the changes from the `data-integrity-improvements` branch (https://github.com/Automattic/newspack-network/pull/89))

### How to test the changes in this Pull Request:

1. On your network, create some user discrepancies by deleting some synchronized users directly in the DB (so the deletions are not synchronised), and adding some via CLI (so the additions are not synchronized) 
4. Visit the Nodes view in the hub site, appending a `_newspack_user_discrepancies` param
5. Observe the discrepancies table as visible on the screenshot above, inspect the results to verify if the data matches your specific discrepancies
6. Visit the WP Users view on both a node site and the hub site, observe the "Newspack Network Activity" column is present, with a "View All" link to the hub site's Event Log

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->