### PR TITLE
chore(content-distribution): better readability for ignored attributes

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -163,10 +163,10 @@ class Content_Distribution {
 		if ( ! self::is_post_distributed( $post ) ) {
 			return;
 		}
-		// Ignore reserved keys but run if the meta is setting the distribution.
+		// Skip ignored keys but run if the meta is setting the distribution.
 		if (
 			Outgoing_Post::DISTRIBUTED_POST_META !== $meta_key &&
-			in_array( $meta_key, self::get_reserved_post_meta_keys(), true )
+			in_array( $meta_key, self::get_ignored_post_meta_keys(), true )
 		) {
 			return;
 		}
@@ -257,10 +257,16 @@ class Content_Distribution {
 	/**
 	 * Get post meta keys that should be ignored on content distribution.
 	 *
-	 * @return string[] The reserved post meta keys.
+	 * When generating the payload for content distribution, post meta with these
+	 * keys will not be included.
+	 *
+	 * Upon sync, these keys will also be ignored when updating the post meta,
+	 * so they'll never be deleted or updated.
+	 *
+	 * @return string[] The ignored post meta keys.
 	 */
-	public static function get_reserved_post_meta_keys() {
-		$reserved_keys = [
+	public static function get_ignored_post_meta_keys() {
+		$ignored_keys = [
 			'_edit_lock',
 			'_edit_last',
 			'_thumbnail_id',
@@ -268,16 +274,16 @@ class Content_Distribution {
 		];
 
 		/**
-		 * Filters the reserved post meta keys that should not be distributed.
+		 * Filters the ignored post meta keys that should not be distributed.
 		 *
-		 * @param string[] $reserved_keys The reserved post meta keys.
-		 * @param WP_Post  $post          The post object.
+		 * @param string[] $ignored_keys The ignored post meta keys.
+		 * @param WP_Post  $post         The post object.
 		 */
-		$reserved_keys = apply_filters( 'newspack_network_content_distribution_reserved_post_meta_keys', $reserved_keys );
+		$ignored_keys = apply_filters( 'newspack_network_content_distribution_ignored_post_meta_keys', $ignored_keys );
 
-		// Always preserve content distribution post meta.
+		// Always ignore content distribution post meta.
 		return array_merge(
-			$reserved_keys,
+			$ignored_keys,
 			[
 				self::PAYLOAD_HASH_META,
 				Outgoing_Post::DISTRIBUTED_POST_META,
@@ -292,19 +298,19 @@ class Content_Distribution {
 	/**
 	 * Get taxonomies that should not be distributed.
 	 *
-	 * @return string[] The reserved taxonomies.
+	 * @return string[] The ignored taxonomies.
 	 */
-	public static function get_reserved_taxonomies() {
-		$reserved_taxonomies = [
+	public static function get_ignored_taxonomies() {
+		$ignored_taxonomies = [
 			'author', // Co-Authors Plus 'author' taxonomy should be ignored as it requires custom handling.
 		];
 
 		/**
-		 * Filters the reserved taxonomies that should not be distributed.
+		 * Filters the ignored taxonomies that should not be distributed.
 		 *
-		 * @param string[] $reserved_taxonomies The reserved taxonomies.
+		 * @param string[] $ignored_taxonomies The ignored taxonomies.
 		 */
-		return apply_filters( 'newspack_network_content_distribution_reserved_taxonomies', $reserved_taxonomies );
+		return apply_filters( 'newspack_network_content_distribution_ignored_taxonomies', $ignored_taxonomies );
 	}
 
 	/**

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -270,18 +270,24 @@ class Incoming_Post {
 	/**
 	 * Update the post meta for a linked post.
 	 *
+	 * This will delete existing post meta that are not in the payload and update
+	 * the existing post meta.
+	 *
+	 * Ignored keys will not be managed, meaning they will not be deleted or
+	 * updated.
+	 *
 	 * @return void
 	 */
 	protected function update_meta() {
 		$data = $this->payload['post_data']['post_meta'];
 
-		$reserved_keys = Content_Distribution_Class::get_reserved_post_meta_keys();
+		$ignored_keys = Content_Distribution_Class::get_ignored_post_meta_keys();
 
-		// Clear existing post meta that are not in the payload.
+		// Delete existing post meta that are not in the payload.
 		$post_meta = get_post_meta( $this->ID );
 		foreach ( $post_meta as $meta_key => $meta_value ) {
 			if (
-				! in_array( $meta_key, $reserved_keys, true ) &&
+				! in_array( $meta_key, $ignored_keys, true ) &&
 				! array_key_exists( $meta_key, $data )
 			) {
 				delete_post_meta( $this->ID, $meta_key );
@@ -293,7 +299,7 @@ class Incoming_Post {
 		}
 
 		foreach ( $data as $meta_key => $meta_value ) {
-			if ( ! in_array( $meta_key, $reserved_keys, true ) ) {
+			if ( ! in_array( $meta_key, $ignored_keys, true ) ) {
 				if ( 1 === count( $meta_value ) ) {
 					update_post_meta( $this->ID, $meta_key, $meta_value[0] );
 				} else {
@@ -349,10 +355,10 @@ class Incoming_Post {
 	 * @return void
 	 */
 	protected function update_taxonomy_terms() {
-		$reserved_taxonomies = Content_Distribution_Class::get_reserved_taxonomies();
-		$data                = $this->payload['post_data']['taxonomy'];
+		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
+		$data               = $this->payload['post_data']['taxonomy'];
 		foreach ( $data as $taxonomy => $terms ) {
-			if ( in_array( $taxonomy, $reserved_taxonomies, true ) ) {
+			if ( in_array( $taxonomy, $ignored_taxonomies, true ) ) {
 				continue;
 			}
 			if ( ! taxonomy_exists( $taxonomy ) ) {

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -251,11 +251,11 @@ class Outgoing_Post {
 	 * @return array The taxonomy term data.
 	 */
 	protected function get_post_taxonomy_terms() {
-		$reserved_taxonomies = Content_Distribution_Class::get_reserved_taxonomies();
-		$taxonomies          = get_object_taxonomies( $this->post->post_type, 'objects' );
+		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
+		$taxonomies         = get_object_taxonomies( $this->post->post_type, 'objects' );
 		$data                = [];
 		foreach ( $taxonomies as $taxonomy ) {
-			if ( in_array( $taxonomy->name, $reserved_taxonomies, true ) ) {
+			if ( in_array( $taxonomy->name, $ignored_taxonomies, true ) ) {
 				continue;
 			}
 			if ( ! $taxonomy->public ) {
@@ -284,7 +284,7 @@ class Outgoing_Post {
 	 * @return array The post meta data.
 	 */
 	protected function get_post_meta() {
-		$reserved_keys = Content_Distribution_Class::get_reserved_post_meta_keys();
+		$ignored_keys = Content_Distribution_Class::get_ignored_post_meta_keys();
 
 		$meta = get_post_meta( $this->post->ID );
 
@@ -294,9 +294,9 @@ class Outgoing_Post {
 
 		$meta = array_filter(
 			$meta,
-			function( $value, $key ) use ( $reserved_keys ) {
-				// Filter out reserved keys.
-				return ! in_array( $key, $reserved_keys, true );
+			function( $value, $key ) use ( $ignored_keys ) {
+				// Filter out ignored keys.
+				return ! in_array( $key, $ignored_keys, true );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -407,13 +407,13 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test reserved taxonomies.
+	 * Test ignored taxonomies.
 	 */
-	public function test_reserved_taxonomies() {
+	public function test_ignored_taxonomies() {
 		$payload = $this->get_sample_payload();
 		$taxonomy = 'author';
 
-		// Register a reserved taxonomy.
+		// Register an ignored taxonomy.
 		register_taxonomy( $taxonomy, 'post', [ 'public' => true ] );
 
 		$payload['post_data']['taxonomy']['author'] = [
@@ -426,7 +426,7 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		// Insert the linked post.
 		$post_id = $this->incoming_post->insert( $payload );
 
-		// Assert that the post does not have the reserved taxonomy term.
+		// Assert that the post does not have the ignored taxonomy term.
 		$terms = wp_get_post_terms( $post_id, $taxonomy );
 		$this->assertEmpty( $terms );
 	}

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -184,9 +184,9 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test reserved taxonomies.
+	 * Test ignored taxonomies.
 	 */
-	public function test_reserved_taxonomies() {
+	public function test_ignored_taxonomies() {
 		$post = $this->outgoing_post->get_post();
 		$taxonomy = 'author';
 		register_taxonomy( $taxonomy, 'post', [ 'public' => true ] );


### PR DESCRIPTION
Update the wording of reserved post meta and taxonomies to **ignored**. It also updates docblocks so the behavior of post meta sync is more clear.

### Testing

There should be no functional changes. Unit tests should pass and distribution should work as expected.