### PR TITLE
chore(content-distribution): log distribution elapsed time

### DIFF
--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -57,10 +57,15 @@ class Network_Post_Updated extends Abstract_Incoming_Event {
 			);
 			Debugger::log( $message );
 			if ( method_exists( 'Newspack\Logger', 'newspack_log' ) ) {
+				$payload_info = $payload;
+				unset( $payload_info['post_data'] );
 				\Newspack\Logger::newspack_log(
 					'newspack_network_post_updated',
 					$message,
-					$payload,
+					[
+						'payload_info' => $payload_info,
+						'elapsed_time' => $elapsed_time,
+					],
 					'debug'
 				);
 			}

--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -46,6 +46,24 @@ class Network_Post_Updated extends Abstract_Incoming_Event {
 			return;
 		}
 		$incoming_post = new Incoming_Post( $payload );
-		$incoming_post->insert();
+		$post_id = $incoming_post->insert();
+
+		if ( ! is_wp_error( $post_id ) ) {
+			$elapsed_time = time() - $this->get_timestamp();
+			$message      = sprintf(
+				'Post %d updated %d seconds after distribution',
+				$post_id,
+				$elapsed_time
+			);
+			Debugger::log( $message );
+			if ( method_exists( 'Newspack\Logger', 'newspack_log' ) ) {
+				\Newspack\Logger::newspack_log(
+					'newspack_network_post_updated',
+					$message,
+					$payload,
+					'debug'
+				);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Implement logging the time between the distribution dispatch and the post being updated in the destination.

### Testing

1. Make sure you have `NEWSPACK_NETWORK_DEBUG` set to true
2. Distribute a post and wait for it to arrive at the destination
3. Check the destination logs and confirm you have the following entry: `Post <post id> updated <elapsed time> seconds after distribution`
4. If your destination is connected to logstash, locate the entry filtering by the `error_code`: `newspack_network_post_updated` 