### PR TITLE
feat(users): bulk user network sync

### DIFF
--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -13,6 +13,8 @@ use const Newspack_Network\constants\EVENT_LOG_PAGE_SLUG;
  * Class to handle the Users admin page
  */
 class Users {
+	private const SYNC_BULK_ACTION = 'sync-across-network';
+	private const SYNC_BULK_SENDBACK_PARAM = 'np_network_manual_sync_updated_user_count';
 
 	/**
 	 * Runs the initialization.
@@ -21,6 +23,9 @@ class Users {
 		add_filter( 'manage_users_columns', [ __CLASS__, 'manage_users_columns' ] );
 		add_filter( 'manage_users_custom_column', [ __CLASS__, 'manage_users_custom_column' ], 99, 3 ); // priority must be higher than Jetpack's jetpack_show_connection_status (10).
 		add_filter( 'users_list_table_query_args', [ __CLASS__, 'users_list_table_query_args' ] );
+		add_filter( 'bulk_actions-users', [ __CLASS__, 'add_users_bulk_actions' ] );
+		add_filter( 'handle_bulk_actions-users', [ __CLASS__, 'users_bulk_actions_sendback' ], 10, 3 );
+		add_action( 'admin_init', [ __CLASS__, 'handle_users_bulk_actions' ] );
 	}
 
 	/**
@@ -118,5 +123,72 @@ class Users {
 			unset( $args['role'] );
 		}
 		return $args;
+	}
+
+	/**
+	 * Add custom bulk actions to the Users table.
+	 *
+	 * @param array $actions An array of the available bulk actions.
+	 */
+	public static function add_users_bulk_actions( $actions ) {
+		if ( current_user_can( 'edit_users' ) ) {
+			$actions[ self::SYNC_BULK_ACTION ] = __( 'Sync across network', 'newspack-network' );
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Change sendback URL for the bulk action.
+	 *
+	 * @param string $sendback The redirect URL.
+	 * @param string $action The action being taken.
+	 * @param array  $user_ids    The items to take the action on.
+	 */
+	public static function users_bulk_actions_sendback( $sendback, $action, $user_ids ) {
+		if ( $action === self::SYNC_BULK_ACTION && ! empty( $user_ids ) ) {
+			$sendback = add_query_arg( self::SYNC_BULK_SENDBACK_PARAM, count( $user_ids ), $sendback );
+		}
+		return $sendback;
+	}
+
+	/**
+	 * Handle custom bulk actions to the Users table.
+	 */
+	public static function handle_users_bulk_actions() {
+		// Handle the bulk-manual-sync request.
+		if ( isset( $_GET['action'], $_REQUEST['users'], $_REQUEST['_wpnonce'] ) && $_GET['action'] === self::SYNC_BULK_ACTION ) {
+			if ( ! wp_verify_nonce( sanitize_text_field( $_REQUEST['_wpnonce'] ), 'bulk-users' ) ) {
+				return;
+			}
+			$user_ids = array_map( 'intval', (array) $_REQUEST['users'] );
+			foreach ( $user_ids as $user_id ) {
+				$user = get_user_by( 'ID', $user_id );
+				if ( $user ) {
+					do_action( 'newspack_network_manual_sync_user', $user );
+				}
+			}
+		}
+
+		// Handle the admin notice.
+		if ( isset( $_GET[ self::SYNC_BULK_SENDBACK_PARAM ] ) && $_GET[ self::SYNC_BULK_SENDBACK_PARAM ] > 0 ) {
+			$count = intval( $_GET[ self::SYNC_BULK_SENDBACK_PARAM ] );
+			$message = sprintf(
+				/* translators: %d is the users count. */
+				_n(
+					'Scheduled %d user to be synced across the network.',
+					'Scheduled %d users to be synced across the network.',
+					$count,
+					'newspack-network'
+				),
+				$count
+			);
+			add_action(
+				'admin_notices',
+				function () use ( $message ) {
+					printf( '<div class="notice notice-success is-dismissible"><p>%s</p></div>', esc_html( $message ) );
+				}
+			);
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an option to bulk-sync users across network.

<img width="267" alt="image" src="https://github.com/user-attachments/assets/3072c41c-5f4e-488a-bfeb-4be51e9a3470">

### How to test the changes in this Pull Request:

1. Ensure you have some non-network-synced users (e.g. editors)
2. Ensure they are not synced across the network (or make some changes to them)
3. Visit the WP Admin Users view, select the users and bulk-network-update them using the the "Bulk actions" select
4. Observe the appropriate events have been added to the Event Log and that once they are processed on the network, the users are updated on other sites

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207830031186495