### PR TITLE
fix(content-distribution): change link to edit origin post

### DIFF
--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -109,9 +109,9 @@ class Editor {
 			'newspack-network-incoming-post',
 			'newspack_network_incoming_post',
 			[
-				'originalSiteUrl' => $incoming->get_original_site_url(),
-				'originalPostUrl' => $incoming->get_original_post_url(),
-				'unlinked'        => ! $incoming->is_linked(),
+				'originalSiteUrl'     => $incoming->get_original_site_url(),
+				'originalPostEditUrl' => $incoming->get_original_post_edit_url(),
+				'unlinked'            => ! $incoming->is_linked(),
 			]
 		);
 	}

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -279,6 +279,18 @@ class Incoming_Post {
 	}
 
 	/**
+	 * Get the original post edit URL.
+	 *
+	 * @return string The post original edit URL. Empty string if not found.
+	 */
+	public function get_original_post_edit_url() {
+		if ( empty( $this->payload['site_url'] ) ) {
+			return '';
+		}
+		return sprintf( '%s/wp-admin/post.php?post=%d&action=edit', $this->payload['site_url'], $this->payload['post_id'] );
+	}
+
+	/**
 	 * Find the post from the payload's network post ID.
 	 *
 	 * @return WP_Post|null The post or null if not found.

--- a/src/content-distribution/incoming-post/index.js
+++ b/src/content-distribution/incoming-post/index.js
@@ -18,7 +18,7 @@ import './style.scss';
 import ContentDistributionPanel from "../content-distribution-panel";
 
 const originalSiteUrl = newspack_network_incoming_post.originalSiteUrl;
-const originalPostUrl = newspack_network_incoming_post.originalPostUrl;
+const originalPostEditUrl = newspack_network_incoming_post.originalPostEditUrl;
 const unlinked = newspack_network_incoming_post.unlinked;
 
 function IncomingPost() {
@@ -141,9 +141,9 @@ function IncomingPost() {
 						<Button
 							variant="secondary"
 							target="_blank"
-							href={ originalPostUrl }
+							href={ originalPostEditUrl }
 						>
-							{ __( 'View origin post', 'newspack-network' ) }
+							{ __( 'Edit origin post', 'newspack-network' ) }
 						</Button>
 						<Button
 							variant={ isUnLinked ? 'primary' : 'secondary' }

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -210,6 +210,17 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get original post edit URL.
+	 */
+	public function test_get_original_post_edit_url() {
+		$this->incoming_post->insert();
+		$this->assertSame(
+			'https://node1.test/wp-admin/post.php?post=1&action=edit',
+			$this->incoming_post->get_original_post_edit_url()
+		);
+	}
+
+	/**
 	 * Test relink post.
 	 */
 	public function test_relink_post() {


### PR DESCRIPTION
When opening a linked post in the editor, you should now see a link to edit the origin post, instead of viewing:

<img width="287" alt="image" src="https://github.com/user-attachments/assets/1b82e6b2-1d7c-4c70-acac-c1cbd9132500" />

### Testing

1. Distribute a post
2. Edit in the destination site
3. Confirm the button now renders a button to "Edit origin post" and links correctly to the editor in the origin site