### PR TITLE
feat: create data event to sync user

### DIFF
--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network;
 
 use Newspack_Network\Utils\Users as User_Utils;
+use Newspack\Data_Events;
 
 /**
  * Class to handle Node settings page
@@ -23,8 +24,20 @@ class Esp_Metadata_Sync {
 		\add_filter( 'newspack_ras_metadata_keys', [ __CLASS__, 'add_custom_metadata_fields' ] );
 		\add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
 		\add_filter( 'newspack_data_events_reader_registered_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
-		\add_action( 'newspack_network_network_reader', [ __CLASS__, 'handle_custom_metadata_for_network_readers' ] );
-		\add_action( 'newspack_network_new_network_reader', [ __CLASS__, 'handle_custom_metadata_for_network_readers' ] );
+		\add_action( 'init', [ __CLASS__, 'register_listeners' ] );
+	}
+
+	/**
+	 * Register the listeners to the Newspack Data Events API
+	 *
+	 * @return void
+	 */
+	public static function register_listeners() {
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return;
+		}
+
+		Data_Events::register_listener( 'newspack_network_new_network_reader', 'network_new_reader', [ __CLASS__, 'new_reader_data_event' ] );
 	}
 
 	/**
@@ -52,62 +65,39 @@ class Esp_Metadata_Sync {
 	 */
 	public static function handle_custom_metadata_fields( $metadata, $user_id ) {
 		if ( $user_id ) {
-			$remote_site       = \get_user_meta( $user_id, User_Utils::USER_META_REMOTE_SITE, true );
-			$registration_site = \esc_url( ! empty( \wp_http_validate_url( $remote_site ) ) ? $remote_site : \get_site_url() );
-			$metadata['network_registration_site'] = $registration_site;
+			$metadata['network_registration_site'] = self::get_registration_site_meta( $user_id );
 		}
 
 		return $metadata;
 	}
 
 	/**
-	 * Trigger a reader data sync to the connected ESP.
+	 * Get the registration site URL for a user.
 	 *
-	 * @param array $contact The contact data to sync.
+	 * @param int $user_id The user ID.
+	 *
+	 * @return string The registration site URL.
 	 */
-	public static function sync_contact( $contact ) {
-		// Only if Reader Activation and Newspack Newsletters are available.
-		if ( ! class_exists( 'Newspack\Reader_Activation' ) || ! method_exists( 'Newspack_Newsletters', 'service_provider' ) ) {
-			return;
-		}
-
-		// Only if RAS + ESP sync is enabled.
-		if ( ! \Newspack\Reader_Activation::is_enabled() || ! \Newspack\Reader_Activation::get_setting( 'sync_esp' ) ) {
-			return;
-		}
-
-		// Only if we have the ESP Data Events connectors.
-		if ( ! class_exists( 'Newspack\Data_Events\Connectors\Mailchimp' ) || ! class_exists( 'Newspack\Data_Events\Connectors\ActiveCampaign' ) ) {
-			return;
-		}
-
-		$service_provider = \Newspack_Newsletters::service_provider();
-		if ( 'mailchimp' === $service_provider ) {
-			return \Newspack\Data_Events\Connectors\Mailchimp::put( $contact );
-		} elseif ( 'active_campaign' === $service_provider ) {
-			return \Newspack\Data_Events\Connectors\ActiveCampaign::put( $contact );
-		}
+	private static function get_registration_site_meta( $user_id ) {
+		$remote_site = \get_user_meta( $user_id, User_Utils::USER_META_REMOTE_SITE, true );
+		return \esc_url( ! empty( \wp_http_validate_url( $remote_site ) ) ? $remote_site : \get_site_url() );
 	}
 
 	/**
-	 * Sync custom metadata fields for network readers.
+	 * Filter the data for the event being triggered
 	 *
 	 * @param WP_User $user The newly created or existing user.
+	 * @return void
 	 */
-	public static function handle_custom_metadata_for_network_readers( $user ) {
+	public static function new_reader_data_event( $user ) {
 		if ( ! $user ) {
 			return;
 		}
-		$contact  = \Newspack\WooCommerce_Connection::get_contact_from_customer( new \WC_Customer( $user->ID ) );
-		$metadata = $contact['metadata'] ?? [];
 
-		// Ensure email is set as the user probably won't have a billing email.
-		if ( ! isset( $contact['email'] ) ) {
-			$contact['email'] = $user->user_email;
-		}
-
-		$contact['metadata'] = self::handle_custom_metadata_fields( $metadata, $user->ID );
-
-		self::sync_contact( $contact );
+		$registration_site_meta = self::get_registration_site_meta( $user->ID );
+		return [
+			'user_id'           => $user->ID,
+			'registration_site' => $registration_site_meta,
+		];
 	}
 }

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -80,7 +80,7 @@ class Esp_Metadata_Sync {
 	 */
 	private static function get_registration_site_meta( $user_id ) {
 		$remote_site = \get_user_meta( $user_id, User_Utils::USER_META_REMOTE_SITE, true );
-		return \esc_url( ! empty( \wp_http_validate_url( $remote_site ) ) ? $remote_site : \get_site_url() );
+		return \esc_url( ! empty( $remote_site ) ? $remote_site : \get_site_url() );
 	}
 
 	/**


### PR DESCRIPTION
This PR does two things

Removes the sync of users from the `newspack_network_network_reader` and leaves it only for `newspack_network_new_network_reader`.

Instead of calling the main plugin's data events method directly, fires a custom Data Events API event and leave the handling of the event to the main plugin, since this is a RAS feature.

## Testing

* Checkout https://github.com/Automattic/newspack-plugin/pull/3259 and the `epic/consolidate-data-flows` on newspack-newsletters plugin
* Set up two sites in a network, one hub and one node
* Make sure both sites have RAS enabled and Sync to ESP option turned on (check if you need the `NEWSPACK_FORCE_ALLOW_ESP_SYNC` constant, I did.)
* Make sure you have an "Audience ID" or Master List configured
* In one of the sites, perform an action that will register a new user, like registering or donating
* Watch the logs for the other site, and wait for it to add the new user
* When the new user is processed and added, make sure you see `Executing action handlers for "network_new_reader".` in your logs
* Right after that, check for the `Normalizing contact data for reader ESP sync:` with all the contacts metadata, make sure `Network Registration Site` is present

 