### PR TITLE
fix(content-distribution): use payload hash on partial updates

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -313,6 +313,8 @@ class Content_Distribution {
 			'_edit_last',
 			'_thumbnail_id',
 			'_yoast_wpseo_primary_category',
+			'_pingme',
+			'_encloseme',
 		];
 
 		/**
@@ -423,10 +425,12 @@ class Content_Distribution {
 			$payload      = $distributed_post->get_payload( $status_on_create );
 			$payload_hash = $distributed_post->get_payload_hash( $payload );
 			$post         = $distributed_post->get_post();
+			// Skip if the payload hash is the same.
 			if ( get_post_meta( $post->ID, self::PAYLOAD_HASH_META, true ) === $payload_hash ) {
 				return;
 			}
 			Data_Events::dispatch( 'network_post_updated', $payload );
+			// Store payload hash to prevent unnecessary updates.
 			update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $payload_hash );
 		}
 	}
@@ -452,11 +456,19 @@ class Content_Distribution {
 			$distributed_post = self::get_distributed_post( $post );
 		}
 		if ( $distributed_post ) {
+			$payload_hash = $distributed_post->get_payload_hash();
+			$post         = $distributed_post->get_post();
+			// Skip if the payload hash is the same.
+			if ( get_post_meta( $post->ID, self::PAYLOAD_HASH_META, true ) === $payload_hash ) {
+				return;
+			}
 			$payload = $distributed_post->get_partial_payload( $post_data_keys );
 			if ( is_wp_error( $payload ) ) {
 				return $payload;
 			}
 			Data_Events::dispatch( 'network_post_updated', $payload );
+			// Store payload hash to prevent unnecessary updates.
+			update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $payload_hash );
 		}
 	}
 }


### PR DESCRIPTION
When partial updates were implemented (#205) it didn't integrate with the payload hash strategy (#198), so every partial update is dispatched even if it's already the most recent distributed data.

This PR implements the payload hash check to partial updates.

It also adds the `_pingme` and `_encloseme` meta to the list of ignored meta keys. These 2 keys are WP internals to manage pings and enclosures via wp-cron and should not be part of the payload.

### Testing

1. On a distributed post, make a content change and save and confirm only 1 dispatch is logged in the hub
2. Make a CAP author change and save and also confirm only 1 dispatch is logged
3. Make a content change, a CAP author change, save, and confirm 2 dispatches are logged
4. Without making any changes, hit Save, and confirm nothing gets dispatched