### PR TITLE
fix: update newspack-scripts to v5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@rushstack/eslint-patch": "^1.1.0",
 				"eslint": "^7.29.0",
 				"lint-staged": "^13.2.0",
-				"newspack-scripts": "^5.3.0",
+				"newspack-scripts": "^5.5.1",
 				"postcss-scss": "^4.0.6",
 				"prettier": "npm:wp-prettier@^2.2.1-beta-1"
 			}
@@ -19566,9 +19566,9 @@
 			"dev": true
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
-			"integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+			"integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -34709,7 +34709,8 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
 			"integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.7",
@@ -34842,7 +34843,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
 			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@emotion/utils": {
 			"version": "1.2.0",
@@ -36245,7 +36247,8 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "7.0.1",
@@ -37471,7 +37474,8 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
 			"integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@webpack-cli/info": {
 			"version": "1.5.0",
@@ -37486,7 +37490,8 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
 			"integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.7",
@@ -37549,7 +37554,8 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.2.0.tgz",
 			"integrity": "sha512-XK3Sdpi9MWoy5qPHnRroY/ypX0VtT5yI5809u5As1P/3k4vlXNw8USH4lJ+rkurAOVqqN5mFlf2XAL9AkpfXyg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.17.0",
@@ -38127,7 +38133,8 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -38170,7 +38177,8 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -39809,7 +39817,8 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
 			"integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"create-require": {
 			"version": "1.1.1",
@@ -41241,7 +41250,8 @@
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
 			"integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.7",
@@ -41452,7 +41462,8 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
 			"integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -42891,7 +42902,8 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -45612,7 +45624,8 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
 			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"jest-regex-util": {
 			"version": "29.4.3",
@@ -47824,9 +47837,9 @@
 			"dev": true
 		},
 		"newspack-scripts": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
-			"integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+			"integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -48170,7 +48183,8 @@
 											"version": "0.15.2",
 											"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
 											"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-											"dev": true
+											"dev": true,
+											"requires": {}
 										},
 										"reakit-warning": {
 											"version": "0.6.2",
@@ -48512,7 +48526,8 @@
 									"version": "0.15.2",
 									"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
 									"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-									"dev": true
+									"dev": true,
+									"requires": {}
 								},
 								"reakit-warning": {
 									"version": "0.6.2",
@@ -48890,7 +48905,8 @@
 											"version": "0.15.2",
 											"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
 											"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-											"dev": true
+											"dev": true,
+											"requires": {}
 										},
 										"reakit-warning": {
 											"version": "0.6.2",
@@ -49211,7 +49227,8 @@
 							"version": "1.4.0",
 							"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-1.4.0.tgz",
 							"integrity": "sha512-uvrgUAhRnOvIysXjcXH9VDsrKLqH9r3BfdGoy+WFLSHFnTfdMhW7bdDQXl4F4UIUuefUwGi+ZvT/rChg9zoBkQ==",
-							"dev": true
+							"dev": true,
+							"requires": {}
 						},
 						"eslint-plugin-jest": {
 							"version": "25.7.0",
@@ -52714,7 +52731,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -53237,13 +53255,15 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-scss": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
 			"integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.12",
@@ -53597,7 +53617,8 @@
 			"version": "6.9.9",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
 			"integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"react": {
 			"version": "17.0.2",
@@ -53613,7 +53634,8 @@
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
 			"integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"react-dom": {
 			"version": "17.0.2",
@@ -56128,7 +56150,8 @@
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
 			"integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"stylelint-config-standard": {
 			"version": "30.0.1",
@@ -57166,7 +57189,8 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
 			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"use-lilius": {
 			"version": "2.0.3",
@@ -57181,13 +57205,15 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
 			"integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
 			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -57383,7 +57409,8 @@
 					"version": "1.8.0",
 					"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 					"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				},
 				"schema-utils": {
 					"version": "3.1.2",
@@ -57607,7 +57634,8 @@
 			"version": "7.5.9",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
 			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@rushstack/eslint-patch": "^1.1.0",
 		"eslint": "^7.29.0",
 		"lint-staged": "^13.2.0",
-		"newspack-scripts": "^5.3.0",
+		"newspack-scripts": "^5.5.1",
 		"postcss-scss": "^4.0.6",
 		"prettier": "npm:wp-prettier@^2.2.1-beta-1"
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the `newspack-scripts` to 5.5.1, which [fixes an issue with generating alpha releases](https://github.com/Automattic/newspack-scripts/pull/212).

### How to test the changes in this Pull Request:

1. Confirm that `npm run release:archive` or `npm run start` look okay! 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
