### PR TITLE
fix(event-log): data css overflow

### DIFF
--- a/includes/hub/admin/css/event-log.css
+++ b/includes/hub/admin/css/event-log.css
@@ -17,6 +17,7 @@
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
   color: rgba(44, 51, 56, 0.8);
   border-radius: 4px;
+  overflow: auto;
 }
 .newspack-network-data-column pre code {
   font-size: 11px;


### PR DESCRIPTION
Fixes element overflow when displaying data with < 300 of length on the event log table:

| Before | After |
| --- | --- |
| <img width="623" alt="image" src="https://github.com/user-attachments/assets/4e3f6e66-4215-4fe7-83df-f8c877dcdc92" /> | <img width="646" alt="image" src="https://github.com/user-attachments/assets/7bbdf113-a838-4209-93c4-401514317e72" /> |
