### PR TITLE
feat(content-distribution): partial payload

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -424,7 +424,7 @@ class Content_Distribution {
 	 * Trigger a partial post distribution.
 	 *
 	 * @param WP_Post|Outgoing_Post|int $post           The post object or ID.
-	 * @param string[]                  $post_data_keys The post data key to update.
+	 * @param string[]                  $post_data_keys The post data keys to update.
 	 *
 	 * @return void|WP_Error The error if the payload is invalid.
 	 */

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -51,7 +51,9 @@ class Content_Distribution {
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_short_circuit_distributed_meta' ], 10, 4 );
 		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ] );
-		add_action( 'updated_postmeta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
+		add_action( 'updated_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
+		add_action( 'added_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
+		add_action( 'deleted_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'before_delete_post', [ __CLASS__, 'handle_post_deleted' ] );
 		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
 

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -201,7 +201,7 @@ class Content_Distribution {
 		) {
 			return;
 		}
-		self::queue_post_distribution( $object_id, 'post_meta' );
+		self::queue_post_distribution( $post->ID, 'post_meta' );
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -106,6 +106,13 @@ class Content_Distribution {
 	}
 
 	/**
+	 * Get queued post distributions.
+	 */
+	public static function get_queued_distributions() {
+		return self::$queued_distributions;
+	}
+
+	/**
 	 * Distribute queued posts.
 	 */
 	public static function distribute_queued_posts() {

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -201,7 +201,7 @@ class Content_Distribution {
 		) {
 			return;
 		}
-		self::queue_post_distribution( $post->ID, 'post_meta' );
+		self::queue_post_distribution( $object_id, 'post_meta' );
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -30,7 +30,7 @@ class Content_Distribution {
 	 *
 	 * @var array Post IDs to update.
 	 */
-	private static $queued_post_updates = [];
+	private static $queued_distributions = [];
 
 	/**
 	 * Initialize this class and register hooks
@@ -78,21 +78,52 @@ class Content_Distribution {
 	}
 
 	/**
+	 * Queue post distribution to run on PHP shutdown.
+	 *
+	 * @param int         $post_id       The post ID.
+	 * @param null|string $post_data_key The post data key to update.
+	 *                                   Default is null (entire post payload).
+	 *
+	 * @return void
+	 */
+	public static function queue_post_distribution( $post_id, $post_data_key = null ) {
+		// Bail if the post is already queued for a full update.
+		if ( isset( self::$queued_distributions[ $post_id ] ) && self::$queued_distributions[ $post_id ] === true ) {
+			return;
+		}
+
+		// Queue for a full post update.
+		if ( empty( $post_data_key ) ) {
+			self::$queued_distributions[ $post_id ] = true;
+			return;
+		}
+
+		// Queue for a partial update.
+		if ( ! isset( self::$queued_distributions[ $post_id ] ) ) {
+			self::$queued_distributions[ $post_id ] = [];
+		}
+		self::$queued_distributions[ $post_id ][] = $post_data_key;
+	}
+
+	/**
 	 * Distribute queued posts.
 	 */
 	public static function distribute_queued_posts() {
-		if ( empty( self::$queued_post_updates ) ) {
+		if ( empty( self::$queued_distributions ) ) {
 			return;
 		}
-		$post_ids = array_unique( self::$queued_post_updates );
-		foreach ( $post_ids as $post_id ) {
+		foreach ( self::$queued_distributions as $post_id => $post_data_keys ) {
 			$post = get_post( $post_id );
 			if ( ! $post ) {
 				continue;
 			}
-			self::distribute_post( $post );
+			if ( is_array( $post_data_keys ) ) {
+				self::distribute_post_partial( $post, array_unique( $post_data_keys ) );
+			} else {
+				self::distribute_post( $post );
+			}
 		}
-		self::$queued_post_updates = [];
+		self::$queued_distributions = [];
 	}
 
 	/**
@@ -170,7 +201,7 @@ class Content_Distribution {
 		) {
 			return;
 		}
-		self::$queued_post_updates[] = $object_id;
+		self::queue_post_distribution( $post->ID, 'post_meta' );
 	}
 
 	/**
@@ -191,7 +222,7 @@ class Content_Distribution {
 		if ( ! self::is_post_distributed( $post ) ) {
 			return;
 		}
-		self::$queued_post_updates[] = $post->ID;
+		self::queue_post_distribution( $post->ID );
 	}
 
 	/**
@@ -386,6 +417,35 @@ class Content_Distribution {
 			}
 			Data_Events::dispatch( 'network_post_updated', $payload );
 			update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $payload_hash );
+		}
+	}
+
+	/**
+	 * Trigger a partial post distribution.
+	 *
+	 * @param WP_Post|Outgoing_Post|int $post           The post object or ID.
+	 * @param string[]                  $post_data_keys The post data key to update.
+	 *
+	 * @return void|WP_Error The error if the payload is invalid.
+	 */
+	public static function distribute_post_partial( $post, $post_data_keys ) {
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return;
+		}
+		if ( is_string( $post_data_keys ) ) {
+			$post_data_keys = [ $post_data_keys ];
+		}
+		if ( $post instanceof Outgoing_Post ) {
+			$distributed_post = $post;
+		} else {
+			$distributed_post = self::get_distributed_post( $post );
+		}
+		if ( $distributed_post ) {
+			$payload = $distributed_post->get_partial_payload( $post_data_keys );
+			if ( is_wp_error( $payload ) ) {
+				return $payload;
+			}
+			Data_Events::dispatch( 'network_post_updated', $payload );
 		}
 	}
 }

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -197,7 +197,7 @@ class Incoming_Post {
 		$current_payload       = $this->get_post_payload();
 		$current_payload_error = self::get_payload_error( $current_payload );
 		if ( is_wp_error( $current_payload_error ) ) {
-			return $current_payload_error->get_error_message();
+			return $current_payload_error;
 		}
 
 		$payload['post_data'] = array_merge( $current_payload['post_data'], $payload['post_data'] );

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -229,6 +229,43 @@ class Outgoing_Post {
 	}
 
 	/**
+	 * Get a partial payload for distribution.
+	 *
+	 * @param string[] $post_data_keys Keys in the post_data array to include in
+	 *                                 the partial payload.
+	 *
+	 * @return array|WP_Error The partial payload or WP_Error if any of the keys were not found.
+	 */
+	public function get_partial_payload( $post_data_keys ) {
+		if ( is_string( $post_data_keys ) ) {
+			$post_data_keys = [ $post_data_keys ];
+		}
+
+		$payload = $this->get_payload();
+		foreach ( $post_data_keys as $post_data_key ) {
+			if ( ! isset( $payload['post_data'][ $post_data_key ] ) ) {
+				return new WP_Error( 'key_not_found', __( 'Key not found in payload.', 'newspack-network' ) );
+			}
+		}
+
+		// Mark the payload as partial.
+		$payload['partial'] = true;
+
+		$post_data = [];
+		foreach ( $post_data_keys as $post_data_key ) {
+			$post_data[ $post_data_key ] = $payload['post_data'][ $post_data_key ];
+		}
+
+		// Always add the date and modified date to the partial payload.
+		$post_data['date_gmt']     = $payload['post_data']['date_gmt'];
+		$post_data['modified_gmt'] = $payload['post_data']['modified_gmt'];
+
+		$payload['post_data'] = $post_data;
+
+		return $payload;
+	}
+
+	/**
 	 * Get the processed post content for distribution.
 	 *
 	 * @return string The post content.

--- a/tests/unit-tests/content-distribution/test-content-distribution.php
+++ b/tests/unit-tests/content-distribution/test-content-distribution.php
@@ -81,12 +81,12 @@ class TestContentDistribution extends \WP_UnitTestCase {
 		// Queue full post for distribution.
 		Content_Distribution_Class::queue_post_distribution( $post_id );
 		$queue = Content_Distribution_Class::get_queued_distributions();
-		$this->assertArrayHasKey( $post_id, $queue );
+		// Assert that the post is queued for full distribution (= true).
 		$this->assertTrue( $queue[ $post_id ] );
 
 		// Queue another attribute for distribution.
-		$queue = Content_Distribution_Class::get_queued_distributions( $post_id, 'taxonomy' );
-		$this->assertArrayHasKey( $post_id, $queue );
+		Content_Distribution_Class::queue_post_distribution( $post_id, 'post_meta' );
+		$queue = Content_Distribution_Class::get_queued_distributions();
 		// Assert that the post is still queued for full distribution.
 		$this->assertTrue( $queue[ $post_id ] );
 	}

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -483,14 +483,13 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test partial post payload update.
+	 * Test partial post payload on insert.
 	 */
 	public function test_partial_payload_insert() {
-		$payload = $this->get_sample_payload();
+		$post_id = $this->incoming_post->insert();
 
-		$post_id = $this->incoming_post->insert( $payload );
-
-		// Update the post payload with a partial update.
+		// Make the payload a partial.
+		$payload              = $this->get_sample_payload();
 		$payload['partial']   = true;
 		$payload['post_data'] = [
 			'title'        => 'Updated Title',
@@ -506,9 +505,9 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test partial post pyload update on instantiating.
+	 * Test partial post payload on instantiation.
 	 */
-	public function test_partial_payload_instantiating() {
+	public function test_partial_payload_instantiation() {
 		$post_id = $this->incoming_post->insert();
 
 		// Make the payload a partial.

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -509,11 +509,10 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	 * Test partial post pyload update on instantiating.
 	 */
 	public function test_partial_payload_instantiating() {
-		$payload = $this->get_sample_payload();
-
-		$this->incoming_post->insert( $payload );
+		$this->incoming_post->insert();
 
 		// Make the payload a partial.
+		$payload              = $this->get_sample_payload();
 		$payload['partial']   = true;
 		$payload['post_data'] = [
 			'title'        => 'Updated Title',

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -509,7 +509,7 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	 * Test partial post pyload update on instantiating.
 	 */
 	public function test_partial_payload_instantiating() {
-		$this->incoming_post->insert();
+		$post_id = $this->incoming_post->insert();
 
 		// Make the payload a partial.
 		$payload              = $this->get_sample_payload();

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -481,4 +481,51 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		$this->incoming_post->insert( $payload );
 		$this->assertSame( 'draft', get_post_status( $post_id ) );
 	}
+
+	/**
+	 * Test partial post payload update.
+	 */
+	public function test_partial_payload_insert() {
+		$payload = $this->get_sample_payload();
+
+		$post_id = $this->incoming_post->insert( $payload );
+
+		// Update the post payload with a partial update.
+		$payload['partial']   = true;
+		$payload['post_data'] = [
+			'title'        => 'Updated Title',
+			'date_gmt'     => $payload['post_data']['date_gmt'],
+			'modified_gmt' => $payload['post_data']['modified_gmt'],
+		];
+
+		$this->incoming_post->insert( $payload );
+
+		// Assert that the post title was updated and the content was not.
+		$this->assertSame( 'Updated Title', get_the_title( $post_id ) );
+		$this->assertSame( 'Content', get_post_field( 'post_content', $post_id ) );
+	}
+
+	/**
+	 * Test partial post pyload update on instantiating.
+	 */
+	public function test_partial_payload_instantiating() {
+		$payload = $this->get_sample_payload();
+
+		$this->incoming_post->insert( $payload );
+
+		// Make the payload a partial.
+		$payload['partial']   = true;
+		$payload['post_data'] = [
+			'title'        => 'Updated Title',
+			'date_gmt'     => $payload['post_data']['date_gmt'],
+			'modified_gmt' => $payload['post_data']['modified_gmt'],
+		];
+
+		$incoming_post = new Incoming_Post( $payload );
+		$incoming_post->insert();
+
+		// Assert that the post title was updated and the content was not.
+		$this->assertSame( 'Updated Title', get_the_title( $post_id ) );
+		$this->assertSame( 'Content', get_post_field( 'post_content', $post_id ) );
+	}
 }

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -526,4 +526,24 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		$this->assertSame( 'Updated Title', get_the_title( $post_id ) );
 		$this->assertSame( 'Content', get_post_field( 'post_content', $post_id ) );
 	}
+
+	/**
+	 * Test partial payload on missing post.
+	 */
+	public function test_partial_payload_missing_post() {
+		$payload = $this->get_sample_payload();
+
+		// Make the payload a partial.
+		$payload['partial']   = true;
+		$payload['post_data'] = [
+			'title'        => 'Updated Title',
+			'date_gmt'     => $payload['post_data']['date_gmt'],
+			'modified_gmt' => $payload['post_data']['modified_gmt'],
+		];
+
+		// Assert that instantiating a partial payload will throw an exception.
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Partial payload requires an existing post.' );
+		new Incoming_Post( $payload );
+	}
 }

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -197,4 +197,16 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		$payload = $this->outgoing_post->get_payload();
 		$this->assertTrue( empty( $payload['post_data']['taxonomy'][ $taxonomy ] ) );
 	}
+
+	/**
+	 * Test get partial payload.
+	 */
+	public function test_get_partial_payload() {
+		$partial_payload = $this->outgoing_post->get_partial_payload( 'post_meta' );
+
+		$this->assertArrayHasKey( 'post_meta', $partial_payload['post_data'] );
+		$this->assertArrayHasKey( 'date_gmt', $partial_payload['post_data'] );
+		$this->assertArrayHasKey( 'modified_gmt', $partial_payload['post_data'] );
+		$this->assertArrayNotHasKey( 'title', $partial_payload['post_data'] );
+	}
 }

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -205,7 +205,7 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		$partial_payload = $this->outgoing_post->get_partial_payload( 'post_meta' );
 
 		$payload = $this->outgoing_post->get_payload();
-		$this->assertTrue( $payload['partial'] );
+		$this->assertTrue( $partial_payload['partial'] );
 		$this->assertSame( $payload['network_post_id'], $partial_payload['network_post_id'] );
 		$this->assertSame( $payload['post_data']['post_meta'], $partial_payload['post_data']['post_meta'] );
 		$this->assertSame( $payload['post_data']['date_gmt'], $partial_payload['post_data']['date_gmt'] );
@@ -222,7 +222,7 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		$partial_payload = $this->outgoing_post->get_partial_payload( [ 'post_meta', 'taxonomy' ] );
 
 		$payload = $this->outgoing_post->get_payload();
-		$this->assertTrue( $payload['partial'] );
+		$this->assertTrue( $partial_payload['partial'] );
 		$this->assertSame( $payload['network_post_id'], $partial_payload['network_post_id'] );
 		$this->assertSame( $payload['post_data']['post_meta'], $partial_payload['post_data']['post_meta'] );
 		$this->assertSame( $payload['post_data']['taxonomy'], $partial_payload['post_data']['taxonomy'] );

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -204,9 +204,29 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 	public function test_get_partial_payload() {
 		$partial_payload = $this->outgoing_post->get_partial_payload( 'post_meta' );
 
-		$this->assertArrayHasKey( 'post_meta', $partial_payload['post_data'] );
-		$this->assertArrayHasKey( 'date_gmt', $partial_payload['post_data'] );
-		$this->assertArrayHasKey( 'modified_gmt', $partial_payload['post_data'] );
+		$payload = $this->outgoing_post->get_payload();
+		$this->assertSame( $payload['network_post_id'], $partial_payload['network_post_id'] );
+		$this->assertSame( $payload['post_data']['post_meta'], $partial_payload['post_data']['post_meta'] );
+		$this->assertSame( $payload['post_data']['date_gmt'], $partial_payload['post_data']['date_gmt'] );
+		$this->assertSame( $payload['post_data']['modified_gmt'], $partial_payload['post_data']['modified_gmt'] );
 		$this->assertArrayNotHasKey( 'title', $partial_payload['post_data'] );
+		$this->assertArrayNotHasKey( 'content', $partial_payload['post_data'] );
+		$this->assertArrayNotHasKey( 'taxonomy', $partial_payload['post_data'] );
+	}
+
+	/**
+	 * Test get partial payload multiple keys.
+	 */
+	public function test_get_partial_payload_multiple_keys() {
+		$partial_payload = $this->outgoing_post->get_partial_payload( [ 'post_meta', 'taxonomy' ] );
+
+		$payload = $this->outgoing_post->get_payload();
+		$this->assertSame( $payload['network_post_id'], $partial_payload['network_post_id'] );
+		$this->assertSame( $payload['post_data']['post_meta'], $partial_payload['post_data']['post_meta'] );
+		$this->assertSame( $payload['post_data']['taxonomy'], $partial_payload['post_data']['taxonomy'] );
+		$this->assertSame( $payload['post_data']['date_gmt'], $partial_payload['post_data']['date_gmt'] );
+		$this->assertSame( $payload['post_data']['modified_gmt'], $partial_payload['post_data']['modified_gmt'] );
+		$this->assertArrayNotHasKey( 'title', $partial_payload['post_data'] );
+		$this->assertArrayNotHasKey( 'content', $partial_payload['post_data'] );
 	}
 }

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -205,6 +205,7 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		$partial_payload = $this->outgoing_post->get_partial_payload( 'post_meta' );
 
 		$payload = $this->outgoing_post->get_payload();
+		$this->assertTrue( $payload['partial'] );
 		$this->assertSame( $payload['network_post_id'], $partial_payload['network_post_id'] );
 		$this->assertSame( $payload['post_data']['post_meta'], $partial_payload['post_data']['post_meta'] );
 		$this->assertSame( $payload['post_data']['date_gmt'], $partial_payload['post_data']['date_gmt'] );
@@ -221,6 +222,7 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 		$partial_payload = $this->outgoing_post->get_partial_payload( [ 'post_meta', 'taxonomy' ] );
 
 		$payload = $this->outgoing_post->get_payload();
+		$this->assertTrue( $payload['partial'] );
 		$this->assertSame( $payload['network_post_id'], $partial_payload['network_post_id'] );
 		$this->assertSame( $payload['post_data']['post_meta'], $partial_payload['post_data']['post_meta'] );
 		$this->assertSame( $payload['post_data']['taxonomy'], $partial_payload['post_data']['taxonomy'] );


### PR DESCRIPTION
Implements support for distribution of partial payloads, given a list of post data keys to include in the payload.

The `Content_Distribution::distribute_post_partial( $post, $post_data_keys )` can be called directly to trigger a partial update, but it should be most commonly used in the context of `distribute_queued_posts()`, which will decide on PHP shutdown whether to execute a partial or full distribution of a given post, based on the contents of the `$queued_distributions` var, populated via the `queue_post_distribution( $post_id, $post_data_key );` method.

E.g., if a post is saved and a post meta is updated in the same execution, the following will be called:

```
Content_Distribution::queue_post_distribution( <post_id> ); // via wp_after_insert_post hook
Content_Distribution::queue_post_distribution( <post_id>, 'post_meta' ); // via updated_post_meta hook
```

The above will trigger a single full post update on shutdown.

If only a post meta is updated on the execution:

```
Content_Distribution::queue_post_distribution( <post_id>, 'post_meta' ); // via updated_post_meta hook
```

A single partial update will run on shutdown.

This PR also improves the post meta coverage by hooking into `added_post_meta` and `deleted_post_meta`.

### Testing

1. Distribute a post to a node
2. Update a post meta via CLI `wp post meta update {post_id} test_meta test_value`
3. Confirm in the hub's event log that the payload's post data only includes `post_meta`, `date_gmt`, and `modified_gmt`
4. Delete the post meta via CLI `wp post meta delete {post_id} test_meta`
5. Confirm in the hub's event log table that the payload includes the `post_meta` and `test_meta` is not there
6. In the dashboard, edit the post and save
7. Confirm in the hub's event log that the full payload is sent