### PR TITLE
fix: load text domain on init hook

### DIFF
--- a/newspack-network.php
+++ b/newspack-network.php
@@ -31,7 +31,12 @@ if ( ! defined( 'NEWSPACK_NETWORK_PLUGIN_FILE' ) ) {
 define( 'NEWSPACK_NETWORK_READER_ROLE', 'network_reader' );
 
 // Load language files.
-load_plugin_textdomain( 'newspack-network', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+add_action(
+	'init',
+	function () {
+		load_plugin_textdomain( 'newspack-network', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+	}
+);
 
 require_once __DIR__ . '/vendor/autoload.php';
 


### PR DESCRIPTION
Fixes a warning about calling `load_plugin_textdomain` too early. Also fixes the text domain itself for the plugin.

### Testing

There are currently no translation files for this plugin, so just test that you don't see a PHP warning `PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>newspack-network</code> domain was triggered too early`.