### PR TITLE
fix(content-distribution): link to post on incoming

### DIFF
--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -109,7 +109,7 @@ class Editor {
 			'newspack-network-incoming-post',
 			'newspack_network_incoming_post',
 			[
-				'originalUrl' => $incoming->get_original_site_url(),
+				'originalUrl' => $incoming->get_original_post_url(),
 				'unlinked'    => ! $incoming->is_linked(),
 			]
 		);

--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -109,7 +109,8 @@ class Editor {
 			'newspack-network-incoming-post',
 			'newspack_network_incoming_post',
 			[
-				'originalUrl' => $incoming->get_original_post_url(),
+				'originalSiteUrl' => $incoming->get_original_site_url(),
+				'originalPostUrl' => $incoming->get_original_post_url(),
 				'unlinked'    => ! $incoming->is_linked(),
 			]
 		);

--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -111,7 +111,7 @@ class Editor {
 			[
 				'originalSiteUrl' => $incoming->get_original_site_url(),
 				'originalPostUrl' => $incoming->get_original_post_url(),
-				'unlinked'    => ! $incoming->is_linked(),
+				'unlinked'        => ! $incoming->is_linked(),
 			]
 		);
 	}

--- a/src/content-distribution/incoming-post/index.js
+++ b/src/content-distribution/incoming-post/index.js
@@ -17,7 +17,8 @@ import { registerPlugin } from '@wordpress/plugins';
 import './style.scss';
 import ContentDistributionPanel from "../content-distribution-panel";
 
-const originalUrl = newspack_network_incoming_post.originalUrl;
+const originalSiteUrl = newspack_network_incoming_post.originalSiteUrl;
+const originalPostUrl = newspack_network_incoming_post.originalPostUrl;
 const unlinked = newspack_network_incoming_post.unlinked;
 
 function IncomingPost() {
@@ -60,8 +61,8 @@ function IncomingPost() {
 		createNotice(
 			'warning',
 			isUnLinked
-				? sprintf( __( 'Originally distributed from %s.', 'newspack-network' ), originalUrl )
-				: sprintf( __( 'Distributed from %s.', 'newspack-network' ), originalUrl ),
+				? sprintf( __( 'Originally distributed from %s.', 'newspack-network' ), originalSiteUrl )
+				: sprintf( __( 'Distributed from %s.', 'newspack-network' ), originalSiteUrl ),
 
 			{
 				id: 'newspack-network-incoming-post-notice',
@@ -140,7 +141,7 @@ function IncomingPost() {
 						<Button
 							variant="secondary"
 							target="_blank"
-							href={ originalUrl }
+							href={ originalPostUrl }
 						>
 							{ __( 'View origin post', 'newspack-network' ) }
 						</Button>


### PR DESCRIPTION
Small fix: the "View origin post" on incoming posts was linking to the original site, not post.

See pamTN9-aEn-p2#comment-13129

## How to test
- On an incoming post, click the button and verify that you are taken to the post and not the homepage