### PR TITLE
feat: handle email change on propagated users

### DIFF
--- a/includes/class-user-update-watcher.php
+++ b/includes/class-user-update-watcher.php
@@ -134,9 +134,10 @@ class User_Update_Watcher {
 	 * @param string $type The change type: meta or prop.
 	 * @param string $key The key of the changed meta or prop.
 	 * @param string $value The new value of the changed meta or prop.
+	 * @param string $old_email In case of an email change, use the old email to find the user in the target site.
 	 * @return void
 	 */
-	private static function add_change( $user_id, $type, $key, $value ) {
+	private static function add_change( $user_id, $type, $key, $value, $old_email = '' ) {
 		if ( ! isset( self::$updated_users[ $user_id ] ) ) {
 			$user = get_userdata( $user_id );
 			if ( $user ) {
@@ -146,6 +147,11 @@ class User_Update_Watcher {
 			} else {
 				return;
 			}
+		}
+
+		// If the email is being updated, we need to use the old email to find the user in the target site.
+		if ( ! empty( $old_email ) ) {
+			self::$updated_users[ $user_id ]['email'] = $old_email;
 		}
 
 		if ( ! isset( self::$updated_users[ $user_id ][ $type ] ) ) {
@@ -231,7 +237,8 @@ class User_Update_Watcher {
 
 		foreach ( self::$user_props as $prop ) {
 			if ( $old_user_data->$prop !== $user_data[ $prop ] ) {
-				self::add_change( $user_id, 'prop', $prop, $user_data[ $prop ] );
+				$old_email = 'user_email' === $prop ? $old_user_data->$prop : '';
+				self::add_change( $user_id, 'prop', $prop, $user_data[ $prop ], $old_email );
 			}
 		}
 	}


### PR DESCRIPTION
Correctly handles email changes on synced users.

### Notes on the implementation

The user email is the glue we use to sync everything about the user in the network. It's what identifies that users in different sites are the same, since they may have a different ID and even usernames in each site.

When they change their email in one of the sites, the new email won't be found in the other sites and the user would no longer be synced.

The solution proposed is very simple. When a user has their email changed, we send the old email (previous to the change) as the email to be used to find the user in the target site. It's simple  enough and it works well.

Here is why I didn't go with a ID based solution:

The natural thought is to base the sync in the user ID, instead of the email, since we always store `remote_user_id`  and `remote_site` metadta for every user, we could manage to use this to find the user in the target site based on their ID or metadata.

But this approach also has its caveats:

First, it's a little more complex than it seems, because the change in the email will not necessarily happen in the same site where the user has been created. This forces us to do some additional juggle:

* With every user change event we send the "remote_user_id" and "remote_site" metadata along
* When I receive the event I have to check if the "remote_site" is the current site. If it is, I search the "remote_id" in the actual Users table ID, otherwise I search for the user based on the metadata.

This is doable, but felt just as fragile as using the old email approach.

I was trying to find pros and cons of each approach and they were more or less the same. But then I thought of one very realistic scenario where the "old_email" solution works better.

When launching new sites with pre-existing users, there's a chance that the same user already exists in more than one site in the network. In such a case, the user sync will work fine, but these users won't have any "remote_id" or "remote_site" information in any site. Thus the ID based solution would not work.

Then the email based solution felt more robust to me.

### Testing

Test updating user email from every direction possible and confirm the updates work fine, along with other user updates (display name, etc)

* From the site where the user was originally registered to the other
* From the site where the user was propagated to, and see if the updates work in their origin site

You can also confirm that any change via `wp_user_update` will also work, as long as the request is correctly terminated.

```
$a = [ 'ID' => 1234, 'user_email' => 'newemail@example.com' ];
wp_update_user( $a );
wp_die(); // this ensure that shutdown hooks are called
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208036449301596