### PR TITLE
feat(subscriptions): limit network-sync'd subscriptions buying

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -26,6 +26,7 @@ class Initializer {
 			Hub\Pull_Endpoint::init();
 			Hub\Event_Listeners::init();
 			Hub\Newspack_Ads_GAM::init();
+			Hub\Network_Data_Endpoint::init();
 			Hub\Connect_Node::init();
 		}
 
@@ -56,6 +57,7 @@ class Initializer {
 		Woocommerce_Memberships\Admin::init();
 		Woocommerce_Memberships\Events::init();
 		Woocommerce_Subscriptions\Admin::init();
+		Woocommerce_Subscriptions\Limiter::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -183,4 +183,27 @@ class Node {
 		);
 		return json_decode( wp_remote_retrieve_body( $response ) );
 	}
+
+	/**
+	 * Get all subscriptions.
+	 *
+	 * @param string $email The email to get subscriptions for.
+	 * @param string $plan_network_ids The plan network ID to get subscriptions for.
+	 */
+	public function get_subscriptions_with_network_plans( $email, $plan_network_ids ) {
+		$response = wp_remote_get( // phpcs:ignore
+			add_query_arg(
+				[
+					'email'            => $email,
+					'plan_network_ids' => $plan_network_ids,
+				],
+				$this->get_url() . '/wp-json/newspack-network/v1/subscriptions'
+			),
+			[
+				'headers' => $this->get_authorization_headers( 'subscriptions' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+		return json_decode( wp_remote_retrieve_body( $response ) );
+	}
 }

--- a/includes/node/class-info-endpoints.php
+++ b/includes/node/class-info-endpoints.php
@@ -34,10 +34,32 @@ class Info_Endpoints {
 				[
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ __CLASS__, 'handle_info_request' ],
-					'permission_callback' => '__return_true',
+					'permission_callback' => [ __CLASS__, 'permission_callback' ],
 				],
 			]
 		);
+		register_rest_route(
+			'newspack-network/v1',
+			'/subscriptions',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_subscriptions_request' ],
+					'permission_callback' => [ __CLASS__, 'permission_callback' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * The permission callback.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public static function permission_callback( $request ) {
+		$route = $request->get_route();
+		$request_slug = substr( $route, strrpos( $route, '/' ) + 1 );
+		return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, $request_slug, Settings::get_secret_key() );
 	}
 
 	/**
@@ -52,6 +74,18 @@ class Info_Endpoints {
 				'not_sync_users_emails' => \Newspack_Network\Utils\Users::get_not_synchronized_users_emails(),
 				'no_role_users_emails'  => \Newspack_Network\Utils\Users::get_no_role_users_emails(),
 			]
+		);
+	}
+
+	/**
+	 * Handles the subscriptions request.
+	 * Will return the active subscription IDs for the given email, when matching a membership by plan network ID.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public static function handle_subscriptions_request( $request ) {
+		return rest_ensure_response(
+			\Newspack_Network\Utils\Users::get_users_active_subscriptions_tied_to_network_ids( $request['email'], $request['plan_network_ids'] )
 		);
 	}
 }

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -238,4 +238,43 @@ class Users {
 	public static function get_not_synchronized_users_count() {
 		return count( self::get_not_synchronized_users( [ 'id' ] ) );
 	}
+
+	/**
+	 * Get user's active subscriptions tied to a network ID.
+	 *
+	 * @param string $email The email of the user to look for.
+	 * @param array  $plan_network_ids Network IDs of the plans.
+	 * @return array Array of active subscription IDs.
+	 */
+	public static function get_users_active_subscriptions_tied_to_network_ids( $email, $plan_network_ids ) {
+		if ( ! function_exists( 'wc_memberships_get_user_memberships' ) || ! function_exists( 'wcs_get_subscription' ) ) {
+			return [];
+		}
+		$active_subscription_ids = [];
+		$user = get_user_by( 'email', $email );
+		if ( ! $user ) {
+			return [];
+		}
+		$memberships = wc_memberships_get_user_memberships( $user->ID );
+		foreach ( $memberships as $membership ) {
+			$membership_plan_network_id = get_post_meta( $membership->get_plan()->get_id(), \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true );
+			if ( ! in_array( $membership_plan_network_id, $plan_network_ids ) ) {
+				continue;
+			}
+			$wcm_wcs_integration = wc_memberships()->get_integrations_instance()->get_subscriptions_instance();
+			if ( ! $wcm_wcs_integration ) {
+				continue;
+			}
+			$subscription_id = $wcm_wcs_integration->get_user_membership_subscription_id( $membership->get_id() );
+			if ( ! $subscription_id ) {
+				continue;
+			}
+			$subscription = wcs_get_subscription( $subscription_id );
+			$subscription_status = $subscription ? $subscription->get_status() : null;
+			if ( $subscription_status === 'active' ) {
+				$active_subscription_ids[] = $subscription_id;
+			}
+		}
+		return $active_subscription_ids;
+	}
 }

--- a/includes/woocommerce-subscriptions/class-admin.php
+++ b/includes/woocommerce-subscriptions/class-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Network Admin customizations for woocommerce subscriptions.
+ * Newspack Network Admin customizations for WooCommerce Subscriptions.
  *
  * @package Newspack
  */
@@ -8,7 +8,7 @@
 namespace Newspack_Network\Woocommerce_Subscriptions;
 
 /**
- * Handles admin tweaks for woocommerce subscriptions.
+ * Handles admin tweaks for WooCommerce Subscriptions.
  *
  * Adds a metabox to the membership plan edit screen to allow the user to add a network id metadata to the plans
  */

--- a/includes/woocommerce-subscriptions/class-limiter.php
+++ b/includes/woocommerce-subscriptions/class-limiter.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Newspack Network limiter for WooCommerce Subscriptions.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Woocommerce_Subscriptions;
+
+/**
+ * Handles limiting for WooCommerce Subscriptions - only one
+ */
+class Limiter {
+	/**
+	 * Cache for restriction checking results.
+	 *
+	 * @var array
+	 */
+	private static $cache = [];
+
+	/**
+	 * Initializer.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_subscription_is_purchasable', [ __CLASS__, 'restrict_network_subscriptions' ], 10, 2 );
+		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'woocommerce_cart_product_cannot_be_purchased_message' ], 10, 2 );
+	}
+
+	/**
+	 * Restricts subscription purchasing from a network-synchronized plan to one.
+	 *
+	 * @param bool                                                        $purchasable Whether the subscription product is purchasable.
+	 * @param \WC_Product_Subscription|\WC_Product_Subscription_Variation $subscription_product The subscription product.
+	 * @return bool
+	 */
+	public static function restrict_network_subscriptions( $purchasable, $subscription_product ) {
+		return self::can_buy_subscription( $subscription_product ) ? $purchasable : false;
+	}
+
+	/**
+	 * Verify if this subscription can be bought.
+	 *
+	 * @param \WC_Product_Subscription|\WC_Product_Subscription_Variation $subscription_product The subscription product.
+	 */
+	public static function can_buy_subscription( $subscription_product ) {
+		$cache_key = $subscription_product->get_id();
+		if ( isset( self::$cache[ $cache_key ] ) ) {
+			return self::$cache[ $cache_key ];
+		}
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			self::$cache[ $cache_key ] = true;
+			return self::$cache[ $cache_key ];
+		}
+
+		// Get the membership plan related to the subscription.
+		$plans = self::get_plans_from_subscription_product( $subscription_product );
+		if ( empty( $plans ) ) {
+			self::$cache[ $cache_key ] = true;
+			return self::$cache[ $cache_key ];
+		}
+		$user_email = get_userdata( $user_id )->user_email;
+		$params = [
+			'email'            => $user_email,
+			'plan_network_ids' => array_column( $plans, 'network_pass_id' ),
+			'site'             => get_bloginfo( 'url' ),
+		];
+		$response = \Newspack_Network\Utils\Requests::request_to_hub( 'wp-json/newspack-network/v1/network-subscriptions', $params, 'GET' );
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code !== 200 ) {
+			self::$cache[ $cache_key ] = true;
+			return self::$cache[ $cache_key ];
+		}
+		$response_data = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( isset( $response_data->active_subscriptions_ids ) && count( $response_data->active_subscriptions_ids ) > 0 ) {
+			self::$cache[ $cache_key ] = false;
+			return self::$cache[ $cache_key ];
+		}
+		self::$cache[ $cache_key ] = true;
+		return self::$cache[ $cache_key ];
+	}
+
+	/**
+	 * Get the plan related to the subscription product.
+	 *
+	 * @param WC_Product $product Product data.
+	 */
+	public static function get_plans_from_subscription_product( $product ) {
+		$membership_plans = [];
+		if ( ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
+			return [];
+		}
+		$plans = array_filter(
+			wc_memberships_get_membership_plans(),
+			function( $plan ) use ( $product ) {
+				return in_array( $product->get_id(), $plan->get_product_ids() );
+			}
+		);
+		return array_map(
+			function( $plan ) {
+				return [
+					'id'              => $plan->get_id(),
+					'network_pass_id' => get_post_meta( $plan->post->ID, \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true ),
+				];
+			},
+			$plans
+		);
+	}
+
+	/**
+	 * Filters the error message shown when a product can't be added to the cart.
+	 *
+	 * @param string     $message Message.
+	 * @param WC_Product $product_data Product data.
+	 *
+	 * @return string
+	 */
+	public static function woocommerce_cart_product_cannot_be_purchased_message( $message, $product_data ) {
+		if ( ! self::can_buy_subscription( $product_data ) ) {
+			return __( 'You can only purchase one subscription in this network at a time.', 'newspack-network' );
+		}
+		return $message;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Restricts subscription buying if the user has already a subscription on another network site (if that subscription is tied to a synchronised membership plan).  

<img width="713" alt="image" src="https://github.com/user-attachments/assets/e93195b0-8c52-4484-8ffa-da042acc455d">

See 1200133283036252-as-1207352955560208/f

### How to test the changes in this Pull Request:

1. Create a granted-on-subscription memberships plan on two network sites, and make them synchronised (set same `Network ID` in the plan settings)
3. One one site, buy the subscription, which should grant you the plan
4. On the second site, log in/register using the same email address
5. On the second site, try to buy the membership-granting subscription – observe it's not allowed (see screenshot above)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207352955560208