### PR TITLE
feat(content-distribution): remove "Quick Edit" from linked posts

### DIFF
--- a/includes/content-distribution/class-admin.php
+++ b/includes/content-distribution/class-admin.php
@@ -7,11 +7,12 @@
 
 namespace Newspack_Network\Content_Distribution;
 
-use Newspack_Network\Site_Role;
-use Newspack_Network\Hub\Nodes;
-use Newspack_Network\Hub\Node;
 use Newspack\Data_Events;
 use Newspack_Network\Admin as Network_Admin;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
+use Newspack_Network\Hub\Node;
+use Newspack_Network\Hub\Nodes;
+use Newspack_Network\Site_Role;
 
 /**
  * Content Distribution Admin Page Class.
@@ -54,6 +55,7 @@ class Admin {
 		add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
 		add_action( 'update_option_' . self::CAPABILITY_ROLES_OPTION_NAME, [ __CLASS__, 'update_capability_roles' ], 10, 2 );
+		add_filter( 'post_row_actions', [ __CLASS__, 'filter_row_actions' ], 15, 2 );
 	}
 
 	/**
@@ -317,5 +319,27 @@ class Admin {
 		return [
 			'url' => $node_url,
 		];
+	}
+
+	/**
+	 * Filter callback.
+	 *
+	 * Remove "quick actions" for linked posts.
+	 *
+	 * @param array    $actions An array of row action links.
+	 * @param \WP_Post $post The post object.
+	 *
+	 * @return array
+	 */
+	public static function filter_row_actions( $actions, $post ) {
+		if ( Site_Role::is_hub() || empty( $actions['inline hide-if-no-js'] ) ) {
+			return $actions;
+		}
+
+		if ( Content_Distribution_Class::is_post_incoming( $post ) && ( new Incoming_Post( $post->ID ) )->is_linked() ) {
+			unset( $actions['inline hide-if-no-js'] );
+		}
+
+		return $actions;
 	}
 }

--- a/includes/content-distribution/class-api.php
+++ b/includes/content-distribution/class-api.php
@@ -8,7 +8,7 @@
 namespace Newspack_Network\Content_Distribution;
 
 use InvalidArgumentException;
-use Newspack_Network\Content_Distribution;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use WP_Error;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -124,7 +124,7 @@ class API {
 			return new WP_Error( 'newspack_network_content_distribution_error', $distribution->get_error_message(), [ 'status' => 400 ] );
 		}
 
-		Content_Distribution::distribute_post( $outgoing_post, $status_on_create );
+		Content_Distribution_Class::distribute_post( $outgoing_post, $status_on_create );
 
 		return rest_ensure_response( $distribution );
 	}

--- a/includes/content-distribution/class-canonical-url.php
+++ b/includes/content-distribution/class-canonical-url.php
@@ -7,7 +7,7 @@
 
 namespace Newspack_Network\Content_Distribution;
 
-use Newspack_Network\Content_Distribution;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 
 /**
  * Class to filter the canonical URLs for distributed content.
@@ -33,7 +33,7 @@ class Canonical_Url {
 	 * @return string
 	 */
 	public static function filter_canonical_url( $canonical_url, $post ) {
-		if ( ! Content_Distribution::is_post_incoming( $post ) ) {
+		if ( ! Content_Distribution_Class::is_post_incoming( $post ) ) {
 			return $canonical_url;
 		}
 

--- a/includes/content-distribution/class-cli.php
+++ b/includes/content-distribution/class-cli.php
@@ -7,7 +7,7 @@
 
 namespace Newspack_Network\Content_Distribution;
 
-use Newspack_Network\Content_Distribution;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use Newspack_Network\Utils\Network;
 use WP_CLI;
 use WP_CLI\ExitException;
@@ -49,7 +49,7 @@ class CLI {
 							__( 'The ID of the post to distribute. Supported post types are: %s', 'newspack-network' ),
 							implode(
 								', ',
-								Content_Distribution::get_distributed_post_types()
+								Content_Distribution_Class::get_distributed_post_types()
 							)
 						),
 						'optional'    => false,
@@ -137,13 +137,13 @@ class CLI {
 		}
 
 		try {
-			$outgoing_post = Content_Distribution::get_distributed_post( $post_id ) ?? new Outgoing_Post( $post_id );
+			$outgoing_post = Content_Distribution_Class::get_distributed_post( $post_id ) ?? new Outgoing_Post( $post_id );
 			$sites = $outgoing_post->set_distribution( $sites );
 			if ( is_wp_error( $sites ) ) {
 				WP_CLI::error( $sites->get_error_message() );
 			}
 
-			Content_Distribution::distribute_post( $outgoing_post, $assoc_args['status_on_create'] ?? 'draft' );
+			Content_Distribution_Class::distribute_post( $outgoing_post, $assoc_args['status_on_create'] ?? 'draft' );
 			WP_CLI::success( sprintf( 'Post with ID %d is distributed to %d sites: %s', $post_id, count( $sites ), implode( ', ', $sites ) ) );
 
 		} catch ( \Exception $e ) {

--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -7,7 +7,7 @@
 
 namespace Newspack_Network\Content_Distribution;
 
-use Newspack_Network\Content_Distribution;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use Newspack_Network\Utils\Network;
 use WP_Post;
 
@@ -30,7 +30,7 @@ class Editor {
 	 * Register the meta available in the editor.
 	 */
 	public static function register_meta() {
-		$post_types = Content_Distribution::get_distributed_post_types();
+		$post_types = Content_Distribution_Class::get_distributed_post_types();
 		foreach ( $post_types as $post_type ) {
 			register_post_meta(
 				$post_type,
@@ -65,14 +65,14 @@ class Editor {
 		$screen = get_current_screen();
 		if (
 			! current_user_can( Admin::CAPABILITY )
-			|| ! in_array( $screen->post_type, Content_Distribution::get_distributed_post_types(), true )
+			|| ! in_array( $screen->post_type, Content_Distribution_Class::get_distributed_post_types(), true )
 		) {
 			return;
 		}
 
 		$post = get_post();
 
-		if ( Content_Distribution::is_post_incoming( $post ) ) {
+		if ( Content_Distribution_Class::is_post_incoming( $post ) ) {
 			self::enqueue_block_editor_assets_for_incoming_post( $post );
 		} else {
 			self::enqueue_block_editor_assets_for_outgoing_post( $post );
@@ -159,7 +159,7 @@ class Editor {
 	 * @return array
 	 */
 	public static function add_distribution_column( $columns, $post_type ) {
-		if ( ! in_array( $post_type, Content_Distribution::get_distributed_post_types(), true ) ) {
+		if ( ! in_array( $post_type, Content_Distribution_Class::get_distributed_post_types(), true ) ) {
 			return $columns;
 		}
 		$columns['content_distribution'] = sprintf(
@@ -183,8 +183,8 @@ class Editor {
 			return;
 		}
 
-		$is_incoming = Content_Distribution::is_post_incoming( $post_id );
-		$is_outgoing = Content_Distribution::is_post_distributed( $post_id );
+		$is_incoming = Content_Distribution_Class::is_post_incoming( $post_id );
+		$is_outgoing = Content_Distribution_Class::is_post_distributed( $post_id );
 
 		if ( ! $is_incoming && ! $is_outgoing ) {
 			return;
@@ -250,7 +250,7 @@ class Editor {
 	 */
 	public static function add_posts_column_styles() {
 		$screen = get_current_screen();
-		if ( ! in_array( $screen->post_type, Content_Distribution::get_distributed_post_types(), true ) ) {
+		if ( ! in_array( $screen->post_type, Content_Distribution_Class::get_distributed_post_types(), true ) ) {
 			return;
 		}
 		?>

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -8,7 +8,7 @@
 namespace Newspack_Network\Content_Distribution;
 
 use Newspack_Network\Debugger;
-use Newspack_Network\Content_Distribution;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use WP_Post;
 use WP_Error;
 
@@ -199,7 +199,7 @@ class Incoming_Post {
 	protected function query_post() {
 		$posts = get_posts(
 			[
-				'post_type'      => Content_Distribution::get_distributed_post_types(),
+				'post_type'      => Content_Distribution_Class::get_distributed_post_types(),
 				'post_status'    => [ 'publish', 'pending', 'draft', 'auto-draft', 'future', 'private', 'inherit', 'trash' ],
 				'posts_per_page' => 1,
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -275,7 +275,7 @@ class Incoming_Post {
 	protected function update_meta() {
 		$data = $this->payload['post_data']['post_meta'];
 
-		$reserved_keys = Content_Distribution::get_reserved_post_meta_keys();
+		$reserved_keys = Content_Distribution_Class::get_reserved_post_meta_keys();
 
 		// Clear existing post meta that are not in the payload.
 		$post_meta = get_post_meta( $this->ID );
@@ -349,7 +349,7 @@ class Incoming_Post {
 	 * @return void
 	 */
 	protected function update_taxonomy_terms() {
-		$reserved_taxonomies = Content_Distribution::get_reserved_taxonomies();
+		$reserved_taxonomies = Content_Distribution_Class::get_reserved_taxonomies();
 		$data                = $this->payload['post_data']['taxonomy'];
 		foreach ( $data as $taxonomy => $terms ) {
 			if ( in_array( $taxonomy, $reserved_taxonomies, true ) ) {

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -7,7 +7,7 @@
 
 namespace Newspack_Network\Content_Distribution;
 
-use Newspack_Network\Content_Distribution;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use Newspack_Network\Utils\Network;
 use WP_Error;
 use WP_Post;
@@ -45,7 +45,7 @@ class Outgoing_Post {
 			throw new \InvalidArgumentException( esc_html( __( 'Only published post are allowed to be distributed.', 'newspack-network' ) ) );
 		}
 
-		if ( ! in_array( $post->post_type, Content_Distribution::get_distributed_post_types() ) ) {
+		if ( ! in_array( $post->post_type, Content_Distribution_Class::get_distributed_post_types() ) ) {
 			/* translators: unsupported post type for content distribution */
 			throw new \InvalidArgumentException( esc_html( sprintf( __( 'Post type %s is not supported as a distributed outgoing post.', 'newspack-network' ), $post->post_type ) ) );
 		}
@@ -147,7 +147,7 @@ class Outgoing_Post {
 	 * @return bool
 	 */
 	public function is_distributed( $site_url = null ) {
-		$distributed_post_types = Content_Distribution::get_distributed_post_types();
+		$distributed_post_types = Content_Distribution_Class::get_distributed_post_types();
 		if ( ! in_array( $this->post->post_type, $distributed_post_types, true ) ) {
 			return false;
 		}
@@ -251,7 +251,7 @@ class Outgoing_Post {
 	 * @return array The taxonomy term data.
 	 */
 	protected function get_post_taxonomy_terms() {
-		$reserved_taxonomies = Content_Distribution::get_reserved_taxonomies();
+		$reserved_taxonomies = Content_Distribution_Class::get_reserved_taxonomies();
 		$taxonomies          = get_object_taxonomies( $this->post->post_type, 'objects' );
 		$data                = [];
 		foreach ( $taxonomies as $taxonomy ) {
@@ -284,7 +284,7 @@ class Outgoing_Post {
 	 * @return array The post meta data.
 	 */
 	protected function get_post_meta() {
-		$reserved_keys = Content_Distribution::get_reserved_post_meta_keys();
+		$reserved_keys = Content_Distribution_Class::get_reserved_post_meta_keys();
 
 		$meta = get_post_meta( $this->post->ID );
 

--- a/tests/unit-tests/content-distribution/test-content-distribution.php
+++ b/tests/unit-tests/content-distribution/test-content-distribution.php
@@ -7,7 +7,6 @@
 
 namespace Test\Content_Distribution;
 
-use Newspack_Network\Content_Distribution;
 use Newspack_Network\Content_Distribution\Outgoing_Post;
 use Newspack_Network\Hub\Node as Hub_Node;
 


### PR DESCRIPTION
Because quick edit let's the user do stuff we don't want on linked posts, this just removes it.

## How to test
On a node site check that all linked posts don't show "quick edit" on hover on the posts listing. Networked posts that are not linked should still have it. 

Posts not networked should also have it (note that distributor also hides it, so not those posts).