### PR TITLE
fix: exclude refund orders from backfill

### DIFF
--- a/includes/cli/backfillers/class-order-changed.php
+++ b/includes/cli/backfillers/class-order-changed.php
@@ -33,6 +33,7 @@ class Order_Changed extends Abstract_Backfiller {
 	public function get_events() {
 		$params = [
 			'limit' => -1,
+			'type'  => 'shop_order',
 		];
 
 		if ( $this->start || $this->end ) {


### PR DESCRIPTION
When running backfillers for orders, the script will error if we encounter a Refund order.

This fixes it. We don't need to sync them because we are just using order to display in the central dashboard