### PR TITLE
Sync comment status

### DIFF
--- a/includes/class-distributor-customizations.php
+++ b/includes/class-distributor-customizations.php
@@ -27,5 +27,6 @@ class Distributor_Customizations {
 		Distributor_Customizations\Author_Distribution::init();
 		Distributor_Customizations\Author_Ingestion::init();
 		Distributor_Customizations\Authorship_Filters::init();
+		Distributor_Customizations\Comment_Status::init();
 	}
 }

--- a/includes/distributor-customizations/class-comment-status.php
+++ b/includes/distributor-customizations/class-comment-status.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Distributor Publication Date tweak.
+ * Newspack Distributor Comment Status Sync.
  *
  * @package Newspack
  */
@@ -8,7 +8,7 @@
 namespace Newspack_Network\Distributor_Customizations;
 
 /**
- * Class to keep the publication date on the distributed posts.
+ * Class to keep the Comment and Ping statuses in sync.
  */
 class Comment_Status {
 

--- a/includes/distributor-customizations/class-comment-status.php
+++ b/includes/distributor-customizations/class-comment-status.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Newspack Distributor Publication Date tweak.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+/**
+ * Class to keep the publication date on the distributed posts.
+ */
+class Comment_Status {
+
+	/**
+	 * Initialize hooks
+	 */
+	public static function init() {
+		// Comment status is already correctly distributed on PULL, so we only need the filter on PUSH and Subscriptions.
+		add_filter( 'dt_push_post_args', [ __CLASS__, 'filter_post_args' ], 10, 2 );
+
+		add_filter( 'dt_subscription_post_args', [ __CLASS__, 'filter_post_args' ], 10, 2 );
+		add_action( 'dt_process_subscription_attributes', [ __CLASS__, 'process_attributes' ], 10, 2 );
+		add_action( 'dt_process_distributor_attributes', [ __CLASS__, 'process_attributes' ], 10, 2 );
+	}
+
+	/**
+	 * Filter the arguments sent to the remote server during a push
+	 *
+	 * @param array   $post_body The post data to be sent to the Node.
+	 * @param WP_Post $post The post object.
+	 */
+	public static function filter_post_args( $post_body, $post ) {
+		$post_body['post_data']['comment_status'] = $post->comment_status;
+		$post_body['post_data']['ping_status']    = $post->ping_status;
+
+		return $post_body;
+	}
+
+	/**
+	 * Process distributed post attributes after the distribution has completed.
+	 *
+	 * @param WP_Post         $post The post object.
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public static function process_attributes( $post, $request ) {
+		wp_update_post(
+			[
+				'ID'             => $post->ID,
+				'comment_status' => $request['post_data']['comment_status'],
+				'ping_status'    => $request['post_data']['ping_status'],
+			]
+		);
+	}
+}


### PR DESCRIPTION
By default, Distributor does not sync the Comment and Ping statuses. 

This PR makes both statuses be kept in sync for distributed posts.

## Testing pushing

* On site A, create a new post and leave comments and pings closed
* Publish and distribute it to site B
* On site B, confirm that the distributed post kept the closed comments and pings statuses
* Back on site A, edit the site and change the comment status. Save
* Go back to site B and confirm the change was synced

## Testing pulling

* On site A, create a new post and leave comments and pings closed
* Publish
* On site B, pull this post from site A
* On site B, confirm that the distributed post kept the closed comments and pings statuses
* Back on site A, edit the site and change the comment status. Save
* Go back to site B and confirm the change was synced

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207141364141168