### PR TITLE
feat: content distribution class

### DIFF
--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -40,6 +40,7 @@ class Accepted_Actions {
 		'network_manual_sync_user'                 => 'User_Manually_Synced',
 		'network_nodes_synced'                     => 'Nodes_Synced',
 		'newspack_network_membership_plan_updated' => 'Membership_Plan_Updated',
+		'network_post_updated'                     => 'Network_Post_Updated',
 	];
 
 	/**
@@ -61,5 +62,6 @@ class Accepted_Actions {
 		'network_nodes_synced',
 		'newspack_node_subscription_changed',
 		'newspack_network_membership_plan_updated',
+		'network_post_updated',
 	];
 }

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -385,7 +385,7 @@ class Content_Distribution {
 
 		// New post, set post status.
 		if ( ! $linked_post ) {
-			$post_data['post_status'] = 'draft';
+			$postarr['post_status'] = 'draft';
 		}
 
 		// Insert the post if it doesn't exist or if it's linked.

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -160,12 +160,14 @@ class Content_Distribution {
 	 * Manually trigger post distribution.
 	 *
 	 * @param WP_Post|int $post The post object or ID.
+	 *
+	 * @return void
 	 */
 	public static function distribute_post( $post ) {
-		if ( ! self::is_post_distributed( $post ) ) {
-			return new WP_Error( 'post_not_distributed', __( 'The post is not distributed across the network.', 'newspack-network' ) );
+		$data = self::handle_post_updated( $post );
+		if ( $data ) {
+			Data_Events::dispatch( 'network_post_updated', $data );
 		}
-		Data_Events::dispatch( 'network_post_updated', self::get_post_payload( $post ) );
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -112,7 +112,7 @@ class Content_Distribution {
 				'site_url'    => get_bloginfo( 'url' ),
 				'post_id'     => $post_id,
 				'is_unlinked' => $is_unlinked,
-			]
+			],
 		];
 	}
 

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -121,7 +121,7 @@ class Content_Distribution {
 	 * Whether the post is distributed. Optionally provide a $site_url to check if
 	 * the post is distributed to that site.
 	 *
-	 * @param WP_Post|int $post    The post object or ID.
+	 * @param WP_Post|int $post     The post object or ID.
 	 * @param int|null    $site_url Optional site ID.
 	 *
 	 * @return bool

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -56,7 +56,7 @@ class Content_Distribution {
 			return;
 		}
 		Data_Events::register_listener( 'wp_after_insert_post', 'network_post_updated', [ __CLASS__, 'handle_post_updated' ] );
-		Data_Events::register_listener( 'wp_after_insert_post', 'network_linked_post_inserted', [ __CLASS__, 'handle_linked_post_inserted' ] );
+		Data_Events::register_listener( 'newspack_network_linked_post_inserted', 'network_linked_post_inserted', [ __CLASS__, 'handle_linked_post_inserted' ] );
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -313,10 +313,7 @@ class Content_Distribution {
 	 * @return void|WP_Error Void on success, WP_Error on failure.
 	 */
 	public static function set_post_unlinked( $post_id, $unlinked = true ) {
-		if ( ! $post_id ) {
-			return new WP_Error( 'invalid_post', __( 'Invalid post.', 'newspack-network' ) );
-		}
-		if ( ! get_post( $post_id ) ) {
+		if ( ! $post_id || ! get_post( $post_id ) ) {
 			return new WP_Error( 'invalid_post', __( 'Invalid post.', 'newspack-network' ) );
 		}
 		update_post_meta( $post_id, self::POST_UNLINKED_META, (bool) $unlinked );

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -82,7 +82,7 @@ class Content_Distribution {
 	/**
 	 * Set the distribution configuration for a given post.
 	 *
-	 * @param int   $post_id  The post ID.
+	 * @param int   $post_id   The post ID.
 	 * @param int[] $site_urls Array of site URLs to distribute the post to.
 	 *
 	 * @return void|WP_Error Void on success, WP_Error on failure.
@@ -165,7 +165,7 @@ class Content_Distribution {
 			$config,
 			[
 				'enabled'   => false,
-				'site_urls'  => [],
+				'site_urls' => [],
 				'post_hash' => '',
 			]
 		);

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Newspack Network Content Distribution.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+use Newspack\Data_Events;
+use WP_Post;
+use WP_Error;
+
+/**
+ * Main class for content distribution
+ */
+class Content_Distribution {
+
+	const POST_META = 'newspack_network_distributed';
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
+	}
+
+	/**
+	 * Register the listeners to the Newspack Data Events API
+	 *
+	 * @return void
+	 */
+	public static function register_listeners() {
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return;
+		}
+		Data_Events::register_listener( 'wp_after_insert_post', 'network_post_updated', [ __CLASS__, 'handle_post_updated' ] );
+	}
+
+	/**
+	 * Post update listener callback.
+	 *
+	 * @param WP_Post|int $post The post object or ID.
+	 */
+	public static function handle_post_updated( $post ) {
+		if ( ! self::is_post_distributed( $post ) ) {
+			return;
+		}
+		return self::get_post_payload( $post );
+	}
+
+	/**
+	 * Get the post types that are allowed to be distributed across the network.
+	 *
+	 * @return array Array of post types.
+	 */
+	public static function get_distributed_post_types() {
+		/**
+		 * Filters the post types that are allowed to be distributed across the network.
+		 *
+		 * @param array $post_types Array of post types.
+		 */
+		return apply_filters( 'newspack_network_distributed_post_types', [ 'post' ] );
+	}
+
+	/**
+	 * Set the distribution configuration for a given post.
+	 *
+	 * @param int   $post_id  The post ID.
+	 * @param int[] $site_ids Array of site IDs to distribute the post to.
+	 *
+	 * @return void
+	 */
+	public static function set_post_distribution( $post_id, $site_ids = [] ) {
+		$config = get_post_meta( $post_id, self::POST_META, true );
+		if ( ! is_array( $config ) ) {
+			$config = [];
+		}
+		$config['enabled']  = empty( $site_ids ) ? false : true;
+		$config['site_ids'] = $site_ids;
+		update_post_meta( $post_id, self::POST_META, $config );
+	}
+
+	/**
+	 * Manually trigger post distribution.
+	 *
+	 * @param WP_Post|int $post The post object or ID.
+	 */
+	public static function distribute_post( $post ) {
+		if ( ! self::is_post_distributed( $post ) ) {
+			return new WP_Error( 'post_not_distributed', __( 'The post is not distributed across the network.', 'newspack-network' ) );
+		}
+		Data_Events::dispatch( 'network_post_updated', self::get_post_payload( $post ) );
+	}
+
+	/**
+	 * Whether the post is distributed.
+	 *
+	 * @param WP_Post|int $post    The post object or ID.
+	 * @param int|null    $site_id Optional site ID.
+	 *
+	 * @return bool
+	 */
+	protected static function is_post_distributed( $post, $site_id = null ) {
+		$post = get_post( $post );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$distributed_post_types = self::get_distributed_post_types();
+		if ( ! in_array( $post->post_type, $distributed_post_types, true ) ) {
+			return false;
+		}
+
+		$config = self::get_post_config( $post );
+		if ( ! $config['enabled'] || empty( $config['site_ids'] ) ) {
+			return false;
+		}
+
+		if ( ! empty( $site_id ) ) {
+			return in_array( $site_id, $config['site_ids'], true );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the distribution configuration for a given post.
+	 *
+	 * @param WP_Post $post The post object.
+	 *
+	 * @return array The distribution configuration.
+	 */
+	protected static function get_post_config( $post ) {
+		$config = get_post_meta( $post->ID, self::POST_META, true );
+		if ( ! is_array( $config ) ) {
+			$config = [];
+		}
+		$config = wp_parse_args(
+			$config,
+			[
+				'enabled'  => false,
+				'site_ids' => [],
+			]
+		);
+		return $config;
+	}
+
+	/**
+	 * Get the post payload for distribution.
+	 *
+	 * @param WP_Post|int $post The post object.
+	 *
+	 * @return array|WP_Error The post payload or WP_Error if the post is invalid.
+	 */
+	protected static function get_post_payload( $post ) {
+		$post = get_post( $post );
+		if ( ! $post ) {
+			return new WP_Error( 'invalid_post', __( 'Invalid post.', 'newspack-network' ) );
+		}
+
+		$config = self::get_post_config( $post );
+		return [
+			'post_id'   => $post->ID,
+			'config'    => $config,
+			'post_data' => [
+				'title'     => html_entity_decode( get_the_title( $post->ID ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
+				'slug'      => $post->post_name,
+				'post_type' => $post->post_type,
+				'content'   => self::get_post_content( $post ),
+				'excerpt'   => $post->post_excerpt,
+				// @ TODO: Add meta, featured image and taxonomies.
+			],
+		];
+	}
+
+	/**
+	 * Get the post content for distribution.
+	 *
+	 * @param WP_Post $post The post object.
+	 *
+	 * @return string The post content.
+	 */
+	protected static function get_post_content( $post ) {
+		global $wp_embed;
+		/**
+		 * Remove autoembed filter so that actual URL will be pushed and not the generated markup.
+		 */
+		remove_filter( 'the_content', [ $wp_embed, 'autoembed' ], 8 );
+		// Filter documented in WordPress core.
+		$post_content = apply_filters( 'the_content', $post->post_content );
+		add_filter( 'the_content', [ $wp_embed, 'autoembed' ], 8 );
+		return $post_content;
+	}
+}

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -26,7 +26,6 @@ class Content_Distribution {
 	 */
 	const POST_HASH_META = 'newspack_network_post_hash';
 
-
 	/**
 	 * Post meta key for the linked post containing the distributed post full payload.
 	 */
@@ -39,6 +38,7 @@ class Content_Distribution {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
+		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 	}
 
 	/**
@@ -51,6 +51,22 @@ class Content_Distribution {
 			return;
 		}
 		Data_Events::register_listener( 'wp_after_insert_post', 'network_post_updated', [ __CLASS__, 'handle_post_updated' ] );
+	}
+
+	/**
+	 * Filter the webhooks request priority so `network_post_updated` is
+	 * prioritized.
+	 *
+	 * @param int    $priority    The request priority.
+	 * @param string $action_name The action name.
+	 *
+	 * @return int The request priority.
+	 */
+	public static function webhooks_request_priority( $priority, $action_name ) {
+		if ( 'network_post_updated' === $action_name ) {
+			return 1;
+		}
+		return $priority;
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -22,7 +22,7 @@ class Content_Distribution {
 	const DISTRIBUTED_POST_META = 'newspack_network_distributed';
 
 	/**
-	 * Post meta key for the linked post containing the distributed post id.
+	 * Post meta key for the linked post containing a post ID unique accross the network.
 	 */
 	const NETWORK_POST_ID_META = 'newspack_network_post_id';
 

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -308,7 +308,7 @@ class Content_Distribution {
 	 * updated.
 	 *
 	 * @param int  $post_id  The post ID.
-	 * @param bool $unlinked Whether the post is unlinked.
+	 * @param bool $unlinked Whether to set the post as unlinked. Default is true.
 	 *
 	 * @return void|WP_Error Void on success, WP_Error on failure.
 	 */
@@ -388,7 +388,7 @@ class Content_Distribution {
 			$postarr['post_status'] = 'draft';
 		}
 
-		// Insert the post if it doesn't exist or if it's linked.
+		// Insert the post if it's linked or a new post.
 		$is_unlinked = $linked_post ? self::is_post_unlinked( $linked_post->ID ) : false;
 		if ( ! $linked_post || ! $is_unlinked ) {
 			// Remove filters that may alter content updates.

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -50,6 +50,7 @@ class Initializer {
 		User_Manual_Sync::init();
 		Distributor_Customizations::init();
 		Esp_Metadata_Sync::init();
+		Content_Distribution::init();
 
 		Synchronize_All::init();
 		Data_Backfill::init();

--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Newspack Network Content Distribution Post Update.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Debugger;
+
+/**
+ * Class to handle the network post update.
+ */
+class Network_Post_Updated extends Abstract_Incoming_Event {
+	/**
+	 * Processes the event
+	 *
+	 * @return void
+	 */
+	public function post_process_in_hub() {
+		$this->process_post_updated();
+	}
+
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		$this->process_post_updated();
+	}
+
+	/**
+	 * Process post updated
+	 */
+	protected function process_post_updated() {
+		$data = $this->get_data();
+		/* @TODO Implement the logic to handle the post update event */
+	}
+}

--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Incoming_Events;
 
 use Newspack_Network\Debugger;
+use Newspack_Network\Content_Distribution;
 
 /**
  * Class to handle the network post update.
@@ -35,7 +36,7 @@ class Network_Post_Updated extends Abstract_Incoming_Event {
 	 * Process post updated
 	 */
 	protected function process_post_updated() {
-		$data = $this->get_data();
-		/* @TODO Implement the logic to handle the post update event */
+		$post_payload = $this->get_data();
+		Content_Distribution::insert_linked_post( (array) $post_payload );
 	}
 }

--- a/tests/unit-tests/test-content-distribution.php
+++ b/tests/unit-tests/test-content-distribution.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Class TestContentDistribution
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Content_Distribution;
+
+/**
+ * Test the Content Distribution class.
+ */
+class TestContentDistribution extends WP_UnitTestCase {
+	/**
+	 * Test set post distribution.
+	 */
+	public function test_set_post_distribution() {
+		$post = $this->factory->post->create_and_get( [ 'post_type' => 'post' ] );
+		$result = Content_Distribution::set_post_distribution( $post->ID, [ 'https://example.com' ] );
+		$this->assertFalse( is_wp_error( $result ) );
+
+		$config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
+		$this->assertTrue( $config['enabled'] );
+		$this->assertSame( [ 'https://example.com' ], $config['site_urls'] );
+		$this->assertMatchesRegularExpression( '/^[a-zA-Z0-9]{32}$/', $config['post_hash'] );
+	}
+
+	/**
+	 * Test set post distribution with invalid post.
+	 */
+	public function test_set_post_distribution_with_invalid_post() {
+		$result = Content_Distribution::set_post_distribution( 0, [ 'https://example.com' ] );
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'invalid_post', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle post updated.
+	 */
+	public function test_handle_post_updated() {
+		$post = $this->factory->post->create_and_get( [ 'post_type' => 'post' ] );
+		Content_Distribution::set_post_distribution( $post->ID, [ 'https://example.com' ] );
+
+		$post_payload = Content_Distribution::handle_post_updated( $post );
+		$this->assertNotEmpty( $post_payload );
+
+		$config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
+
+		$this->assertSame( $post->ID, $post_payload['post_id'] );
+		$this->assertEquals( $config, $post_payload['config'] );
+
+		// Assert that 'post_data' only contains the expected keys.
+		$post_data_keys = [ 'title', 'date', 'slug', 'post_type', 'raw_content', 'content', 'excerpt' ];
+		$this->assertEmpty( array_diff( $post_data_keys, array_keys( $post_payload['post_data'] ) ) );
+		$this->assertEmpty( array_diff( array_keys( $post_payload['post_data'] ), $post_data_keys ) );
+	}
+
+	/**
+	 * Test handle post updated with invalid post.
+	 */
+	public function test_handle_post_updated_with_invalid_post() {
+		// Post that is not distributed.
+		$post = $this->factory->post->create_and_get( [ 'post_type' => 'post' ] );
+		$post_payload = Content_Distribution::handle_post_updated( $post );
+		$this->assertNull( $post_payload );
+
+		// Missing post.
+		$post_payload = Content_Distribution::handle_post_updated( 0 );
+		$this->assertNull( $post_payload );
+	}
+
+	/**
+	 * Get sample post payload.
+	 */
+	private function get_sample_post_payload() {
+		return [
+			'post_id'   => 1,
+			'config'    => [
+				'enabled'   => true,
+				'site_urls' => [ 'https://example.com' ],
+				'post_hash' => '1234567890abcdef1234567890abcdef',
+			],
+			'post_data' => [
+				'title'       => 'Title',
+				'date'        => '2021-01-01 00:00:00',
+				'slug'        => 'slug',
+				'post_type'   => 'post',
+				'raw_content' => 'Content',
+				'content'     => '<p>Content</p>',
+				'excerpt'     => 'Excerpt',
+			],
+		];
+	}
+
+	/**
+	 * Test insert linked post.
+	 */
+	public function test_insert_linked_post() {
+		$post_payload = $this->get_sample_post_payload();
+
+		// Update blog URL to match the distributed post.
+		update_option( 'siteurl', 'https://example.com' );
+		update_option( 'home', 'https://example.com' );
+
+		// Insert the linked post.
+		$linked_post_id = Content_Distribution::insert_linked_post( $post_payload );
+		$this->assertGreaterThan( 0, $linked_post_id );
+	}
+
+	/**
+	 * Test insert linked post with invalid payload.
+	 */
+	public function test_insert_linked_post_with_invalid_payload() {
+		$linked_post_id = Content_Distribution::insert_linked_post( [] );
+		$this->assertTrue( is_wp_error( $linked_post_id ) );
+		$this->assertSame( 'invalid_post_payload', $linked_post_id->get_error_code() );
+	}
+
+	/**
+	 * Test insert linked post with invalid site.
+	 */
+	public function test_insert_linked_post_with_invalid_site() {
+		$post_payload = $this->get_sample_post_payload();
+
+		// Update blog URL to not match the distributed post.
+		update_option( 'siteurl', 'https://example2.com' );
+		update_option( 'home', 'https://example2.com' );
+
+		// Insert the linked post.
+		$linked_post_id = Content_Distribution::insert_linked_post( $post_payload );
+		$this->assertTrue( is_wp_error( $linked_post_id ) );
+		$this->assertSame( 'invalid_site', $linked_post_id->get_error_code() );
+	}
+
+	/**
+	 * Test insert existing linked post.
+	 */
+	public function test_insert_existing_linked_post() {
+		$post_payload = $this->get_sample_post_payload();
+
+		// Update blog URL to match the distributed post.
+		update_option( 'siteurl', 'https://example.com' );
+		update_option( 'home', 'https://example.com' );
+
+		// Insert the linked post for the first time.
+		$linked_post_id = Content_Distribution::insert_linked_post( $post_payload );
+
+		// Modify the post payload to simulate an update.
+		$post_payload['post_data']['title'] = 'Updated Title';
+		$post_payload['post_data']['content'] = 'Updated Content';
+		$post_payload['post_data']['raw_content'] = 'Updated Content';
+
+		// Insert the updated linked post.
+		$updated_linked_post_id = Content_Distribution::insert_linked_post( $post_payload );
+
+		// Assert that the updated post has the same ID as the original post.
+		$this->assertSame( $linked_post_id, $updated_linked_post_id );
+
+		// Assert that the updated post has the updated title and content.
+		$linked_post = get_post( $updated_linked_post_id );
+		$this->assertSame( 'Updated Title', $linked_post->post_title );
+		$this->assertSame( 'Updated Content', $linked_post->post_content );
+	}
+
+	/**
+	 * Test insert linked post when unlinked.
+	 */
+	public function test_insert_linked_post_when_unlinked() {
+		$post_payload = $this->get_sample_post_payload();
+
+		// Update blog URL to match the distributed post.
+		update_option( 'siteurl', 'https://example.com' );
+		update_option( 'home', 'https://example.com' );
+
+		// Insert the linked post for the first time.
+		$linked_post_id = Content_Distribution::insert_linked_post( $post_payload );
+
+		// Unlink the post.
+		Content_Distribution::set_post_unlinked( $linked_post_id );
+
+		// Update linked post with custom content.
+		$this->factory->post->update_object( $linked_post_id, [ 'post_title' => 'Custom Title', 'post_content' => 'Custom Content' ] );
+
+		// Modify the post payload to simulate an update.
+		$post_payload['post_data']['title'] = 'Updated Title';
+		$post_payload['post_data']['content'] = 'Updated Content';
+		$post_payload['post_data']['raw_content'] = 'Updated Content';
+
+		// Insert the updated linked post.
+		$updated_linked_post_id = Content_Distribution::insert_linked_post( $post_payload );
+
+		// Assert that the custom content was preserved.
+		$linked_post = get_post( $updated_linked_post_id );
+		$this->assertSame( 'Custom Title', $linked_post->post_title );
+		$this->assertSame( 'Custom Content', $linked_post->post_content );
+	}
+
+	/**
+	 * Test relink post.
+	 */
+	public function test_relink_post() {
+		$post_payload = $this->get_sample_post_payload();
+
+		// Update blog URL to match the distributed post.
+		update_option( 'siteurl', 'https://example.com' );
+		update_option( 'home', 'https://example.com' );
+
+		// Insert the linked post for the first time.
+		$linked_post_id = Content_Distribution::insert_linked_post( $post_payload );
+
+		// Unlink the post.
+		Content_Distribution::set_post_unlinked( $linked_post_id );
+
+		// Update linked post with custom content.
+		$this->factory->post->update_object( $linked_post_id, [ 'post_title' => 'Custom Title', 'post_content' => 'Custom Content' ] );
+
+		// Relink the post.
+		Content_Distribution::set_post_unlinked( $linked_post_id, false );
+
+		// Assert that the post is linked and distributed content restored.
+		$this->assertSame( $post_payload['post_data']['title'], get_the_title( $linked_post_id ) );
+		$this->assertSame( $post_payload['post_data']['raw_content'], get_post_field( 'post_content', $linked_post_id ) );
+	}
+}

--- a/tests/unit-tests/test-content-distribution.php
+++ b/tests/unit-tests/test-content-distribution.php
@@ -22,13 +22,13 @@ class TestContentDistribution extends WP_UnitTestCase {
 		$config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
 		$this->assertTrue( $config['enabled'] );
 		$this->assertSame( [ 'https://example.com' ], $config['site_urls'] );
-		$this->assertMatchesRegularExpression( '/^[a-zA-Z0-9]{32}$/', $config['post_hash'] );
+		$this->assertSame( 32, strlen( $config['network_post_id'] ) );
 	}
 
 	/**
-	 * Test set post distribution persists the post hash.
+	 * Test set post distribution persists the network post ID.
 	 */
-	public function test_set_post_distribution_persists_post_hash() {
+	public function test_set_post_distribution_persists_network_post_id() {
 		$post = $this->factory->post->create_and_get( [ 'post_type' => 'post' ] );
 		$result = Content_Distribution::set_post_distribution( $post->ID, [ 'https://example.com' ] );
 		$config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
@@ -37,7 +37,7 @@ class TestContentDistribution extends WP_UnitTestCase {
 		$result = Content_Distribution::set_post_distribution( $post->ID, [ 'https://example2.com' ] );
 		$new_config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
 
-		$this->assertSame( $config['post_hash'], $new_config['post_hash'] );
+		$this->assertSame( $config['network_post_id'], $new_config['network_post_id'] );
 	}
 
 	/**
@@ -93,9 +93,9 @@ class TestContentDistribution extends WP_UnitTestCase {
 			'site_url'  => 'https://hub.com',
 			'post_id'   => 1,
 			'config'    => [
-				'enabled'   => true,
-				'site_urls' => [ 'https://example.com' ],
-				'post_hash' => '1234567890abcdef1234567890abcdef',
+				'enabled'         => true,
+				'site_urls'       => [ 'https://example.com' ],
+				'network_post_id' => '1234567890abcdef1234567890abcdef',
 			],
 			'post_data' => [
 				'title'       => 'Title',

--- a/tests/unit-tests/test-content-distribution.php
+++ b/tests/unit-tests/test-content-distribution.php
@@ -31,8 +31,6 @@ class TestContentDistribution extends WP_UnitTestCase {
 	public function test_set_post_distribution_persists_post_hash() {
 		$post = $this->factory->post->create_and_get( [ 'post_type' => 'post' ] );
 		$result = Content_Distribution::set_post_distribution( $post->ID, [ 'https://example.com' ] );
-		$this->assertFalse( is_wp_error( $result ) );
-
 		$config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
 
 		// Update the post distribution.

--- a/tests/unit-tests/test-content-distribution.php
+++ b/tests/unit-tests/test-content-distribution.php
@@ -26,6 +26,23 @@ class TestContentDistribution extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test set post distribution persists the post hash.
+	 */
+	public function test_set_post_distribution_persists_post_hash() {
+		$post = $this->factory->post->create_and_get( [ 'post_type' => 'post' ] );
+		$result = Content_Distribution::set_post_distribution( $post->ID, [ 'https://example.com' ] );
+		$this->assertFalse( is_wp_error( $result ) );
+
+		$config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
+
+		// Update the post distribution.
+		$result = Content_Distribution::set_post_distribution( $post->ID, [ 'https://example2.com' ] );
+		$new_config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
+
+		$this->assertSame( $config['post_hash'], $new_config['post_hash'] );
+	}
+
+	/**
 	 * Test set post distribution with invalid post.
 	 */
 	public function test_set_post_distribution_with_invalid_post() {

--- a/tests/unit-tests/test-content-distribution.php
+++ b/tests/unit-tests/test-content-distribution.php
@@ -46,6 +46,7 @@ class TestContentDistribution extends WP_UnitTestCase {
 
 		$config = get_post_meta( $post->ID, Content_Distribution::DISTRIBUTED_POST_META, true );
 
+		$this->assertSame( get_bloginfo( 'url' ), $post_payload['site_url'] );
 		$this->assertSame( $post->ID, $post_payload['post_id'] );
 		$this->assertEquals( $config, $post_payload['config'] );
 
@@ -74,6 +75,7 @@ class TestContentDistribution extends WP_UnitTestCase {
 	 */
 	private function get_sample_post_payload() {
 		return [
+			'site_url'  => 'https://hub.com',
 			'post_id'   => 1,
 			'config'    => [
 				'enabled'   => true,

--- a/tests/unit-tests/test-content-distribution.php
+++ b/tests/unit-tests/test-content-distribution.php
@@ -179,7 +179,13 @@ class TestContentDistribution extends WP_UnitTestCase {
 		Content_Distribution::set_post_unlinked( $linked_post_id );
 
 		// Update linked post with custom content.
-		$this->factory->post->update_object( $linked_post_id, [ 'post_title' => 'Custom Title', 'post_content' => 'Custom Content' ] );
+		$this->factory->post->update_object(
+			$linked_post_id,
+			[
+				'post_title'   => 'Custom Title',
+				'post_content' => 'Custom Content',
+			]
+		);
 
 		// Modify the post payload to simulate an update.
 		$post_payload['post_data']['title'] = 'Updated Title';
@@ -212,7 +218,13 @@ class TestContentDistribution extends WP_UnitTestCase {
 		Content_Distribution::set_post_unlinked( $linked_post_id );
 
 		// Update linked post with custom content.
-		$this->factory->post->update_object( $linked_post_id, [ 'post_title' => 'Custom Title', 'post_content' => 'Custom Content' ] );
+		$this->factory->post->update_object(
+			$linked_post_id,
+			[
+				'post_title'   => 'Custom Title',
+				'post_content' => 'Custom Content',
+			]
+		);
 
 		// Relink the post.
 		Content_Distribution::set_post_unlinked( $linked_post_id, false );


### PR DESCRIPTION
1208510338230630-as-1208621948575042/f

Introduces the main class for the Network's content distribution with basic functionality for a post to be distributed across the network according to a specified configuration.

It uses Newspack Network implementation on top of data events for that, so it creates 2 new data events:

## `network_post_updated`

Fires once a distributed post updates, with the following payload:

```json
{
	"site_url": "https://node1.com",
	"post_id": 1,
	"config": {
		"enabled": true,
		"site_urls": [ "https://hub.com", "https://node2.com" ],
		"network_post_id": "1234567890abcdef1234567890abcdef"
	},
	"post_data": {
		"title": "Hello World",
		"date": "2021-01-01 00:00:00",
		"slug": "hello-world",
		"post_type": "post",
		"raw_content": "Content",
		"content": "<p>Content</p>",
		"excerpt": "Excerpt"
	}
}
```

`$post_payload['config']` contains the required information for distribution:
 - `enabled`: Whether distribution is enabled
 - `site_urls`: Sites to distribute the post to
 - `network_post_id`: An md5 composed of site URL and post ID to be unique across the network

The network post ID is used to match an existing linked post to perform updates:

https://github.com/Automattic/newspack-network/blob/2d3f9ca6c2dcfa6ecfcbe06db1896e0fa1c6816c/includes/class-content-distribution.php#L278-L304

## `network_linked_post_inserted`

Fires once a linked post is updated, with the following payload:

```json
{
	"origin": {
		"site_url": "https://node1.com",
		"post_id": 1
	},
	"destination": {
		"site_url": "https://node2.com",
		"post_id": 123,
		"is_unlinked": false
	}
}
```

This event is not yet used but should allow the origin site (or hub) to be aware of its linked posts across the network. This can be for UI or system purposes.

### Testing

1. Make sure you have a working Network setup with at least 1 hub and 2 nodes (let's call them hub, node1, node2)
2. On node1, create a new post with various blocks (paragraph, image, quote, button, HPP...) and grab the post ID
3. Open wp shell and configure the post distribution to hub and node2 by running with the following:

```php
$post_id = 0; // Change to your post ID.
$site_urls = [ 'http://hub.local', 'http://node2.local' ]; // Change to match your setup urls.
Newspack_Network\Content_Distribution::set_post_distribution( $post_id, $site_urls );
```

4. The data event is attached to `wp_after_insert_post`, so you can either hit "Save" on the post or trigger it manually via shell with:

```php
Newspack_Network\Content_Distribution::distribute_post( $post_id );
```

5. Once all the events are dealt with, you should see the post with the correct title, date, and content in both hub and node2. Author and taxonomies are not covered in this PR (see 1208510338230630-as-1208621948575089/f and 1208510338230630-as-1208621948575091/f)
6. Let's unlink the post in node2 by running in node2's shell:

```php
$linked_post_id = 0; // Change to node2's linked post ID
Newspack_Network\Content_Distribution::set_post_unlinked( $linked_post_id );
```

7. In node1, make changes to the post and save
8. Once the events are done, confirm the post has been updated in the hub but remained unchanged in node2
9. Make changes to the post in node2 and save
10. Relink the post in node2:

```php
$linked_post_id = 0; // Change to node2's linked post ID
Newspack_Network\Content_Distribution::set_post_unlinked( $linked_post_id, false );
```

11. Confirm the post in node2 now reflects the most recent content from the distributed post