### PR TITLE
feat(content-distribution): log incoming post errors

### DIFF
--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -463,6 +463,7 @@ class Incoming_Post {
 			$post_id = wp_insert_post( $postarr, true );
 
 			if ( is_wp_error( $post_id ) ) {
+				self::log( 'Failed to insert post with message: ' . $post_id->get_error_message() );
 				return $post_id;
 			}
 

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -101,6 +101,19 @@ class Incoming_Post {
 	}
 
 	/**
+	 * Log a message.
+	 *
+	 * @param string $message The message to log.
+	 */
+	protected function log( $message ) {
+		$prefix = '[Incoming Post]';
+		if ( ! empty( $this->payload ) ) {
+			$prefix .= ' ' . $this->payload['network_post_id'];
+		}
+		Debugger::log( $prefix . ' ' . $message );
+	}
+
+	/**
 	 * Validate a payload.
 	 *
 	 * @param array $payload The payload to validate.
@@ -297,7 +310,7 @@ class Incoming_Post {
 
 		$attachment_id = media_sideload_image( $thumbnail_url, $this->ID, '', 'id' );
 		if ( is_wp_error( $attachment_id ) ) {
-			Debugger::log( 'Failed to upload featured image for post ' . $this->ID . ' with message: ' . $attachment_id->get_error_message() );
+			self::log( 'Failed to upload featured image for post ' . $this->ID . ' with message: ' . $attachment_id->get_error_message() );
 			return;
 		}
 
@@ -327,6 +340,7 @@ class Incoming_Post {
 				if ( ! $term ) {
 					$term = wp_insert_term( $term_data['name'], $taxonomy );
 					if ( is_wp_error( $term ) ) {
+						self::log( 'Failed to insert term ' . $term_data['name'] . ' for taxonomy ' . $taxonomy . ' with message: ' . $term->get_error_message() );
 						continue;
 					}
 					$term = get_term_by( 'id', $term['term_id'], $taxonomy, ARRAY_A );
@@ -395,6 +409,7 @@ class Incoming_Post {
 		if ( ! empty( $payload ) ) {
 			$error = $this->update_payload( $payload );
 			if ( is_wp_error( $error ) ) {
+				self::log( 'Failed to update payload: ' . $error->get_error_message() );
 				return $error;
 			}
 		}
@@ -451,6 +466,7 @@ class Incoming_Post {
 
 			// The wp_insert_post() function might return `0` on failure.
 			if ( ! $post_id ) {
+				self::log( 'Failed to insert post with data: ' . print_r( $postarr, true ) );
 				return new WP_Error( 'insert_error', __( 'Error inserting post.', 'newspack-network' ) );
 			}
 

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -427,6 +427,7 @@ class Incoming_Post {
 			! empty( $current_payload ) &&
 			$current_payload['post_data']['modified_gmt'] > $post_data['modified_gmt']
 		) {
+			self::log( 'Linked post content is newer than the post payload.' );
 			return new WP_Error( 'old_modified_date', __( 'Linked post content is newer than the post payload.', 'newspack-network' ) );
 		}
 

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -104,6 +104,8 @@ class Incoming_Post {
 	 * Log a message.
 	 *
 	 * @param string $message The message to log.
+	 *
+	 * @return void
 	 */
 	protected function log( $message ) {
 		$prefix = '[Incoming Post]';
@@ -466,7 +468,7 @@ class Incoming_Post {
 
 			// The wp_insert_post() function might return `0` on failure.
 			if ( ! $post_id ) {
-				self::log( 'Failed to insert post with data: ' . print_r( $postarr, true ) );
+				self::log( 'Failed to insert post.' );
 				return new WP_Error( 'insert_error', __( 'Error inserting post.', 'newspack-network' ) );
 			}
 


### PR DESCRIPTION
Implements additional logging with an intelligible prefix to errors that can occur when a distributed post arrives at its destination.

### Testing

1. Add the following to line 342 of `includes/content-distribution/class-incoming-post.php`:

```php
$term = new WP_Error( 'test_error',  'Test error' );
```

2. On the same file, add the following to line 312:

```php
$attachment_id = new WP_Error( 'test_error', 'Test error' );
```

3. Make sure you have `define( 'NEWSPACK_NETWORK_DEBUG', true );` added to all your network sites
3. Distribute a post with a featured image and categories/tags
4. In the receiving node, check the logs and confirm the error is logged:

```
[Incoming Post] 1222943f3be7e643ee008fc972d1793e Failed to upload featured image for post 123 with message: Test error
[Incoming Post] 1222943f3be7e643ee008fc972d1793e Failed to insert term Test for taxonomy category with message: Test error
```