### PR TITLE
feat(testing): Add co-authors-plus to unit testing

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -95,6 +95,13 @@ install_wp() {
 	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
+# Install plugins needed for the test suite.
+install_contrib_plugins() {
+  # Also see set_up_contrib_plugins() in ./bootstrap.php in this repo for how to activate plugins in the test suite.
+  wget -nv -O /tmp/co-authors-plus.zip https://downloads.wordpress.org/plugin/co-authors-plus.zip
+  unzip -q -o /tmp/co-authors-plus.zip -d $WP_CORE_DIR/wp-content/plugins/
+}
+
 install_test_suite() {
 	# portable in-place argument for both GNU sed and Mac OSX sed
 	if [[ $(uname -s) == 'Darwin' ]]; then
@@ -176,5 +183,6 @@ install_db() {
 }
 
 install_wp
+install_contrib_plugins
 install_test_suite
 install_db

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,46 @@ define( 'IS_TEST_ENV', 1 );
 require_once "{$newspack_network_hub_test_dir}/includes/functions.php";
 
 /**
+ * Include and activate the 3rd-party plugins we use.
+ *
+ * See install_contrib_plugins in bin/install-wp-tests.sh for the list of plugins we download.
+ */
+function set_up_contrib_plugins(): void {
+	// Add plugins to this array to have them loaded by the test suite.
+	// Note that it would load and activate the plugin in all tests, so use sparingly.
+	$plugins_active_in_tests = [
+		// The CAP plugin is used so much in our code that it is hard to test without it.
+		'co-authors-plus' => 'co-authors-plus/co-authors-plus.php',
+	];
+
+	$wordpress_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress';
+	foreach ( $plugins_active_in_tests as $plugin ) {
+		$plugin_file = "$wordpress_dir/wp-content/plugins/$plugin";
+
+		if ( ! file_exists( $plugin_file ) ) {
+			// Be very, very specific about what is wrong to save hours of error finding.
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.HeredocOutputNotEscaped
+			echo <<<MESSAGE
+			----------------------------------------------
+			👋
+			This is an error message from your friendly function set_up_contrib_plugins() in bootstrap.php:
+			Could not find the plugin file: $plugin_file 
+			Make sure the plugin gets downloaded in the install_contrib_plugins() function in bin/install-wp-tests.sh.
+			Make sure you have run ./bin/install-wp-tests.sh.
+			Sometimes deleting the WordPress test directory $wordpress_dir and then running ./bin/install-wp-tests.sh again helps.\n
+			----------------------------------------------
+			MESSAGE;
+			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.HeredocOutputNotEscaped
+			exit( 1 );
+		}
+		tests_add_filter( 'muplugins_loaded', fn() => require $plugin_file );
+	}
+
+	// This will activate the plugins in the test suite.
+	$GLOBALS['wp_tests_options']['active_plugins'] = $plugins_active_in_tests;
+}
+
+/**
  * Manually load the plugin being tested.
  */
 function newspack_network_hub_manually_load_plugin() {
@@ -29,6 +69,9 @@ function newspack_network_hub_manually_load_plugin() {
 }
 
 tests_add_filter( 'muplugins_loaded', 'newspack_network_hub_manually_load_plugin' );
+
+// Include and "activate" plugins needed.
+set_up_contrib_plugins();
 
 require_once __DIR__ . '/../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 


### PR DESCRIPTION
This adds CAP so it's always enabled in unit tests. It will need to be specifically disabled in tests if testing something that does not want CAP.

## Todo
- [ ] Add a test that uses CAP 

## How to test
It's for tests! I guess run all tests 