### PR TITLE
feat(content-distribution): reserved taxonomies

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -184,13 +184,16 @@ class Content_Distribution {
 			return;
 		}
 		$data = [
-			'origin'      => [
+			'network_post_id' => $post_payload['network_post_id'],
+			'outgoing' => [
 				'site_url' => $post_payload['site_url'],
 				'post_id'  => $post_payload['post_id'],
+				'post_url' => $post_payload['post_url'],
 			],
-			'destination' => [
+			'incoming' => [
 				'site_url'  => get_bloginfo( 'url' ),
 				'post_id'   => $post_id,
+				'post_url'  => get_permalink( $post_id ),
 				'is_linked' => $is_linked,
 			],
 		];

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -42,6 +42,7 @@ class Content_Distribution {
 		add_action( 'shutdown', [ __CLASS__, 'distribute_queued_posts' ] );
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_short_circuit_distributed_meta' ], 10, 4 );
+		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ], 10 );
 		add_action( 'updated_postmeta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
 

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -249,6 +249,24 @@ class Content_Distribution {
 	}
 
 	/**
+	 * Get taxonomies that should not be distributed.
+	 *
+	 * @return string[] The reserved taxonomies.
+	 */
+	public static function get_reserved_taxonomies() {
+		$reserved_taxonomies = [
+			'author', // Co-Authors Plus 'author' taxonomy should be ignored as it requires custom handling.
+		];
+
+		/**
+		 * Filters the reserved taxonomies that should not be distributed.
+		 *
+		 * @param string[] $reserved_taxonomies The reserved taxonomies.
+		 */
+		return apply_filters( 'newspack_network_content_distribution_reserved_taxonomies', $reserved_taxonomies );
+	}
+
+	/**
 	 * Whether a given post is distributed.
 	 *
 	 * @param WP_Post|int $post The post object or ID.

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -42,7 +42,7 @@ class Content_Distribution {
 		add_action( 'shutdown', [ __CLASS__, 'distribute_queued_posts' ] );
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_short_circuit_distributed_meta' ], 10, 4 );
-		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ], 10 );
+		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ] );
 		add_action( 'updated_postmeta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
 

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -185,12 +185,12 @@ class Content_Distribution {
 		}
 		$data = [
 			'network_post_id' => $post_payload['network_post_id'],
-			'outgoing' => [
+			'outgoing'        => [
 				'site_url' => $post_payload['site_url'],
 				'post_id'  => $post_payload['post_id'],
 				'post_url' => $post_payload['post_url'],
 			],
-			'incoming' => [
+			'incoming'        => [
 				'site_url'  => get_bloginfo( 'url' ),
 				'post_id'   => $post_id,
 				'post_url'  => get_permalink( $post_id ),

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -288,16 +288,20 @@ class Incoming_Post {
 	 * @return void
 	 */
 	protected function update_taxonomy_terms() {
-		$data = $this->payload['post_data']['taxonomy'];
+		$reserved_taxonomies = Content_Distribution::get_reserved_taxonomies();
+		$data                = $this->payload['post_data']['taxonomy'];
 		foreach ( $data as $taxonomy => $terms ) {
+			if ( in_array( $taxonomy, $reserved_taxonomies, true ) ) {
+				continue;
+			}
 			if ( ! taxonomy_exists( $taxonomy ) ) {
 				continue;
 			}
 			$term_ids = [];
 			foreach ( $terms as $term_data ) {
-				$term = get_term_by( 'slug', $term_data['slug'], $taxonomy, ARRAY_A );
+				$term = get_term_by( 'name', $term_data['name'], $taxonomy, ARRAY_A );
 				if ( ! $term ) {
-					$term = wp_insert_term( $term_data['name'], $taxonomy, [ 'slug' => $term_data['slug'] ] );
+					$term = wp_insert_term( $term_data['name'], $taxonomy );
 					if ( is_wp_error( $term ) ) {
 						continue;
 					}

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -215,9 +215,13 @@ class Outgoing_Post {
 	 * @return array The taxonomy term data.
 	 */
 	protected function get_post_taxonomy_terms() {
-		$taxonomies = get_object_taxonomies( $this->post->post_type, 'objects' );
-		$data       = [];
+		$reserved_taxonomies = Content_Distribution::get_reserved_taxonomies();
+		$taxonomies          = get_object_taxonomies( $this->post->post_type, 'objects' );
+		$data                = [];
 		foreach ( $taxonomies as $taxonomy ) {
+			if ( in_array( $taxonomy->name, $reserved_taxonomies, true ) ) {
+				continue;
+			}
 			if ( ! $taxonomy->public ) {
 				continue;
 			}

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -173,6 +173,7 @@ class Outgoing_Post {
 		return [
 			'site_url'        => get_bloginfo( 'url' ),
 			'post_id'         => $this->post->ID,
+			'post_url'        => get_permalink( $this->post->ID ),
 			'network_post_id' => $this->get_network_post_id(),
 			'sites'           => $this->get_distribution(),
 			'post_data'       => [

--- a/tests/unit-tests/test-incoming-post.php
+++ b/tests/unit-tests/test-incoming-post.php
@@ -345,7 +345,7 @@ class TestIncomingPost extends WP_UnitTestCase {
 			[
 				'name' => 'Author 1',
 				'slug' => 'author-1',
-			]
+			],
 		];
 
 		// Insert the linked post.

--- a/tests/unit-tests/test-incoming-post.php
+++ b/tests/unit-tests/test-incoming-post.php
@@ -330,4 +330,29 @@ class TestIncomingPost extends WP_UnitTestCase {
 		// Assert that the custom post meta was removed on relink.
 		$this->assertEmpty( get_post_meta( $post_id, 'custom', true ) );
 	}
+
+	/**
+	 * Test reserved taxonomies.
+	 */
+	public function test_reserved_taxonomies() {
+		$payload = $this->get_sample_payload();
+		$taxonomy = 'author';
+
+		// Register a reserved taxonomy.
+		register_taxonomy( $taxonomy, 'post', [ 'public' => true ] );
+
+		$payload['post_data']['taxonomy']['author'] = [
+			[
+				'name' => 'Author 1',
+				'slug' => 'author-1',
+			]
+		];
+
+		// Insert the linked post.
+		$post_id = $this->incoming_post->insert( $payload );
+
+		// Assert that the post does not have the reserved taxonomy term.
+		$terms = wp_get_post_terms( $post_id, $taxonomy );
+		$this->assertEmpty( $terms );
+	}
 }

--- a/tests/unit-tests/test-outgoing-post.php
+++ b/tests/unit-tests/test-outgoing-post.php
@@ -166,4 +166,19 @@ class TestOutgoingPost extends WP_UnitTestCase {
 		$this->assertSame( 'a', $payload['post_data']['post_meta'][ $multiple_meta_key ][0] );
 		$this->assertSame( 'b', $payload['post_data']['post_meta'][ $multiple_meta_key ][1] );
 	}
+
+	/**
+	 * Test reserved taxonomies.
+	 */
+	public function test_reserved_taxonomies() {
+		$post = $this->outgoing_post->get_post();
+		$taxonomy = 'author';
+		register_taxonomy( $taxonomy, 'post', [ 'public' => true ] );
+
+		$term = $this->factory->term->create( [ 'taxonomy' => $taxonomy ] );
+		wp_set_post_terms( $post->ID, [ $term ], $taxonomy );
+
+		$payload = $this->outgoing_post->get_payload();
+		$this->assertTrue( empty( $payload['post_data']['taxonomy'][ $taxonomy ] ) );
+	}
 }

--- a/tests/unit-tests/test-outgoing-post.php
+++ b/tests/unit-tests/test-outgoing-post.php
@@ -115,6 +115,7 @@ class TestOutgoingPost extends WP_UnitTestCase {
 
 		$this->assertSame( get_bloginfo( 'url' ), $payload['site_url'] );
 		$this->assertSame( $this->outgoing_post->get_post()->ID, $payload['post_id'] );
+		$this->assertSame( get_permalink( $this->outgoing_post->get_post()->ID ), $payload['post_url'] );
 		$this->assertSame( 32, strlen( $payload['network_post_id'] ) );
 		$this->assertEquals( $distribution, $payload['sites'] );
 


### PR DESCRIPTION
Implement the support for reserved taxonomies, starting with CAP's `author` taxonomy, as it requires custom handling.

This PR also changes the distribution of taxonomy terms, syncing them via `name` instead of `slug`. This allows for a more predictable behavior connecting with existing terms.

### Testing

1. Double check unit tests are accurate
2. Distribute a post with categories and tags via CLI 
3. Confirm the post gets distributed with the correct terms
4. If you don't have CAP active, register the `author` taxonomy somewhere in the plugin code:
```php
register_taxonomy( 'author', 'post', [ 'public' => true ] );
```
5. Set a term to your post and distribute:
```php
$term = wp_insert_term( 'Test Author', 'author' );
wp_set_object_terms( <post-id>, [ $term['term_id'] ], 'author' );
Newspack_Network\Content_Distribution::distribute_post( <post-id> );
```
6. Confirm in the node that the `author` taxonomy term is not distributed