### PR TITLE
fix(memberships-sync): handle active subs from other nodes

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -24,6 +24,7 @@ class Initializer {
 			Hub\Nodes::init();
 			Hub\Webhook::init();
 			Hub\Pull_Endpoint::init();
+			Hub\Network_Data_Endpoint::init();
 			Hub\Event_Listeners::init();
 			Hub\Newspack_Ads_GAM::init();
 			Hub\Connect_Node::init();
@@ -55,6 +56,7 @@ class Initializer {
 
 		Woocommerce_Memberships\Admin::init();
 		Woocommerce_Memberships\Events::init();
+		Woocommerce_Memberships\Subscriptions_Integration::init();
 		Woocommerce_Subscriptions\Admin::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );

--- a/includes/hub/class-network-data-endpoint.php
+++ b/includes/hub/class-network-data-endpoint.php
@@ -36,7 +36,7 @@ class Network_Data_Endpoint {
 				[
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ __CLASS__, 'api_get_network_subscriptions' ],
-					'permission_callback' => '__return_true',
+					'permission_callback' => '__return_true', // Auth will be handled by \Newspack_Network\Utils\Requests::get_request_to_hub_errors.
 				],
 			]
 		);
@@ -46,26 +46,26 @@ class Network_Data_Endpoint {
 	 * Get active subscription IDs from the network.
 	 *
 	 * @param string $email Email of the user.
-	 * @param string $plan_network_id Network ID of the plan.
+	 * @param string $plan_network_ids Network ID of the plan.
 	 * @param string $site Site URL.
 	 */
-	public static function get_active_subscription_ids_from_network( $email, $plan_network_id, $site ) {
+	public static function get_active_subscription_ids_from_network( $email, $plan_network_ids, $site = false ) {
 		$active_subscriptions_ids = [];
 		foreach ( Nodes::get_all_nodes() as $node ) {
-			if ( $site === $node->get_url() ) {
-				// Skip the node which is making the request. It's only interested in the other nodes.
+			if ( $site && $site === $node->get_url() ) {
+				// Skip the node which is making the request.
 				continue;
 			}
+			$node_subscription_ids = $node->get_subscriptions_with_network_plans( $email, $plan_network_ids );
+			$active_subscriptions_ids = array_merge( $active_subscriptions_ids, $node_subscription_ids );
+		}
+		// Also look on the Hub itself, unless the $site was provided.
+		if ( $site !== false ) {
 			$active_subscriptions_ids = array_merge(
 				$active_subscriptions_ids,
-				$node->get_subscriptions_with_network_plan( $email, $plan_network_id )
+				\Newspack_Network\Utils\Users::get_users_active_subscriptions_tied_to_network_ids( $email, $plan_network_ids )
 			);
 		}
-		// Also look on the Hub itself.
-		$active_subscriptions_ids = array_merge(
-			$active_subscriptions_ids,
-			\Newspack_Network\Utils\Users::get_users_active_subscriptions_tied_to_network_id( $email, $plan_network_id )
-		);
 		return $active_subscriptions_ids;
 	}
 
@@ -80,13 +80,12 @@ class Network_Data_Endpoint {
 		if ( \is_wp_error( $request_error ) ) {
 			return new WP_REST_Response( [ 'error' => $request_error->get_error_message() ], 403 );
 		}
-		if ( ! isset( $request['plan_network_id'] ) || empty( $request['plan_network_id'] ) ) {
-			return new WP_REST_Response( [ 'error' => __( 'Missing plan_network_id', 'newspack-network' ) ], 400 );
+		if ( ! isset( $request['plan_network_ids'] ) || empty( $request['plan_network_ids'] ) ) {
+			return new WP_REST_Response( [ 'error' => __( 'Missing plan_network_ids', 'newspack-network' ) ], 400 );
 		}
-
 		return new WP_REST_Response(
 			[
-				'active_subscriptions_ids' => self::get_active_subscription_ids_from_network( $request['email'], $request['plan_network_id'], $request['site'] ),
+				'active_subscriptions_ids' => self::get_active_subscription_ids_from_network( $request['email'], $request['plan_network_ids'], $request['site'] ),
 			]
 		);
 	}

--- a/includes/hub/class-network-data-endpoint.php
+++ b/includes/hub/class-network-data-endpoint.php
@@ -57,7 +57,9 @@ class Network_Data_Endpoint {
 				continue;
 			}
 			$node_subscription_ids = $node->get_subscriptions_with_network_plans( $email, $plan_network_ids );
-			$active_subscriptions_ids = array_merge( $active_subscriptions_ids, $node_subscription_ids );
+			if ( is_array( $node_subscription_ids ) ) {
+				$active_subscriptions_ids = array_merge( $active_subscriptions_ids, $node_subscription_ids );
+			}
 		}
 		// Also look on the Hub itself, unless the $site was provided.
 		if ( $site !== false ) {

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -12,7 +12,7 @@ use Newspack_Network\Rest_Authenticaton;
 use WP_Post;
 
 /**
- * Class to represent one Node of the netowrk
+ * Class to represent a Node in the network
  */
 class Node {
 	/**
@@ -179,6 +179,30 @@ class Node {
 			$this->get_url() . '/wp-json/newspack-network/v1/info',
 			[
 				'headers' => $this->get_authorization_headers( 'info' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+		return json_decode( wp_remote_retrieve_body( $response ) );
+	}
+
+	/**
+	 * Get all subscriptions of a user, related to provided network plan IDs.
+	 *
+	 * @param string $email The email to get subscriptions for.
+	 * @param string $plan_network_ids The plan network ID to get subscriptions for.
+	 */
+	public function get_subscriptions_with_network_plans( $email, $plan_network_ids ) {
+		$response = wp_remote_get( // phpcs:ignore
+			add_query_arg(
+				[
+					'email'            => $email,
+					'plan_network_ids' => $plan_network_ids,
+				],
+				$this->get_url() . '/wp-json/newspack-network/v1/subscriptions'
+			),
+			[
+				'headers' => $this->get_authorization_headers( 'subscriptions' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			]
 		);
 		return json_decode( wp_remote_retrieve_body( $response ) );

--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -73,6 +73,10 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 		User_Update_Watcher::$enabled     = false;
 
 		$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
+		if ( ! $user ) {
+			Debugger::log( 'User not found.' );
+			return;
+		}
 
 		$user_membership = wc_memberships_get_user_membership( $user->ID, $local_plan_id );
 
@@ -108,7 +112,7 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 			)
 		);
 
-		Debugger::log( 'User membership updated' );
+		Debugger::log( 'User membership updated.' );
 	}
 
 	/**

--- a/includes/node/class-info-endpoints.php
+++ b/includes/node/class-info-endpoints.php
@@ -31,12 +31,32 @@ class Info_Endpoints {
 				[
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => [ __CLASS__, 'handle_info_request' ],
-					'permission_callback' => function( $request ) {
-						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'info', Settings::get_secret_key() );
-					},
+					'permission_callback' => [ __CLASS__, 'permission_callback' ],
 				],
 			]
 		);
+		register_rest_route(
+			'newspack-network/v1',
+			'/subscriptions',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_subscriptions_request' ],
+					'permission_callback' => [ __CLASS__, 'permission_callback' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * The permission callback.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public static function permission_callback( $request ) {
+		$route = $request->get_route();
+		$request_slug = substr( $route, strrpos( $route, '/' ) + 1 );
+		return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, $request_slug, Settings::get_secret_key() );
 	}
 
 	/**
@@ -51,6 +71,18 @@ class Info_Endpoints {
 				'not_sync_users_emails' => \Newspack_Network\Utils\Users::get_not_synchronized_users_emails(),
 				'no_role_users_emails'  => \Newspack_Network\Utils\Users::get_no_role_users_emails(),
 			]
+		);
+	}
+
+	/**
+	 * Handles the subscriptions request.
+	 * Will return the active subscription IDs for the given email, when matching a membership by plan network ID.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public static function handle_subscriptions_request( $request ) {
+		return rest_ensure_response(
+			\Newspack_Network\Utils\Users::get_users_active_subscriptions_tied_to_network_ids( $request['email'], $request['plan_network_ids'] )
 		);
 	}
 }

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -238,4 +238,43 @@ class Users {
 	public static function get_not_synchronized_users_count() {
 		return count( self::get_not_synchronized_users( [ 'id' ] ) );
 	}
+
+	/**
+	 * Get user's active subscriptions tied to a network ID.
+	 *
+	 * @param string $email The email of the user to look for.
+	 * @param array  $plan_network_ids Network IDs of the plans.
+	 * @return array Array of active subscription IDs.
+	 */
+	public static function get_users_active_subscriptions_tied_to_network_ids( $email, $plan_network_ids ) {
+		if ( ! function_exists( 'wc_memberships_get_user_memberships' ) || ! function_exists( 'wcs_get_subscription' ) ) {
+			return [];
+		}
+		$active_subscription_ids = [];
+		$user = get_user_by( 'email', $email );
+		if ( ! $user ) {
+			return [];
+		}
+		$memberships = wc_memberships_get_user_memberships( $user->ID );
+		foreach ( $memberships as $membership ) {
+			$membership_plan_network_id = get_post_meta( $membership->get_plan()->get_id(), \Newspack_Network\Woocommerce_Memberships\Admin::NETWORK_ID_META_KEY, true );
+			if ( ! in_array( $membership_plan_network_id, $plan_network_ids ) ) {
+				continue;
+			}
+			$wcm_wcs_integration = wc_memberships()->get_integrations_instance()->get_subscriptions_instance();
+			if ( ! $wcm_wcs_integration ) {
+				continue;
+			}
+			$subscription_id = $wcm_wcs_integration->get_user_membership_subscription_id( $membership->get_id() );
+			if ( ! $subscription_id ) {
+				continue;
+			}
+			$subscription = wcs_get_subscription( $subscription_id );
+			$subscription_status = $subscription ? $subscription->get_status() : null;
+			if ( $subscription_status === 'active' ) {
+				$active_subscription_ids[] = $subscription_id;
+			}
+		}
+		return $active_subscription_ids;
+	}
 }

--- a/includes/woocommerce-memberships/class-admin.php
+++ b/includes/woocommerce-memberships/class-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Network Admin customizations for woocommerce memberships.
+ * Newspack Network Admin customizations for WooCommerce Memberships.
  *
  * @package Newspack
  */
@@ -8,9 +8,7 @@
 namespace Newspack_Network\Woocommerce_Memberships;
 
 /**
- * Handles admin tweaks for woocommerce memberships.
- *
- * Adds a metabox to the membership plan edit screen to allow the user to add a network id metadata to the plans
+ * Handles admin tweaks for WooCommerce Memberships.
  */
 class Admin {
 

--- a/includes/woocommerce-memberships/class-events.php
+++ b/includes/woocommerce-memberships/class-events.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Network Woo Membership events
+ * Newspack Network WooCommerce Memberships events
  *
  * @package Newspack
  */

--- a/includes/woocommerce-memberships/class-subscriptions-integration.php
+++ b/includes/woocommerce-memberships/class-subscriptions-integration.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Newspack Network WooCommerce Subscriptions integration for WooCommerce Memberships.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Woocommerce_Memberships;
+
+/**
+ * Handles tweaks for WooCommerce Memberships WooCommerce Subscriptions integration.
+ */
+class Subscriptions_Integration {
+	/**
+	 * Runs the initialization.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		// You'd think this first filter is enough, but it's not. Even if the membership cancellation via linked subscription
+		// is prevented, the expiry code is also executed.
+		add_filter( 'wc_memberships_cancel_subscription_linked_membership', [ __CLASS__, 'prevent_membership_expiration' ], 10, 2 );
+		add_filter( 'wc_memberships_expire_user_membership', [ __CLASS__, 'prevent_membership_expiration' ], 10, 2 );
+	}
+
+	/**
+	 * Prevent membership expiration if another network site has a synced membership active.
+	 *
+	 * @param bool                                                      $cancel_or_expire whether to cancel/expire the membership when the subscription is cancelled (default true).
+	 * @param \WC_Memberships_Integration_Subscriptions_User_Membership $user_membership the subscription-tied membership.
+	 */
+	public static function prevent_membership_expiration( $cancel_or_expire, $user_membership ) {
+		$user_email = get_userdata( $user_membership->user_id )->user_email;
+		$membership_plan_id = get_post_meta( $user_membership->get_plan()->get_id(), Admin::NETWORK_ID_META_KEY, true );
+
+		if ( \Newspack_Network\Site_Role::is_hub() ) {
+			$active_subscriptions_ids = \Newspack_Network\Hub\Network_Data_Endpoint::get_active_subscription_ids_from_network(
+				$user_email,
+				[ $membership_plan_id ]
+			);
+		} else {
+			$params = [
+				'site'             => get_bloginfo( 'url' ),
+				'plan_network_ids' => [ $membership_plan_id ],
+				'email'            => $user_email,
+			];
+			$response = \Newspack_Network\Utils\Requests::request_to_hub( 'wp-json/newspack-network/v1/network-subscriptions', $params, 'GET' );
+			if ( is_wp_error( $response ) ) {
+				return $cancel_or_expire;
+			}
+			$active_subscriptions_ids = json_decode( wp_remote_retrieve_body( $response ) )->active_subscriptions_ids ?? [];
+		}
+		$can_cancel = empty( $active_subscriptions_ids );
+		if ( ! $can_cancel ) {
+			$user_membership->add_note(
+				__( 'Membership is not cancelled, because there is at least one active subscription linked to the membership plan on the network.', 'newspack-plugin' )
+			);
+		}
+		return $can_cancel ? $cancel_or_expire : false;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds handling of the following edge case: a user might have two separate subscriptions on two sites of the network, both granting the same (synchronized, that is!) membership. If one of these subscriptions is cancelled, but the other one still active, the membership should still be active.

See https://app.asana.com/0/1206478771616338/1207029554091953/f

### How to test the changes in this Pull Request:

1. Buy a synced-membership-granting subscription on two sites of the network, using the same email address
2. As the site admin, cancel one of the subscriptions
3. Observe that the memberships are still active on both sites

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207832962147246