### PR TITLE
Fix Submenu Highlights 

### DIFF
--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -32,6 +32,7 @@ class Nodes {
 		add_action( 'newspack_network_node_saved', [ __CLASS__, 'sync_nodes' ] );
 		add_action( 'newspack_network_node_trashed', [ __CLASS__, 'sync_nodes' ] );
 		add_action( 'newspack_network_node_untrashed', [ __CLASS__, 'sync_nodes' ] );
+		add_filter( 'submenu_file', [ __CLASS__, 'submenu_file' ] );
 	}
 
 	/**
@@ -337,5 +338,25 @@ class Nodes {
 		}
 
 		do_action( 'newspack_network_nodes_synced', $nodes_data );
+	}
+
+	/**
+	 * Highlight the correct submenu item.
+	 *
+	 * @param string $submenu_file The current submenu file.
+	 * 
+	 * @return string
+	 */
+	public static function submenu_file( $submenu_file ) {
+		global $pagenow;
+
+		// Highlight "Nodes" submenu on Add New Node screen.
+		if ( $submenu_file === Network_Admin::PAGE_SLUG 
+			&& $pagenow === 'post-new.php' 
+			&& self::POST_TYPE_SLUG === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) {
+			return 'edit.php?post_type=newspack_hub_nodes';
+		}
+		
+		return $submenu_file;
 	}
 }

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -80,6 +80,9 @@ class Orders {
 			'show_in_menu'     => Network_Admin::PAGE_SLUG,
 			'can_export'       => false,
 			'capability_type'  => 'post',
+			'capabilities'     => [
+				'create_posts' => false, // Removes "add new".
+			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,
 		);

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -81,7 +81,7 @@ class Orders {
 			'can_export'       => false,
 			'capability_type'  => 'post',
 			'capabilities'     => [
-				'create_posts' => false, // Removes "add new".
+				'create_posts' => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -80,6 +80,9 @@ class Subscriptions {
 			'show_in_menu'     => Network_Admin::PAGE_SLUG,
 			'can_export'       => false,
 			'capability_type'  => 'post',
+			'capabilities'     => [
+				'create_posts' => false, // Removes "add new".
+			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,
 		);

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -81,7 +81,7 @@ class Subscriptions {
 			'can_export'       => false,
 			'capability_type'  => 'post',
 			'capabilities'     => [
-				'create_posts' => false, // Removes "add new".
+				'create_posts' => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,


### PR DESCRIPTION
### Problem:

The Network plugin has 3 custom post types: Nodes, Subscriptions, and Orders.  For each of these 3 CPTs, the submenu was not being highlighted when on the "add new" screens.  Here is an example from "add new node":

![image](https://github.com/user-attachments/assets/cd85d9b4-97a4-49d2-be4f-9aa568b8ba2d)

### Solution for Nodes CPT:

Added `add_filter( 'submenu_file', [ __CLASS__, 'submenu_file' ] );`

![image](https://github.com/user-attachments/assets/e1ebe305-f37d-4206-943d-7e281df88d51)

### Solution for Subscriptions and Orders:

If I understand correctly the subscriptions and orders CPTs shouldn't allow "add new" anyway since they are imported/synced into the database.  So just remove ability to "add new".

```
'capabilities' => [
    'create_posts' => false, // Removes "add new".
],
```

![image](https://github.com/user-attachments/assets/ebcd1d97-75e2-4130-8c32-b488003fa931)


