### PR TITLE
feat(membership-plans): improvements 

### DIFF
--- a/includes/class-rest-authenticaton.php
+++ b/includes/class-rest-authenticaton.php
@@ -33,6 +33,10 @@ class Rest_Authenticaton {
 			'endpoint' => '|^/wc/v2/memberships/plans|',
 			'callback' => [ __CLASS__, 'add_filter_for_woo_read_endpoints' ],
 		],
+		'get-woo-memberships'      => [
+			'endpoint' => '|^/wc/v2/memberships|',
+			'callback' => [ __CLASS__, 'add_filter_for_woo_read_endpoints' ],
+		],
 	];
 
 	/**

--- a/includes/cli/backfillers/class-reader-registered.php
+++ b/includes/cli/backfillers/class-reader-registered.php
@@ -56,7 +56,9 @@ class Reader_Registered extends Abstract_Backfiller {
 			]
 		);
 
+		WP_CLI::line( '' );
 		WP_CLI::line( sprintf( 'Found %s user(s) eligible for sync.', count( $users ) ) );
+		WP_CLI::line( '' );
 
 		$this->maybe_initialize_progress_bar( 'Processing users', count( $users ) );
 

--- a/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -58,6 +58,9 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 		$this->maybe_initialize_progress_bar( 'Processing memberships', count( $membership_posts_ids ) );
 
 		$events = [];
+		WP_CLI::line( '' );
+		WP_CLI::line( sprintf( 'Found %s membership(s) eligible for sync.', count( $membership_posts_ids ) ) );
+		WP_CLI::line( '' );
 
 		foreach ( $membership_posts_ids as $post_id ) {
 			$membership = new \WC_Memberships_User_Membership( $post_id );
@@ -77,6 +80,7 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 				'membership_id'   => $membership->get_id(),
 				'new_status'      => $status,
 			];
+			$timestamp = null;
 			switch ( $status ) {
 				case 'paused':
 					$timestamp = strtotime( $membership->get_paused_date() );

--- a/includes/hub/admin/class-membership-plans-table.php
+++ b/includes/hub/admin/class-membership-plans-table.php
@@ -54,8 +54,8 @@ class Membership_Plans_Table extends \WP_List_Table {
 		$membership_plans_from_network_data = Membership_Plans::get_membership_plans_from_network();
 
 		// Handle table sorting.
-		$order = $_REQUEST['order'] ?? false; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$orderby = $_REQUEST['orderby'] ?? false; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$order = isset( $_REQUEST['order'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['order'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
+		$orderby = isset( $_REQUEST['orderby'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['orderby'] ) ) : false; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 		if ( $order && $orderby ) {
 			usort(
 				$membership_plans_from_network_data['plans'],

--- a/includes/hub/admin/class-membership-plans-table.php
+++ b/includes/hub/admin/class-membership-plans-table.php
@@ -22,16 +22,28 @@ class Membership_Plans_Table extends \WP_List_Table {
 	 */
 	public function get_columns() {
 		$columns = [
-			'id'   => __( 'ID', 'newspack-network' ),
 			'name' => __( 'Name', 'newspack-network' ),
 		];
 		$columns['site_url'] = __( 'Site URL', 'newspack-network' );
 		$columns['network_pass_id'] = __( 'Network ID', 'newspack-network' );
 		if ( \Newspack_Network\Admin::use_experimental_auditing_features() ) {
-			$columns['active_members_count'] = __( 'Active Members', 'newspack-network' );
-			$columns['network_pass_discrepancies'] = __( 'Discrepancies', 'newspack-network' );
+			$columns['active_memberships_count'] = __( 'Active Memberships', 'newspack-network' );
+			$columns['network_pass_discrepancies'] = __( 'Membership Discrepancies', 'newspack-network' );
+
+			$active_subscriptions_sum = array_reduce(
+				$this->items,
+				function( $carry, $item ) {
+					return $carry + ( is_numeric( $item['active_subscriptions_count'] ) ? $item['active_subscriptions_count'] : 0 );
+				},
+				0
+			);
+			$subs_info = sprintf(
+				' <span class="dashicons dashicons-info-outline" title="%s"></span>',
+				__( 'Active Subscriptions tied to this membership plan', 'newspack-network' )
+			);
+			// translators: %d is the sum of active subscriptions.
+			$columns['active_subscriptions_count'] = sprintf( __( 'Active Subscriptions (%d)', 'newspack-network' ), $active_subscriptions_sum ) . $subs_info;
 		}
-		$columns['links'] = __( 'Links', 'newspack-network' );
 		return $columns;
 	}
 
@@ -39,8 +51,25 @@ class Membership_Plans_Table extends \WP_List_Table {
 	 * Prepare items to be displayed
 	 */
 	public function prepare_items() {
-		$this->_column_headers = [ $this->get_columns(), [], [], 'id' ];
-		$this->items = Membership_Plans::get_membershp_plans_from_network();
+		$membership_plans_from_network_data = Membership_Plans::get_membership_plans_from_network();
+
+		// Handle table sorting.
+		$order = $_REQUEST['order'] ?? false; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$orderby = $_REQUEST['orderby'] ?? false; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( $order && $orderby ) {
+			usort(
+				$membership_plans_from_network_data['plans'],
+				function( $a, $b ) use ( $orderby, $order ) {
+					if ( $order === 'asc' ) {
+						return $a[ $orderby ] <=> $b[ $orderby ];
+					}
+					return $b[ $orderby ] <=> $a[ $orderby ];
+				}
+			);
+		}
+
+		$this->items = $membership_plans_from_network_data['plans'];
+		$this->_column_headers = [ $this->get_columns(), [], $this->get_sortable_columns(), 'id' ];
 	}
 
 	/**
@@ -53,6 +82,10 @@ class Membership_Plans_Table extends \WP_List_Table {
 	public function column_default( $item, $column_name ) {
 		$memberships_list_url = sprintf( '%s/wp-admin/edit.php?s&post_status=wcm-active&post_type=wc_user_membership&post_parent=%d', $item['site_url'], $item['id'] );
 
+		if ( $column_name === 'name' ) {
+			$edit_url = sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $item['site_url'], $item['id'] );
+			return sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), $item[ $column_name ] . ' (#' . $item['id'] . ')' );
+		}
 		if ( $column_name === 'network_pass_id' && $item[ $column_name ] ) {
 			return sprintf( '<code>%s</code>', $item[ $column_name ] );
 		}
@@ -65,7 +98,15 @@ class Membership_Plans_Table extends \WP_List_Table {
 
 			$memberships_list_url_with_emails_url = add_query_arg(
 				\Newspack_Network\Woocommerce_Memberships\Admin::MEMBERSHIPS_TABLE_EMAILS_QUERY_PARAM,
-				implode( ',', $discrepancies ),
+				implode(
+					',',
+					array_map(
+						function( $email_address ) {
+							return urlencode( $email_address );
+						},
+						$discrepancies
+					)
+				),
 				$memberships_list_url
 			);
 			$message = sprintf(
@@ -80,13 +121,18 @@ class Membership_Plans_Table extends \WP_List_Table {
 			);
 			return sprintf( '<a href="%s">%s</a>', esc_url( $memberships_list_url_with_emails_url ), esc_html( $message ) );
 		}
-		if ( $column_name === 'links' ) {
-			$edit_url = sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $item['site_url'], $item['id'] );
-			return sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), esc_html__( 'Edit', 'newspack-network' ) );
-		}
-		if ( $column_name === 'active_members_count' && $item[ $column_name ] ) {
+		if ( $column_name === 'active_memberships_count' && isset( $item[ $column_name ] ) ) {
 			return sprintf( '<a href="%s">%s</a>', esc_url( $memberships_list_url ), $item[ $column_name ] );
 		}
 		return isset( $item[ $column_name ] ) ? $item[ $column_name ] : '';
+	}
+
+	/**
+	 * Get sortable columns.
+	 */
+	public function get_sortable_columns() {
+		return [
+			'network_pass_id' => [ 'network_pass_id', false, __( 'Network Pass ID' ), __( 'Table ordered by Network Pass ID.' ) ],
+		];
 	}
 }

--- a/includes/hub/admin/class-membership-plans.php
+++ b/includes/hub/admin/class-membership-plans.php
@@ -88,7 +88,7 @@ abstract class Membership_Plans {
 		);
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			Debugger::log( 'API request for node\'s memberships failed' );
-			return;
+			return null;
 		}
 		return json_decode( wp_remote_retrieve_body( $response ) );
 	}
@@ -126,6 +126,9 @@ abstract class Membership_Plans {
 				$query_args['include_active_members_emails'] = 1;
 			}
 			$node_plans = self::fetch_collection_from_api( $node, 'wc/v2/memberships/plans', 'membership-plans', $query_args );
+			if ( $node_plans === null ) {
+				continue;
+			}
 			foreach ( $node_plans as $plan ) {
 				$network_pass_id = null;
 				foreach ( $plan->meta_data as $meta ) {

--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -135,7 +135,9 @@ class Admin {
 		if ( $request && isset( $request->get_headers()['x_np_network_signature'] ) ) {
 			// Add network plan ID to the response.
 			$plan = wc_memberships_get_membership_plan( $response->data['plan_id'] );
-			$response->data['plan_network_id'] = get_post_meta( $plan->id, self::NETWORK_ID_META_KEY, true );
+			if ( $plan !== false ) {
+				$response->data['plan_network_id'] = get_post_meta( $plan->id, self::NETWORK_ID_META_KEY, true );
+			}
 		}
 		return $response;
 	}

--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -66,6 +66,7 @@ class Admin {
 		add_filter( 'post_row_actions', array( __CLASS__, 'post_row_actions' ), 99, 2 ); // After the Memberships plugin.
 		add_filter( 'map_meta_cap', array( __CLASS__, 'map_meta_cap' ), 20, 4 );
 		add_filter( 'wc_memberships_rest_api_membership_plan_data', [ __CLASS__, 'add_data_to_membership_plan_response' ], 2, 3 );
+		add_filter( 'woocommerce_rest_prepare_wc_user_membership', [ __CLASS__, 'add_data_to_wc_user_membership_response' ], 2, 3 );
 		add_filter( 'request', [ __CLASS__, 'request_query' ] );
 		add_action( 'pre_user_query', [ __CLASS__, 'pre_user_query' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notices' ] );
@@ -100,12 +101,43 @@ class Admin {
 	 */
 	public static function add_data_to_membership_plan_response( $data, $plan, $request ) {
 		if ( $request && isset( $request->get_headers()['x_np_network_signature'] ) ) {
-			$data['active_members_count'] = $plan->get_memberships_count( 'active' );
-			if ( $request->get_param( 'include_active_members_emails' ) ) {
-				$data['active_members_emails'] = self::get_active_members_emails( $plan );
+			$data['active_memberships_count'] = $plan->get_memberships_count( 'active' );
+			$network_pass_id = get_post_meta( $plan->id, self::NETWORK_ID_META_KEY, true );
+			if ( $network_pass_id && $request->get_param( 'include_active_members_emails' ) ) {
+				$data['active_subscriptions_count'] = self::get_plan_related_active_subscriptions( $plan );
+				$data['active_members_emails'] = array_values( array_unique( self::get_active_members_emails( $plan ) ) );
+			} else {
+				$data['active_subscriptions_count'] = __( 'Only displayed for plans with a Network ID.', 'newspack-network' );
 			}
 		}
 		return $data;
+	}
+
+	/**
+	 * Get the active subscriptions related to a membership plan.
+	 *
+	 * @param \WC_Memberships_Membership_Plan $plan The membership plan.
+	 */
+	public static function get_plan_related_active_subscriptions( $plan ) {
+		$product_ids = $plan->get_product_ids();
+		$subscriptions = wcs_get_subscriptions_for_product( $product_ids, 'ids', [ 'subscription_status' => 'active' ] );
+		return count( $subscriptions );
+	}
+
+	/**
+	 * Filter user membership data from REST API.
+	 *
+	 * @param \WP_REST_Response $response the response object.
+	 * @param null|\WP_Post     $user the user membership post object.
+	 * @param \WP_REST_Request  $request the request object.
+	 */
+	public static function add_data_to_wc_user_membership_response( $response, $user, $request ) {
+		if ( $request && isset( $request->get_headers()['x_np_network_signature'] ) ) {
+			// Add network plan ID to the response.
+			$plan = wc_memberships_get_membership_plan( $response->data['plan_id'] );
+			$response->data['plan_network_id'] = get_post_meta( $plan->id, self::NETWORK_ID_META_KEY, true );
+		}
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some tweaks to the Membership Plans table:

1. Wording changes (e.g. "Active Members" -> "Active Memberships")
2. Adds an "Active Subscriptions" column:

<img width="325" alt="image" src="https://github.com/Automattic/newspack-network/assets/7383192/9f6d197b-15b5-441f-add2-014e09dc87ba">

3. Enables table sorting by Network ID
4. Removes "Links" column in favour of linking with the plan name

(Note: this is a part of integrating the changes from the `data-integrity-improvements` branch (https://github.com/Automattic/newspack-network/pull/89))

### How to test the changes in this Pull Request:

1. Set `NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_FEATURES` env variable to `true`
1. Visit the "Membership Plans" view on the Hub site and observe the changes listed above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->