### PR TITLE
fix: remove recursive import `use`

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -7,8 +7,6 @@
 
 namespace Newspack_Network;
 
-use Newspack_Network\Admin;
-
 /**
  * Class to handle the plugin admin pages
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes recursive import in class `Newspack_Network\Admin`