### PR TITLE
fix(content-distribution): Improve CSS for blocked editor

### DIFF
--- a/src/content-distribution/incoming-post/style.scss
+++ b/src/content-distribution/incoming-post/style.scss
@@ -28,16 +28,19 @@
 	}
 
 	.editor-sidebar:not(#newspack-network-incoming-post\:newspack-network-content-distribution-panel, #edit-post\:document) {
-		@include grey-out-outer;
 
 		.components-panel {
-			@include grey-out-inner;
+			@include grey-out-outer;
+
+			* {
+				@include grey-out-inner;
+			}
 		}
 	}
 
 	// This will grey out most – but not the top part with status, trash, etc. That part is not in a panel.
 	#edit-post\:document {
-		.components-panel__body {
+		.components-panel__body, .editor-post-featured-image {
 			@include grey-out-outer;
 
 			* {


### PR DESCRIPTION
This fixes 2 things that came out of #181

* Also blocks the "Featured image" button so that is not editable on linked posts
* Fixes a bug where it was not possible to click from the "Block" tab in the sidebar to the "Post" tab.

## How to test
On a linked post – ensure that the sidebar blocks what it should (and no more) and that you can click between the tabs in the sidebar.