### PR TITLE
fix(content-distribution): prevent consecutive dispatches

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -21,6 +21,9 @@ use WP_Post;
  * Main class for content distribution
  */
 class Content_Distribution {
+
+	const PAYLOAD_HASH_META = '_newspack_network_payload_hash';
+
 	/**
 	 * Queued network post updates.
 	 *
@@ -77,6 +80,9 @@ class Content_Distribution {
 	 * Distribute queued posts.
 	 */
 	public static function distribute_queued_posts() {
+		if ( empty( self::$queued_post_updates ) ) {
+			return;
+		}
 		$post_ids = array_unique( self::$queued_post_updates );
 		foreach ( $post_ids as $post_id ) {
 			$post = get_post( $post_id );
@@ -85,6 +91,7 @@ class Content_Distribution {
 			}
 			self::distribute_post( $post );
 		}
+		self::$queued_post_updates = [];
 	}
 
 	/**
@@ -175,6 +182,9 @@ class Content_Distribution {
 	public static function handle_post_updated( $post ) {
 		$post = get_post( $post );
 		if ( ! $post ) {
+			return;
+		}
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || wp_is_post_revision( $post->ID ) ) {
 			return;
 		}
 		if ( ! self::is_post_distributed( $post ) ) {
@@ -268,6 +278,7 @@ class Content_Distribution {
 		return array_merge(
 			$reserved_keys,
 			[
+				self::PAYLOAD_HASH_META,
 				Outgoing_Post::DISTRIBUTED_POST_META,
 				Incoming_Post::NETWORK_POST_ID_META,
 				Incoming_Post::PAYLOAD_META,
@@ -360,7 +371,14 @@ class Content_Distribution {
 			$distributed_post = self::get_distributed_post( $post );
 		}
 		if ( $distributed_post ) {
-			Data_Events::dispatch( 'network_post_updated', $distributed_post->get_payload( $status_on_create ) );
+			$payload      = $distributed_post->get_payload( $status_on_create );
+			$payload_hash = $distributed_post->get_payload_hash( $payload );
+			$post         = $distributed_post->get_post();
+			if ( get_post_meta( $post->ID, self::PAYLOAD_HASH_META, true ) === $payload_hash ) {
+				return;
+			}
+			Data_Events::dispatch( 'network_post_updated', $payload );
+			update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $payload_hash );
 		}
 	}
 }

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -178,6 +178,23 @@ class Outgoing_Post {
 	}
 
 	/**
+	 * Get the payload hash.
+	 *
+	 * @param array|null $payload Optional payload to hash.
+	 *
+	 * @return string The payload hash.
+	 */
+	public function get_payload_hash( $payload = null ) {
+		if ( empty( $payload ) ) {
+			$payload = $this->get_payload();
+		}
+		unset( $payload['status_on_create'] );
+		unset( $payload['post_data']['date_gmt'] );
+		unset( $payload['post_data']['modified_gmt'] );
+		return md5( wp_json_encode( $payload ) );
+	}
+
+	/**
 	 * Get the post payload for distribution.
 	 *
 	 * @param string $status_on_create The post status when creating the post.


### PR DESCRIPTION
p1737411007755239-slack-C055SRT7WN4

When saving a post via Gutenberg, there's a high chance that at least 2 requests will be made to save the post. (see https://github.com/WordPress/gutenberg/issues/15094)

This will cause consecutive dispatches to distribute the post, potentially with the same payload. This PR prevents dispatches with the same payload from getting through.

### Testing

1. Distribute a post to a node
2. Make changes in the editor and save
3. Confirm only 1 dispatch is made and the change is distributed
4. Add a new custom field via the "Custom Fields" advanced section and save
5. Confirm that also only 1 dispatch is made and the change is distributed
6. Make changes to the content, add a new custom field and save
7. Confirm that 2 dispatches are made and the change is distributed (the first will be post content and the second with post meta)
