### PR TITLE
fix(content-distribution): post insertion hook and additional meta for incoming post event

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -184,13 +184,16 @@ class Content_Distribution {
 			return;
 		}
 		$data = [
-			'origin'      => [
+			'network_post_id' => $post_payload['network_post_id'],
+			'outgoing' => [
 				'site_url' => $post_payload['site_url'],
 				'post_id'  => $post_payload['post_id'],
+				'post_url' => $post_payload['post_url'],
 			],
-			'destination' => [
+			'incoming' => [
 				'site_url'  => get_bloginfo( 'url' ),
 				'post_id'   => $post_id,
+				'post_url'  => get_permalink( $post_id ),
 				'is_linked' => $is_linked,
 			],
 		];

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -42,6 +42,7 @@ class Content_Distribution {
 		add_action( 'shutdown', [ __CLASS__, 'distribute_queued_posts' ] );
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_short_circuit_distributed_meta' ], 10, 4 );
+		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ], 10 );
 		add_action( 'updated_postmeta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
 

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -42,7 +42,7 @@ class Content_Distribution {
 		add_action( 'shutdown', [ __CLASS__, 'distribute_queued_posts' ] );
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_short_circuit_distributed_meta' ], 10, 4 );
-		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ], 10 );
+		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ] );
 		add_action( 'updated_postmeta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
 

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -185,12 +185,12 @@ class Content_Distribution {
 		}
 		$data = [
 			'network_post_id' => $post_payload['network_post_id'],
-			'outgoing' => [
+			'outgoing'        => [
 				'site_url' => $post_payload['site_url'],
 				'post_id'  => $post_payload['post_id'],
 				'post_url' => $post_payload['post_url'],
 			],
-			'incoming' => [
+			'incoming'        => [
 				'site_url'  => get_bloginfo( 'url' ),
 				'post_id'   => $post_id,
 				'post_url'  => get_permalink( $post_id ),

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -173,6 +173,7 @@ class Outgoing_Post {
 		return [
 			'site_url'        => get_bloginfo( 'url' ),
 			'post_id'         => $this->post->ID,
+			'post_url'        => get_permalink( $this->post->ID ),
 			'network_post_id' => $this->get_network_post_id(),
 			'sites'           => $this->get_distribution(),
 			'post_data'       => [

--- a/tests/unit-tests/test-outgoing-post.php
+++ b/tests/unit-tests/test-outgoing-post.php
@@ -115,6 +115,7 @@ class TestOutgoingPost extends WP_UnitTestCase {
 
 		$this->assertSame( get_bloginfo( 'url' ), $payload['site_url'] );
 		$this->assertSame( $this->outgoing_post->get_post()->ID, $payload['post_id'] );
+		$this->assertSame( get_permalink( $this->outgoing_post->get_post()->ID ), $payload['post_url'] );
 		$this->assertSame( 32, strlen( $payload['network_post_id'] ) );
 		$this->assertEquals( $distribution, $payload['sites'] );
 


### PR DESCRIPTION
When rewriting the hooks for #170, I forgot to hook `handle_post_updated` to `wp_after_insert_post` to distribute on post content updates.

This PR adds the missing hook and also implements additional metadata for the post inserted event. These additional meta will be helpful for UI elements later on.

### Testing

Confirm a distributed post update reaches its connected nodes.