### PR TITLE
feat: ensure that membership plans have unique network id

### DIFF
--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -163,7 +163,39 @@ class Admin {
 		}
 
 		$network_id = sanitize_text_field( wp_unslash( $_POST['newspack_network_id'] ?? '' ) );
+
+		$network_id = self::unique_network_id( $network_id, $post_id );
+
 		update_post_meta( $post_id, self::NETWORK_ID_META_KEY, $network_id );
+	}
+
+	/**
+	 * Given a network id, makes it unique among all the membership plans.
+	 *
+	 * @param string $network_id The network id to make unique.
+	 * @param int    $post_id The post ID that is being saved.
+	 * @return string The unique network id.
+	 */
+	private static function unique_network_id( $network_id, $post_id ) {
+		global $wpdb;
+		$network_id = sanitize_text_field( $network_id );
+		$query = $wpdb->prepare(
+			"SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = %s AND post_id != %d",
+			self::NETWORK_ID_META_KEY,
+			$post_id
+		);
+
+		$ids = $wpdb->get_col( $query ); // phpcs:ignore
+
+		$count               = 2;
+		$original_network_id = $network_id;
+
+		while ( in_array( $network_id, $ids, true ) ) {
+			$network_id = $original_network_id . '-' . $count;
+			$count++;
+		}
+
+		return $network_id;
 	}
 
 	/**


### PR DESCRIPTION
One membership plan in one site should always map to one membership plan in the other sites.

This PRs make sure you don't allow users to set the same "network id" for more than one membership plan.

This is an alternative to https://github.com/Automattic/newspack-network/pull/80

## Testing

* Create a membership plan and assign a network id
* Confirm it saves the network id as you created it
* edit the membership plan and confirm the network id is kept
* Create another membership plan and try to assign the same network id
* confirm the network id is suffixed with `-2`
* Try to create a third one and confirm it's still unique
* Edit any of the membership plans and add an unique network id and make sure it does not get the `-2` suffix added when it shouldn't