### PR TITLE
feat: limit purchase of a network membership

### DIFF
--- a/includes/woocommerce-memberships/class-limit-purchase.php
+++ b/includes/woocommerce-memberships/class-limit-purchase.php
@@ -20,6 +20,10 @@ class Limit_Purchase {
 	public static function init() {
 		add_filter( 'woocommerce_subscription_is_purchasable', [ __CLASS__, 'restrict_network_subscriptions' ], 10, 2 );
 		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'woocommerce_cart_product_cannot_be_purchased_message' ], 10, 2 );
+
+		// Also limit purchase for logged out users, inferring their IDs from the email.
+		// add_filter( 'woocommerce_subscriptions_product_limited_for_user', [ __CLASS__, 'subscriptions_product_limited_for_user' ], 10, 3 );
+		add_filter( 'woocommerce_cart_item_is_purchasable', [ __CLASS__, 'subscriptions_product_limited_for_user' ], 10, 4 );
 	}
 
 	/**
@@ -34,12 +38,16 @@ class Limit_Purchase {
 	}
 
 	/**
-	 * Given a product, check if the current user has an active subscription in another site that gives access to the same membership.
+	 * Given a product, check if the user has an active subscription in another site that gives access to the same membership.
 	 *
 	 * @param \WC_Product $product Product data.
+	 * @param int|null    $user_id User ID, defaults to the current user.
 	 */
-	private static function get_network_equivalent_subscription_for_current_user( \WC_Product $product ) {
-		$user_id = get_current_user_id();
+	private static function get_network_equivalent_subscription_for_current_user( \WC_Product $product, $user_id = null ) {
+		if ( is_null( $user_id ) ) {
+			$user_id = self::get_user_id_from_email();
+		}
+
 		if ( ! $user_id ) {
 			return;
 		}
@@ -104,5 +112,65 @@ class Limit_Purchase {
 			);
 		}
 		return $message;
+	}
+
+	/**
+	 * Get user from email.
+	 *
+	 * @return false|int User ID if found by email address, false otherwise.
+	 */
+	private static function get_user_id_from_email() {
+		$billing_email = filter_input( INPUT_POST, 'billing_email', FILTER_SANITIZE_EMAIL );
+		error_log( print_r( $_REQUEST, true ) );
+		if ( $billing_email ) {
+			$customer = \get_user_by( 'email', $billing_email );
+			if ( $customer ) {
+				return $customer->ID;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Trigger the subscriptions-limiting logic, using the user gleaned from the email address.
+	 *
+	 * @param bool           $is_limited_for_user If the subscription should be limited.
+	 * @param int|WC_Product $product A WC_Product object or the ID of a product.
+	 * @param int            $user_id The user ID.
+	 */
+	public static function subscriptions_product_limited_for_user( $is_limited_for_user, $key, $values, $product ) {
+		error_log( '=========================' );
+		error_log( 'Limiting purchase for logged out user' );
+
+		$user_id = get_current_user_id();
+
+		if ( $user_id !== 0 ) {
+			return $is_limited_for_user;
+		}
+
+
+		$id_from_email = self::get_user_id_from_email();
+		error_log( $id_from_email );
+		if ( $id_from_email ) {
+			$network_subscription = self::get_network_equivalent_subscription_for_current_user( $product, $user_id );
+
+			error_log( 'Network subscription: ' . print_r( $network_subscription, true ) );
+			if ( $network_subscription ) {
+				add_filter(
+					'woocommerce_cart_item_removed_message',
+					function( $message ) use ( $network_subscription ) {
+						return sprintf(
+							/* translators: %s: Site URL */
+							__( "You can't buy this subscription because you already have it active on %s", 'newspack-network' ),
+							$network_subscription['site']
+						);
+					},
+					10,
+					2
+				);
+				$is_limited_for_user = true;
+			}
+		}
+		return $is_limited_for_user;
 	}
 }

--- a/includes/woocommerce-memberships/class-limit-purchase.php
+++ b/includes/woocommerce-memberships/class-limit-purchase.php
@@ -149,11 +149,7 @@ class Limit_Purchase {
 				$product = $cart_item['data'];
 				$network_active_subscription = self::get_network_equivalent_subscription_for_current_user( $product, $id_from_email );
 				if ( $network_active_subscription ) {
-					$error_message = sprintf(
-						/* translators: %s: Site URL */
-						__( "You can't buy this subscription because you already have it active on %s", 'newspack-network' ),
-						$network_active_subscription['site']
-					);
+					$error_message = __( 'Oops! You already have a subscription on another site in this network that grants you access to this site as well. Please log in using the same email address.', 'newspack-network' );
 					$errors->add( 'network_subscription', $error_message );
 				}
 			}

--- a/includes/woocommerce-memberships/class-limit-purchase.php
+++ b/includes/woocommerce-memberships/class-limit-purchase.php
@@ -133,7 +133,7 @@ class Limit_Purchase {
 	}
 
 	/**
- 	 * Validate network subscription for logged out readers.
+	 * Validate network subscription for logged out readers.
 	 *
 	 * @param array     $data   Checkout data.
 	 * @param WC_Errors $errors Checkout errors.
@@ -147,8 +147,14 @@ class Limit_Purchase {
 			$cart_items = WC()->cart->get_cart();
 			foreach ( $cart_items as $cart_item ) {
 				$product = $cart_item['data'];
-				if ( self::get_network_equivalent_subscription_for_current_user( $product, $id_from_email ) ) {
-					$errors->add( 'network_subscription', __( 'You can\'t buy this subscription because you already have it active on another site.', 'newspack-network' ) );
+				$network_active_subscription = self::get_network_equivalent_subscription_for_current_user( $product, $id_from_email );
+				if ( $network_active_subscription ) {
+					$error_message = sprintf(
+						/* translators: %s: Site URL */
+						__( "You can't buy this subscription because you already have it active on %s", 'newspack-network' ),
+						$network_active_subscription['site']
+					);
+					$errors->add( 'network_subscription', $error_message );
 				}
 			}
 		}


### PR DESCRIPTION
Limit subscription purchase if it grants access to a membership the user already has access to in another site of the Network.

This is the same thing as https://github.com/Automattic/newspack-network/pull/137 (instructions number 4 on https://github.com/Automattic/newspack-network/pull/138) but for logged out readers.

Here's how to test it:

* Having two sites in a Newspack Network installation
* On site A and B, create a membership plan with the same "Network ID"
* In each site, create a subscription product that grants access to these membership plans
* Make sure the network is in sync ( `wp newspack-network process-webhooks` in all Nodes and then `wp newspack-network sync-all` in all nodes)
* On site A, as a new reader, purchase the subscription
* Make sure the network is in sync again
* Visit site B, not logged in
* Attempt to purchase the subscription, using the same email used in site A
* You should not be allowed to make the purchase and should see a message saying that you already have that membership in another site:

![image](https://github.com/user-attachments/assets/1a693d7a-715f-4a1d-bd35-abb6c4fe059e)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1207352955560208