### PR TITLE
fix(content-distribution): sync non-publish posts

### DIFF
--- a/includes/content-distribution/class-api.php
+++ b/includes/content-distribution/class-api.php
@@ -118,6 +118,15 @@ class API {
 			return new WP_Error( 'newspack_network_content_distribution_error', $e->getMessage(), [ 'status' => 400 ] );
 		}
 
+		$current_distribution = $outgoing_post->get_distribution();
+
+		$new_urls = array_diff( $urls, $current_distribution );
+
+		// If distributing to new destinations, the post must be published.
+		if ( ! empty( $new_urls ) && 'publish' !== get_post_status( $post_id ) ) {
+			return new WP_Error( 'newspack_network_content_distribution_error', __( 'Post must be published to distribute.', 'newspack-network' ), [ 'status' => 400 ] );
+		}
+
 		$distribution = $outgoing_post->set_distribution( $urls );
 
 		if ( is_wp_error( $distribution ) ) {

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -42,10 +42,6 @@ class Outgoing_Post {
 			throw new \InvalidArgumentException( esc_html( __( 'Invalid post.', 'newspack-network' ) ) );
 		}
 
-		if ( 'publish' !== $post->post_status ) {
-			throw new \InvalidArgumentException( esc_html( __( 'Only published post are allowed to be distributed.', 'newspack-network' ) ) );
-		}
-
 		if ( ! in_array( $post->post_type, Content_Distribution_Class::get_distributed_post_types() ) ) {
 			/* translators: unsupported post type for content distribution */
 			throw new \InvalidArgumentException( esc_html( sprintf( __( 'Post type %s is not supported as a distributed outgoing post.', 'newspack-network' ), $post->post_type ) ) );

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -94,17 +94,6 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test non-published post.
-	 */
-	public function test_non_published_post() {
-		$post = $this->factory->post->create_and_get( [ 'post_type' => 'post', 'post_status' => 'draft' ] ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
-		// Assert the instantiating an Outgoing_Post throws an exception.
-		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'Only published post are allowed to be distributed.' );
-		new Outgoing_Post( $post );
-	}
-
-	/**
 	 * Test get post distribution.
 	 */
 	public function test_get_distribution() {


### PR DESCRIPTION
1208510338230630-as-1209335539861544

The logic to prevent distributing a post when it's not published is at the instantiation level for the Outgoing_Post object, which creates issues when an already published and distributed post moves to draft. We need to be able to instantiate the object, since it has already been distributed.

This causes issues when attempting to sync a distributed post when it moves to non-publish statuses.

This PR removes that restriction from the constructor and applies to the distribution API callback.

### Testing

1. While on trunk, distribute a post with status on create set to `publish`
2. Move the post to draft and confirm that the change does not propagate
3. Checkout this branch, repeat steps 1 and 2 and confirm the status changes are synced