### PR TITLE
feat(content-distribution): control distribution meta and prevent multiple dispatches

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -161,6 +161,7 @@ class Content_Distribution {
 	 * @return void
 	 */
 	public static function handle_post_updated( $post ) {
+		$post = get_post( $post );
 		if ( ! $post ) {
 			return;
 		}

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -20,7 +20,7 @@ class Content_Distribution {
 	/**
 	 * Queued network post updates.
 	 *
-	 * @var array Map of post IDs to update.
+	 * @var array Post IDs to update.
 	 */
 	private static $queued_post_updates = [];
 
@@ -65,7 +65,7 @@ class Content_Distribution {
 	 * Distribute queued posts.
 	 */
 	public static function distribute_queued_posts() {
-		$post_ids = array_keys( self::$queued_post_updates );
+		$post_ids = array_unique( self::$queued_post_updates );
 		foreach ( $post_ids as $post_id ) {
 			$post = get_post( $post_id );
 			if ( ! $post ) {
@@ -150,7 +150,7 @@ class Content_Distribution {
 		) {
 			return;
 		}
-		self::$queued_post_updates[ $object_id ] = true;
+		self::$queued_post_updates[] = $object_id;
 	}
 
 	/**
@@ -168,7 +168,7 @@ class Content_Distribution {
 		if ( ! self::is_post_distributed( $post ) ) {
 			return;
 		}
-		self::$queued_post_updates[ $post->ID ] = true;
+		self::$queued_post_updates[] = $post->ID;
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -18,30 +18,61 @@ use WP_Post;
  */
 class Content_Distribution {
 	/**
+	 * Queued network post updates.
+	 *
+	 * @var array Map of post IDs to update.
+	 */
+	private static $queued_post_updates = [];
+
+	/**
 	 * Initialize this class and register hooks
 	 *
 	 * @return void
 	 */
 	public static function init() {
-		if ( ! defined( 'NEWPACK_NETWORK_CONTENT_DISTRIBUTION' ) || ! NEWPACK_NETWORK_CONTENT_DISTRIBUTION ) {
+		// Place content distribution behind a constant but run under unit tests.
+		if (
+			! ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) &&
+			( ! defined( 'NEWPACK_NETWORK_CONTENT_DISTRIBUTION' ) || ! NEWPACK_NETWORK_CONTENT_DISTRIBUTION )
+		) {
 			return;
 		}
-		CLI::init();
-		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
+
+		add_action( 'init', [ __CLASS__, 'register_data_event_actions' ] );
+		add_action( 'shutdown', [ __CLASS__, 'distribute_queued_posts' ] );
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
+		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_shortcircuit_distributed_meta' ], 10, 4 );
+		add_action( 'updated_postmeta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
+		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
+
+		CLI::init();
 	}
 
 	/**
-	 * Register the listeners to the Newspack Data Events API
+	 * Register the data event actions for content distribution.
 	 *
 	 * @return void
 	 */
-	public static function register_listeners() {
+	public static function register_data_event_actions() {
 		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
 			return;
 		}
-		Data_Events::register_listener( 'wp_after_insert_post', 'network_post_updated', [ __CLASS__, 'handle_post_updated' ] );
-		Data_Events::register_listener( 'newspack_network_incoming_post_inserted', 'network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ] );
+		Data_Events::register_action( 'network_post_updated' );
+		Data_Events::register_action( 'network_incoming_post_inserted' );
+	}
+
+	/**
+	 * Distribute queued posts.
+	 */
+	public static function distribute_queued_posts() {
+		$post_ids = array_keys( self::$queued_post_updates );
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post ) {
+				continue;
+			}
+			self::distribute_post( $post );
+		}
 	}
 
 	/**
@@ -61,21 +92,85 @@ class Content_Distribution {
 	}
 
 	/**
-	 * Post update listener callback.
+	 * Validate whether an update to DISTRIBUTED_POST_META is allowed.
 	 *
-	 * @param Outgoing_Post|WP_Post|int $post The post object or ID.
-	 *
-	 * @return array|null The post payload or null if the post is not distributed.
+	 * @param null|bool $check      Whether to allow updating metadata for the given type. Default null.
+	 * @param int       $object_id  Object ID.
+	 * @param string    $meta_key   Meta key.
+	 * @param mixed     $meta_value Metadata value.
 	 */
-	public static function handle_post_updated( $post ) {
-		if ( ! $post instanceof Outgoing_Post ) {
-			$post = self::get_distributed_post( $post );
-		}
-		if ( $post ) {
-			return $post->get_payload();
+	public static function maybe_shortcircuit_distributed_meta( $check, $object_id, $meta_key, $meta_value ) {
+		if ( Outgoing_Post::DISTRIBUTED_POST_META !== $meta_key ) {
+			return $check;
 		}
 
-		return null;
+		// Ensure the post type can be distributed.
+		$post_types = self::get_distributed_post_types();
+		$post_type  = get_post_type( $object_id );
+		if ( ! in_array( $post_type, $post_types, true ) ) {
+			return false;
+		}
+
+		$error = Outgoing_Post::validate_distribution( $meta_value );
+		if ( is_wp_error( $error ) ) {
+			return false;
+		}
+
+		// Prevent removing existing distributions.
+		$current_value = get_post_meta( $object_id, $meta_key, true );
+		$diff = array_diff( empty( $current_value ) ? [] : $current_value, $meta_value );
+		if ( ! empty( $diff ) ) {
+			return false;
+		}
+
+		return $check;
+	}
+
+	/**
+	 * Distribute post on postmeta update.
+	 *
+	 * @param int    $meta_id    Meta ID.
+	 * @param int    $object_id  Object ID.
+	 * @param string $meta_key   Meta key.
+	 *
+	 * @return void
+	 */
+	public static function handle_postmeta_update( $meta_id, $object_id, $meta_key ) {
+		if ( ! $object_id ) {
+			return;
+		}
+		$post = get_post( $object_id );
+		if ( ! $post ) {
+			return;
+		}
+		if ( ! self::is_post_distributed( $post ) ) {
+			return;
+		}
+		// Ignore reserved keys but run if the meta is setting the distribution.
+		if (
+			Outgoing_Post::DISTRIBUTED_POST_META !== $meta_key &&
+			in_array( $meta_key, self::get_reserved_post_meta_keys(), true )
+		) {
+			return;
+		}
+		self::$queued_post_updates[ $object_id ] = true;
+	}
+
+	/**
+	 * Distribute post on post updated.
+	 *
+	 * @param WP_Post|int $post The post object or ID.
+	 *
+	 * @return void
+	 */
+	public static function handle_post_updated( $post ) {
+		if ( ! $post ) {
+			return;
+		}
+		if ( ! self::is_post_distributed( $post ) ) {
+			return;
+		}
+		self::$queued_post_updates[ $post->ID ] = true;
 	}
 
 	/**
@@ -86,7 +181,10 @@ class Content_Distribution {
 	 * @param array   $post_payload The post payload.
 	 */
 	public static function handle_incoming_post_inserted( $post_id, $is_linked, $post_payload ) {
-		return [
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return;
+		}
+		$data = [
 			'origin'      => [
 				'site_url' => $post_payload['site_url'],
 				'post_id'  => $post_payload['post_id'],
@@ -97,6 +195,7 @@ class Content_Distribution {
 				'is_linked' => $is_linked,
 			],
 		];
+		Data_Events::dispatch( 'network_incoming_post_inserted', $data );
 	}
 
 	/**
@@ -148,6 +247,17 @@ class Content_Distribution {
 	}
 
 	/**
+	 * Whether a given post is distributed.
+	 *
+	 * @param WP_Post|int $post The post object or ID.
+	 *
+	 * @return bool Whether the post is distributed.
+	 */
+	public static function is_post_distributed( $post ) {
+		return (bool) self::get_distributed_post( $post );
+	}
+
+	/**
 	 * Get a distributed post.
 	 *
 	 * @param WP_Post|int $post The post object or ID.
@@ -165,16 +275,23 @@ class Content_Distribution {
 	}
 
 	/**
-	 * Manually trigger post distribution.
+	 * Trigger post distribution.
 	 *
 	 * @param WP_Post|Outgoing_Post|int $post The post object or ID.
 	 *
 	 * @return void
 	 */
 	public static function distribute_post( $post ) {
-		$data = self::handle_post_updated( $post );
-		if ( $data ) {
-			Data_Events::dispatch( 'network_post_updated', $data );
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return;
+		}
+		if ( $post instanceof Outgoing_Post ) {
+			$distributed_post = $post;
+		} else {
+			$distributed_post = self::get_distributed_post( $post );
+		}
+		if ( $distributed_post ) {
+			Data_Events::dispatch( 'network_post_updated', $distributed_post->get_payload() );
 		}
 	}
 }

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -41,7 +41,7 @@ class Content_Distribution {
 		add_action( 'init', [ __CLASS__, 'register_data_event_actions' ] );
 		add_action( 'shutdown', [ __CLASS__, 'distribute_queued_posts' ] );
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
-		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_shortcircuit_distributed_meta' ], 10, 4 );
+		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_short_circuit_distributed_meta' ], 10, 4 );
 		add_action( 'updated_postmeta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
 
@@ -99,27 +99,24 @@ class Content_Distribution {
 	 * @param string    $meta_key   Meta key.
 	 * @param mixed     $meta_value Metadata value.
 	 */
-	public static function maybe_shortcircuit_distributed_meta( $check, $object_id, $meta_key, $meta_value ) {
+	public static function maybe_short_circuit_distributed_meta( $check, $object_id, $meta_key, $meta_value ) {
 		if ( Outgoing_Post::DISTRIBUTED_POST_META !== $meta_key ) {
 			return $check;
 		}
 
 		// Ensure the post type can be distributed.
 		$post_types = self::get_distributed_post_types();
-		$post_type  = get_post_type( $object_id );
-		if ( ! in_array( $post_type, $post_types, true ) ) {
+		if ( ! in_array( get_post_type( $object_id ), $post_types, true ) ) {
 			return false;
 		}
 
-		$error = Outgoing_Post::validate_distribution( $meta_value );
-		if ( is_wp_error( $error ) ) {
+		if ( is_wp_error( Outgoing_Post::validate_distribution( $meta_value ) ) ) {
 			return false;
 		}
 
 		// Prevent removing existing distributions.
 		$current_value = get_post_meta( $object_id, $meta_key, true );
-		$diff = array_diff( empty( $current_value ) ? [] : $current_value, $meta_value );
-		if ( ! empty( $diff ) ) {
+		if ( ! empty( array_diff( empty( $current_value ) ? [] : $current_value, $meta_value ) ) ) {
 			return false;
 		}
 
@@ -270,7 +267,6 @@ class Content_Distribution {
 		} catch ( \InvalidArgumentException ) {
 			return null;
 		}
-
 		return $outgoing_post->is_distributed() ? $outgoing_post : null;
 	}
 

--- a/includes/content-distribution/class-cli.php
+++ b/includes/content-distribution/class-cli.php
@@ -89,13 +89,13 @@ class CLI {
 
 		try {
 			$outgoing_post = Content_Distribution::get_distributed_post( $post_id ) ?? new Outgoing_Post( $post_id );
-			$config = $outgoing_post->set_config( $sites );
-			if ( is_wp_error( $config ) ) {
-				WP_CLI::error( $config->get_error_message() );
+			$sites = $outgoing_post->set_distribution( $sites );
+			if ( is_wp_error( $sites ) ) {
+				WP_CLI::error( $sites->get_error_message() );
 			}
 
 			Content_Distribution::distribute_post( $outgoing_post );
-			WP_CLI::success( sprintf( 'Post with ID %d is distributed to %d sites: %s', $post_id, count( $config['site_urls'] ), implode( ', ', $config['site_urls'] ) ) );
+			WP_CLI::success( sprintf( 'Post with ID %d is distributed to %d sites: %s', $post_id, count( $sites ), implode( ', ', $sites ) ) );
 
 		} catch ( \Exception $e ) {
 			WP_CLI::error( $e->getMessage() );

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -85,7 +85,7 @@ class Incoming_Post {
 		}
 
 		$this->payload         = $payload;
-		$this->network_post_id = $payload['config']['network_post_id'];
+		$this->network_post_id = $payload['network_post_id'];
 
 		$post = $this->query_post();
 		if ( $post ) {
@@ -105,20 +105,19 @@ class Incoming_Post {
 		if (
 			! is_array( $payload ) ||
 			empty( $payload['post_id'] ) ||
-			empty( $payload['config'] ) ||
+			empty( $payload['network_post_id'] ) ||
+			empty( $payload['sites'] ) ||
 			empty( $payload['post_data'] )
 		) {
 			return new WP_Error( 'invalid_post', __( 'Invalid post payload.', 'newspack-network' ) );
 		}
 
-		$config = $payload['config'];
-
-		if ( empty( $config['network_post_id'] ) || empty( $config['site_urls'] ) ) {
+		if ( empty( $payload['sites'] ) ) {
 			return new WP_Error( 'not_distributed', __( 'Post is not configured for distribution.', 'newspack-network' ) );
 		}
 
 		$site_url = get_bloginfo( 'url' );
-		if ( ! in_array( $site_url, $config['site_urls'], true ) ) {
+		if ( ! in_array( $site_url, $payload['sites'], true ) ) {
 			return new WP_Error( 'not_distributed_to_site', __( 'Post is not configured for distribution on this site.', 'newspack-network' ) );
 		}
 	}
@@ -317,7 +316,7 @@ class Incoming_Post {
 		}
 
 		// Do not update if network post ID mismatches.
-		if ( $this->network_post_id !== $payload['config']['network_post_id'] ) {
+		if ( $this->network_post_id !== $payload['network_post_id'] ) {
 			return new WP_Error( 'mismatched_post_id', __( 'Mismatched post ID.', 'newspack-network' ) );
 		}
 

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -17,9 +17,9 @@ use WP_Post;
  */
 class Outgoing_Post {
 	/**
-	 * The post meta key for the distributed post configuration.
+	 * The post meta key for the sites the post is distributed to.
 	 */
-	const DISTRIBUTED_POST_META = 'newspack_network_distributed';
+	const DISTRIBUTED_POST_META = 'newspack_network_distributed_sites';
 
 	/**
 	 * The post object.
@@ -59,22 +59,34 @@ class Outgoing_Post {
 	}
 
 	/**
-	 * Set the distribution configuration for a given post.
+	 * Get network post ID.
 	 *
-	 * @param int[] $site_urls Array of site URLs to distribute the post to.
-	 *
-	 * @return array|WP_Error Config array on success, WP_Error on failure.
+	 * @return string The network post ID.
 	 */
-	public function set_config( $site_urls ) {
-		if ( empty( $site_urls ) ) {
-			return new WP_Error( 'config_no_site_urls', __( 'No site URLs provided.', 'newspack-network' ) );
+	public function get_network_post_id() {
+		return md5( $this->post->ID . get_bloginfo( 'url' ) );
+	}
+
+	/**
+	 * Validate URLs for distribution.
+	 *
+	 * @param string[] $urls Array of site URLs to distribute the post to.
+	 *
+	 * @return true|WP_Error True on success, WP_Error on failure.
+	 */
+	public static function validate_distribution( $urls ) {
+		if ( empty( $urls ) ) {
+			return new WP_Error( 'no_site_urls', __( 'No site URLs provided.', 'newspack-network' ) );
 		}
 
-		$networked_urls      = Network::get_networked_urls();
-		$urls_not_in_network = array_diff( $site_urls, $networked_urls );
+		if ( in_array( get_bloginfo( 'url' ), $urls, true ) ) {
+			return new WP_Error( 'no_own_site', __( 'Cannot distribute to own site.', 'newspack-network' ) );
+		}
+
+		$urls_not_in_network = Network::get_non_networked_urls_from_list( $urls );
 		if ( ! empty( $urls_not_in_network ) ) {
 			return new WP_Error(
-				'config_non_networked_urls',
+				'non_networked_urls',
 				sprintf(
 					/* translators: %s: list of non-networked URLs */
 					__( 'Non-networked URLs were passed to config: %s', 'newspack-network' ),
@@ -83,27 +95,34 @@ class Outgoing_Post {
 			);
 		}
 
+		return true;
+	}
 
-		$config = get_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, true );
-		if ( ! is_array( $config ) ) {
-			$config = [];
-		}
-		// Set post network ID.
-		if ( empty( $config['network_post_id'] ) ) {
-			$config['network_post_id'] = md5( $this->post->ID . get_bloginfo( 'url' ) );
+	/**
+	 * Set the distribution configuration for a given post.
+	 *
+	 * @param int[] $site_urls Array of site URLs to distribute the post to.
+	 *
+	 * @return array|WP_Error Config array on success, WP_Error on failure.
+	 */
+	public function set_distribution( $site_urls ) {
+		$error = self::validate_distribution( $site_urls );
+		if ( is_wp_error( $error ) ) {
+			return $error;
 		}
 
-		if ( empty( $config['site_urls'] ) ) {
-			$config['site_urls'] = [];
+		$distribution = get_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, true );
+		if ( ! is_array( $distribution ) ) {
+			$distribution = [];
 		}
 
 		// If there are urls not already in the config, add them. Note that we don't support
 		// removing urls from the config.
-		$config['site_urls'] = array_unique( array_merge( $config['site_urls'], $site_urls ) );
+		$distribution = array_unique( array_merge( $distribution, $site_urls ) );
 
-		update_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, $config );
+		update_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, $distribution );
 
-		return $config;
+		return $distribution;
 	}
 
 	/**
@@ -120,35 +139,28 @@ class Outgoing_Post {
 			return false;
 		}
 
-		$config = $this->get_config();
-		if ( empty( $config['site_urls'] ) ) {
+		$distribution = $this->get_distribution();
+		if ( empty( $distribution ) ) {
 			return false;
 		}
 
 		if ( ! empty( $site_url ) ) {
-			return in_array( $site_url, $config['site_urls'], true );
+			return in_array( $site_url, $distribution, true );
 		}
 
 		return true;
 	}
 
 	/**
-	 * Get the distribution configuration for a given post.
+	 * Get the sites the post is distributed to.
 	 *
 	 * @return array The distribution configuration.
 	 */
-	public function get_config() {
+	public function get_distribution() {
 		$config = get_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, true );
 		if ( ! is_array( $config ) ) {
 			$config = [];
 		}
-		$config = wp_parse_args(
-			$config,
-			[
-				'site_urls'       => [],
-				'network_post_id' => '',
-			]
-		);
 		return $config;
 	}
 
@@ -158,12 +170,12 @@ class Outgoing_Post {
 	 * @return array|WP_Error The post payload or WP_Error if the post is invalid.
 	 */
 	public function get_payload() {
-		$config = self::get_config();
 		return [
-			'site_url'  => get_bloginfo( 'url' ),
-			'post_id'   => $this->post->ID,
-			'config'    => $config,
-			'post_data' => [
+			'site_url'        => get_bloginfo( 'url' ),
+			'post_id'         => $this->post->ID,
+			'network_post_id' => $this->get_network_post_id(),
+			'sites'           => $this->get_distribution(),
+			'post_data'       => [
 				'title'         => html_entity_decode( get_the_title( $this->post->ID ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
 				'date_gmt'      => $this->post->post_date_gmt,
 				'modified_gmt'  => $this->post->post_modified_gmt,

--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -38,7 +38,7 @@ class Network_Post_Updated extends Abstract_Incoming_Event {
 	protected function process_post_updated() {
 		$payload = (array) $this->get_data();
 
-		Debugger::log( 'Processing network_post_updated ' . wp_json_encode( $payload['config'] ) );
+		Debugger::log( 'Processing network_post_updated ' . wp_json_encode( $payload['sites'] ) );
 
 		$error = Incoming_Post::get_payload_error( $payload );
 		if ( is_wp_error( $error ) ) {

--- a/includes/utils/class-network.php
+++ b/includes/utils/class-network.php
@@ -45,4 +45,26 @@ class Network {
 	public static function is_networked_url( string $url ): bool {
 		return in_array( untrailingslashit( $url ), self::get_networked_urls(), true );
 	}
+
+	/**
+	 * Get list of network URLs given a list of URLs.
+	 *
+	 * @param string[] $urls Array of URLs.
+	 *
+	 * @return string[] Array of networked URLs.
+	 */
+	public static function get_networked_urls_from_list( array $urls ): array {
+		return array_intersect( array_map( 'untrailingslashit', $urls ), self::get_networked_urls() );
+	}
+
+	/**
+	 * Get list of URLs that don't belong in the network given a list of URLs.
+	 *
+	 * @param string[] $urls Array of URLs.
+	 *
+	 * @return string[] Array of networked URLs.
+	 */
+	public static function get_non_networked_urls_from_list( array $urls ): array {
+		return array_diff( array_map( 'untrailingslashit', $urls ), self::get_networked_urls() );
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,8 @@ if ( ! file_exists( "{$newspack_network_hub_test_dir}/includes/functions.php" ) 
 	exit( 1 );
 }
 
+define( 'IS_TEST_ENV', 1 );
+
 // Give access to tests_add_filter() function.
 require_once "{$newspack_network_hub_test_dir}/includes/functions.php";
 

--- a/tests/unit-tests/test-content-distribution.php
+++ b/tests/unit-tests/test-content-distribution.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Class TestContentDistribution
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Content_Distribution;
+use Newspack_Network\Content_Distribution\Outgoing_Post;
+use Newspack_Network\Hub\Node as Hub_Node;
+
+/**
+ * Test the Content_Distribution class.
+ */
+class TestContentDistribution extends WP_UnitTestCase {
+	/**
+	 * "Mocked" network nodes.
+	 *
+	 * @var array
+	 */
+	protected $network = [
+		[
+			'id'    => 1234,
+			'title' => 'Test Node',
+			'url'   => 'https://node.test',
+		],
+		[
+			'id'    => 5678,
+			'title' => 'Test Node 2',
+			'url'   => 'https://other-node.test',
+		],
+	];
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// "Mock" the network node(s).
+		update_option( Hub_Node::HUB_NODES_SYNCED_OPTION, $this->network );
+	}
+
+	/**
+	 * Test update distributed post meta.
+	 */
+	public function test_update_distributed_post_meta() {
+		$post_id = $this->factory->post->create();
+
+		// Assert that you're not allowed to update the meta with a non-network site.
+		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [ 'http://non-network-site.com' ] );
+		$this->assertFalse( $result );
+
+		// Assert that you're allowed to update the meta with a network site.
+		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [ 'https://node.test' ] );
+		$this->assertNotFalse( $result );
+
+		// Assert that you can't remove a site from distribution.
+		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [ 'https://other-node.test' ] );
+		$this->assertFalse( $result );
+
+		// Assert that you can add a site to distribution.
+		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [ 'https://node.test', 'https://other-node.test' ] );
+		$this->assertNotFalse( $result );
+	}
+}

--- a/tests/unit-tests/test-incoming-post.php
+++ b/tests/unit-tests/test-incoming-post.php
@@ -37,14 +37,11 @@ class TestIncomingPost extends WP_UnitTestCase {
 	 */
 	private function get_sample_payload() {
 		return [
-			'site_url'  => $this->node_1,
-			'post_id'   => 1,
-			'config'    => [
-				'enabled'         => true,
-				'site_urls'       => [ $this->node_2 ],
-				'network_post_id' => '1234567890abcdef1234567890abcdef',
-			],
-			'post_data' => [
+			'site_url'        => $this->node_1,
+			'post_id'         => 1,
+			'network_post_id' => '1234567890abcdef1234567890abcdef',
+			'sites'           => [ $this->node_2 ],
+			'post_data'       => [
 				'title'         => 'Title',
 				'date_gmt'      => '2021-01-01 00:00:00',
 				'modified_gmt'  => '2021-01-01 00:00:00',
@@ -117,12 +114,6 @@ class TestIncomingPost extends WP_UnitTestCase {
 		$error = Incoming_Post::get_payload_error( $payload );
 		$this->assertTrue( is_wp_error( $error ) );
 		$this->assertSame( 'not_distributed_to_site', $error->get_error_code() );
-
-		// Assert invalid config.
-		$payload['config'] = 'invalid';
-		$error = Incoming_Post::get_payload_error( $payload );
-		$this->assertTrue( is_wp_error( $error ) );
-		$this->assertSame( 'not_distributed', $error->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
Implements support for short-circuiting the distribution post meta update if it's not valid. Also implements support for distributing a post if a post meta changes, given we're also syncing them.

Because of the data event dispatch on post meta updates, there can be multiple dispatches in a single post save, if it includes multiple post meta updates. To prevent that, the distribution is now queued to be executed on `shutdown`. With this strategy, only the most recent payload will be distributed in the execution.

This PR also introduces a change to how the distribution meta for the outgoing post works. There's no need for the outgoing post configuration meta to include the network post ID, as it's deterministic. Without it, it's left only with the site URLs. Because of that, it's now only an array of site URLs, and the methods have been renamed from `set_config()` to `set_distribution()`.

### Testing

There should be no functional change, except `update_post_meta()` should now also trigger an update. Let's test it with the CLI:

1. Make sure you have a network setup with a hub and 2 nodes (node1 and node2)
2. In the hub, create a post and distribute to node1:

```
wp newspack network distribute post <post-id> --sites=https://node1.test
```

3. Confirm the post is distributed to node1
4. Distribute to node2 as well:

```
wp newspack network distribute post <post-id> --sites=https://node2.test
```

5. Confirm the post is distributed to node2
6. Now update a post meta:

```
wp post meta update <post-id> custom-meta test
```

7. Confirm the post meta gets distributed to both node1 and node2