### PR TITLE
fix: Force Distributor to not override bylines

### DIFF
--- a/includes/class-distributor-customizations.php
+++ b/includes/class-distributor-customizations.php
@@ -27,5 +27,6 @@ class Distributor_Customizations {
 		Distributor_Customizations\Author_Ingestion::init();
 		Distributor_Customizations\Authorship_Filters::init();
 		Distributor_Customizations\Comment_Status::init();
+		Distributor_Customizations\Force_Author_Byline::init();
 	}
 }

--- a/includes/distributor-customizations/class-force-author-byline.php
+++ b/includes/distributor-customizations/class-force-author-byline.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Newspack Distributor Force Author byline option.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Distributor_Customizations;
+
+/**
+ * Class to enforce that the "Override Author Byline" option is always disabled.
+ */
+class Force_Author_Byline {
+
+	/**
+	 * Initialize hooks
+	 */
+	public static function init() {
+		add_filter( 'option_dt_settings', [ __CLASS__, 'filter_dt_settings' ] );
+		add_filter( 'default_option_dt_settings', [ __CLASS__, 'filter_dt_settings' ] );
+		add_action( 'admin_init', [ __CLASS__, 'remove_setting' ], 11 );
+	}
+
+	/**
+	 * Filter the Distributor settings to ensure that the "Override Author Byline" option is always disabled.
+	 *
+	 * @param array $settings The Distributor settings.
+	 */
+	public static function filter_dt_settings( $settings ) {
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
+		$settings['override_author_byline'] = false;
+		return $settings;
+	}
+
+	/**
+	 * Remove the "Override Author Byline" setting from the Distributor settings page.
+	 */
+	public static function remove_setting() {
+		global $wp_settings_fields;
+
+		if (
+			isset( $wp_settings_fields['distributor'] ) &&
+			isset( $wp_settings_fields['distributor']['dt-section-1'] ) &&
+			isset( $wp_settings_fields['distributor']['dt-section-1']['override_author_byline'] )
+		) {
+			unset( $wp_settings_fields['distributor']['dt-section-1']['override_author_byline'] );
+		}
+	}
+}


### PR DESCRIPTION
Forces the Distributor option to override Bylines with the site URL to false and remove it from the UI.

![image](https://github.com/user-attachments/assets/19d38ee8-39f2-47d5-bb58-3f9fcd408845)

### Testing

1. Visit Distributor > Settings
2. Make sure you don't see the "Override Author Byline" option
3. in a shell run `Distributor\Utils\get_settings();`
4. Confirm that `override_author_byline` is always set to `false`