### PR TITLE
fix: Include correct classname

### DIFF
--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -7,8 +7,7 @@
 
 namespace Newspack_Network\Incoming_Events;
 
-use Newspack_Network\Debugger;
-use Newspack_Network\Content_Distribution\Linked_Post;
+use Newspack_Network\Content_Distribution\Incoming_Post;
 
 /**
  * Class to handle the network post update.
@@ -37,11 +36,11 @@ class Network_Post_Updated extends Abstract_Incoming_Event {
 	 */
 	protected function process_post_updated() {
 		$payload = (array) $this->get_data();
-		$error   = Linked_Post::get_payload_error( $payload );
+		$error   = Incoming_Post::get_payload_error( $payload );
 		if ( is_wp_error( $error ) ) {
 			return;
 		}
-		$linked_post = new Linked_Post( $payload );
-		$linked_post->insert();
+		$incoming_post = new Incoming_Post( $payload );
+		$incoming_post->insert();
 	}
 }


### PR DESCRIPTION
The old classname "Linked_Post" was still used instead of "Incoming_Post" causing sync to fail.

## How to test
Probably eyeballing is enough