### PR TITLE
feat(content-distribution): migration tweaks

### DIFF
--- a/includes/content-distribution/class-distributor-migrator.php
+++ b/includes/content-distribution/class-distributor-migrator.php
@@ -55,13 +55,13 @@ class Distributor_Migrator {
 			return $caps;
 		}
 
-		$post_id = $args[0];
-		if ( ! Content_Distribution::is_post_distributed( $post_id ) ) {
+		$locked = get_transient( self::MIGRATION_LOCK_TRANSIENT_NAME );
+		if ( ! $locked ) {
 			return $caps;
 		}
 
-		$locked = get_transient( self::MIGRATION_LOCK_TRANSIENT_NAME );
-		if ( ! $locked ) {
+		$post_id = $args[0];
+		if ( ! Content_Distribution::is_post_distributed( $post_id ) ) {
 			return $caps;
 		}
 


### PR DESCRIPTION
Implements 2 new features to the migration:

 - `--dry-run` flag for the CLI command
 - Lock editing distributed posts for 10 minutes after a migration to give time for the incoming posts to process:

<img width="849" alt="image" src="https://github.com/user-attachments/assets/7b76130e-4c19-4385-8919-e868d15adc46" />

### Testing

1. Using Distributor, distribute a post to a couple of nodes
2. Run the dry run migration:

```
wp newspack network distributor migrate --all --dry-run
```

3. Confirm you get information about the migration but it doesn't go through
4. Run the migration:

```
wp newspack network distributor migrate --all
```

5. Confirm the migration runs
6. Visit the posts dashboard in the distribution origin and confirm you get the notice as in the image above and you're unable to edit the distributed posts (other posts should be fine)
7. Wait 10 minutes or manually delete the transient:

```
wp transient delete newspack_network_distributor_migration_lock
```

8. Refresh the page and confirm the notice is gone and you are able to edit the posts