### PR TITLE
fix(content-distribution): persist site hash

### DIFF
--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -68,7 +68,12 @@ class Outgoing_Post {
 	 * @return string The network post ID.
 	 */
 	public function get_network_post_id() {
-		return md5( $this->post->ID . get_bloginfo( 'url' ) );
+		$site_hash = get_option( 'newspack_network_content_distribution_hash' );
+		if ( ! $site_hash ) {
+			$site_hash = md5( get_bloginfo( 'url' ) );
+			update_option( 'newspack_network_content_distribution_hash', $site_hash );
+		}
+		return md5( $site_hash . $this->post->ID );
 	}
 
 	/**


### PR DESCRIPTION
We're not expecting a site URL to change, which is expected to break their network communications (not just content distribution). Nonetheless, I've been having some issues with the network post ID because my local setup has a dynamic site URL, generating different IDs whether the code is running via shell, CLI, or the browser.

This change is to ensure that the site hash is consistent and the relationship between distributed posts never breaks.

## Testing

Distribution should work the same. Distribute a post to a node, save a few changes, and confirm the post (and its changes) are distributed.