### PR TITLE
feat: place content distribution behind a constant

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -22,6 +22,9 @@ class Content_Distribution {
 	 * @return void
 	 */
 	public static function init() {
+		if ( ! defined( 'NEWPACK_NETWORK_CONTENT_DISTRIBUTION' ) || ! NEWPACK_NETWORK_CONTENT_DISTRIBUTION ) {
+			return;
+		}
 		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 	}


### PR DESCRIPTION
Place the feature behind a constant so it can be merged to trunk and we can work outside of epic branches.

As we are still without any UI, the constant will only prevent hooks from allowing distribution to occur. The classes and methods should remain available via code.

### Testing

1. Set `define( 'NEWPACK_NETWORK_CONTENT_DISTRIBUTION', true );` in your `wp-config.php`
2. Make sure you have a network setup with at least 1 hub and 1 node
3. On the hub, create a new post and configure its distribution:

```php
$post_id = 0; // Change to your post ID.
$outgoing_post = new Newspack_Network\Content_Distribution\Outgoing_Post( $post_id );
$outgoing_post->set_config( [ 'http://node1.local' ] ); // Change to match your node URL.
Newspack_Network\Content_Distribution::distribute_post( $outgoing_post );
```

4. Confirm the node receives the post
5. Change the constant to false in `wp-config.php`
6. Make a change to the original post and save
7. Confirm the changes are not distributed