### PR TITLE
fix(sync): use `newspack_esp_sync_contact` filter for the `network_registration_site` field

### DIFF
--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -68,7 +68,7 @@ class Esp_Metadata_Sync {
 			return $contact;
 		}
 		$contact['metadata']['network_registration_site'] = self::get_registration_site_meta( $user->ID );
-		return $metadata;
+		return $contact;
 	}
 
 	/**

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -23,7 +23,7 @@ class Esp_Metadata_Sync {
 	public static function init() {
 		\add_filter( 'newspack_ras_metadata_keys', [ __CLASS__, 'add_custom_metadata_fields' ] );
 		\add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
-		\add_filter( 'newspack_data_events_reader_registered_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
+		\add_filter( 'newspack_esp_sync_contact', [ __CLASS__, 'handle_esp_sync_contact' ], 10, 2 );
 		\add_action( 'init', [ __CLASS__, 'register_listeners' ] );
 	}
 
@@ -53,6 +53,18 @@ class Esp_Metadata_Sync {
 		}
 
 		return $metadata_fields;
+	}
+
+	/**
+	 * Add handling for custom metadata fields when syncing to ESP.
+	 *
+	 * @param array $contact The contact metadata data.
+	 *
+	 * @return array The updated contact data.
+	 */
+	public static function handle_esp_sync_contact( $contact ) {
+		$contact['metadata']['network_registration_site'] = self::get_registration_site_meta( $user_id );
+		return $metadata;
 	}
 
 	/**

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -63,7 +63,8 @@ class Esp_Metadata_Sync {
 	 * @return array The updated contact data.
 	 */
 	public static function handle_esp_sync_contact( $contact ) {
-		$contact['metadata']['network_registration_site'] = self::get_registration_site_meta( $user_id );
+		$user = get_user_by( 'email', $contact['email'] );
+		$contact['metadata']['network_registration_site'] = self::get_registration_site_meta( $user->ID );
 		return $metadata;
 	}
 

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -22,7 +22,6 @@ class Esp_Metadata_Sync {
 	 */
 	public static function init() {
 		\add_filter( 'newspack_ras_metadata_keys', [ __CLASS__, 'add_custom_metadata_fields' ] );
-		\add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'handle_custom_metadata_fields' ], 10, 2 );
 		\add_filter( 'newspack_esp_sync_contact', [ __CLASS__, 'handle_esp_sync_contact' ], 10, 2 );
 		\add_action( 'init', [ __CLASS__, 'register_listeners' ] );
 	}
@@ -69,22 +68,6 @@ class Esp_Metadata_Sync {
 		}
 		$contact['metadata']['network_registration_site'] = self::get_registration_site_meta( $user->ID );
 		return $contact;
-	}
-
-	/**
-	 * Add handling for custom metadata fields. Only fire for newly created users.
-	 *
-	 * @param array     $metadata The contact metadata data.
-	 * @param int|false $user_id Created user ID, or false if the user already exists.
-	 *
-	 * @return array The updated contact data.
-	 */
-	public static function handle_custom_metadata_fields( $metadata, $user_id ) {
-		if ( $user_id ) {
-			$metadata['network_registration_site'] = self::get_registration_site_meta( $user_id );
-		}
-
-		return $metadata;
 	}
 
 	/**

--- a/includes/class-esp-metadata-sync.php
+++ b/includes/class-esp-metadata-sync.php
@@ -64,6 +64,9 @@ class Esp_Metadata_Sync {
 	 */
 	public static function handle_esp_sync_contact( $contact ) {
 		$user = get_user_by( 'email', $contact['email'] );
+		if ( ! $user ) {
+			return $contact;
+		}
 		$contact['metadata']['network_registration_site'] = self::get_registration_site_meta( $user->ID );
 		return $metadata;
 	}


### PR DESCRIPTION
https://github.com/Automattic/newspack-plugin/pull/3359 introduced a new `newspack_esp_sync_contact` filter, which should be used for any contact data manipulation during a sync.

This change also removes an unnecessary hook that had no effect.

### How to test

1. Make sure your Hub and Node sites are able to sync contact:

* Enable RAS
* Enable ESP Sync in Newspack > Engagement > Advanced
* Make sure to select a Master list
* Make sure the "Network Registration Site" field is enabled
* Make sure testing sites have `define( 'NEWSPACK_ALLOW_READER_SYNC', true );`
* Make sure the main plugin is running latest `trunk`
* Also make sure you have `define( 'NEWSPACK_LOG_LEVEL', 3);`  to be able to see ESP sync logs

2. Watch the logs `tail -f /tmp/2024-mm-dd--newspack_esp_sync`

3. Visit the Node site as an anonymous visitor and register
4. Confirm you see a `RAS Reader registration` log entry and the data includes the "Registration Site" with the Node url
5. Wait for the event to propagate to the Hub, (or run `wp newspack-network process-webhooks`)
6. Confirm you now see a `RAS Newspack Network: User propagated from another site in the network.` in the Hub's logs, and that the data includes the "Registration Site" with the Node url

7. Now as an anonymous reader visit the Hub and register
8. Make sure you see the `RAS Reader registration` event on the Hub's log, with "Registration Site"
9. Go to the Node and Pull the latest events in Newspack Network > Node Settings
10. Confirrm you see the   `RAS Newspack Network: User propagated from another site in the network.` in the Node's logs, with the "Registration Site" filled