### PR TITLE
fix(content-distribution): debug post update and remove deprecated config

### DIFF
--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -113,11 +113,7 @@ class Incoming_Post {
 
 		$config = $payload['config'];
 
-		if (
-			empty( $config['enabled'] ) ||
-			empty( $config['network_post_id'] ) ||
-			empty( $config['site_urls'] )
-		) {
+		if ( empty( $config['network_post_id'] ) || empty( $config['site_urls'] ) ) {
 			return new WP_Error( 'not_distributed', __( 'Post is not configured for distribution.', 'newspack-network' ) );
 		}
 

--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -7,6 +7,7 @@
 
 namespace Newspack_Network\Incoming_Events;
 
+use Newspack_Network\Debugger;
 use Newspack_Network\Content_Distribution\Incoming_Post;
 
 /**
@@ -36,8 +37,12 @@ class Network_Post_Updated extends Abstract_Incoming_Event {
 	 */
 	protected function process_post_updated() {
 		$payload = (array) $this->get_data();
-		$error   = Incoming_Post::get_payload_error( $payload );
+
+		Debugger::log( 'Processing network_post_updated ' . wp_json_encode( $payload['config'] ) );
+
+		$error = Incoming_Post::get_payload_error( $payload );
 		if ( is_wp_error( $error ) ) {
+			Debugger::log( 'Error processing network_post_updated: ' . $error->get_error_message() );
 			return;
 		}
 		$incoming_post = new Incoming_Post( $payload );


### PR DESCRIPTION
Add debugger log to the `network_post_updated` event and fixes an issue with `get_payload_error()` using a deprecated config parameter.

### Testing

Confirm that distribution works and the node logs `Processing network_post_updated [config]`