### PR TITLE
feat: increase pull frequency and amount

### DIFF
--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -51,7 +51,7 @@ class Pull_Endpoint {
 	 * @return int
 	 */
 	public static function get_pull_limit() {
-		return defined( 'NEWSPACK_NETWORK_EVENTS_PULL_LIMIT' ) && is_numeric( NEWSPACK_NETWORK_EVENTS_PULL_LIMIT ) ? NEWSPACK_NETWORK_EVENTS_PULL_LIMIT : 20;
+		return defined( 'NEWSPACK_NETWORK_EVENTS_PULL_LIMIT' ) && is_numeric( NEWSPACK_NETWORK_EVENTS_PULL_LIMIT ) ? NEWSPACK_NETWORK_EVENTS_PULL_LIMIT : 40;
 	}
 
 	/**

--- a/includes/node/class-pulling.php
+++ b/includes/node/class-pulling.php
@@ -21,7 +21,7 @@ class Pulling {
 	 *
 	 * @var int
 	 */
-	const PULL_INTERVAL = 60 * 5; // 5 minutes
+	const PULL_INTERVAL = 60 * 2; // 2 minutes
 
 	/**
 	 * The option name that stores the ID of the last processed event.


### PR DESCRIPTION
This PR increases the number of events fetched per pull from 20 to 40 and reduces the pull interval from 5 to 2 minutes.

### Testing

1. In a node, register a new reader and donate
2. Confirm the events are propagated to other nodes in less than 3 minutes (webhook propagation + pull interval)