### PR TITLE
feat(content-distribution): default distribution status

### DIFF
--- a/includes/content-distribution/class-admin.php
+++ b/includes/content-distribution/class-admin.php
@@ -44,6 +44,11 @@ class Admin {
 	const CAPABILITY_ROLES_OPTION_NAME = 'newspack_distribute_capability_roles';
 
 	/**
+	 * The default distribution status option name
+	 */
+	const DEFAULT_DISTRIBUTION_STATUS_OPTION_NAME = 'newspack_default_distribution_status';
+
+	/**
 	 * Initialize this class and register hooks
 	 *
 	 * @return void
@@ -132,6 +137,12 @@ class Admin {
 			'callback' => [ __CLASS__, 'capability_roles_callback' ],
 		];
 
+		$settings[] = [
+			'key'      => self::DEFAULT_DISTRIBUTION_STATUS_OPTION_NAME,
+			'label'    => esc_html__( 'Default Distribution Post Status', 'newspack-network' ),
+			'callback' => [ __CLASS__, 'default_distribution_status_callback' ],
+		];
+
 		foreach ( $settings as $setting ) {
 			add_settings_field(
 				$setting['key'],
@@ -211,6 +222,51 @@ class Admin {
 			'<br/><small>%1$s</small>',
 			esc_html__( 'Select the roles of users on this site that will be allowed to distribute content to sites in the network.', 'newspack-network' )
 		);
+	}
+
+	/**
+	 * The default distribution status setting callback
+	 *
+	 * @return void
+	 */
+	public static function default_distribution_status_callback() {
+		$current = self::get_default_distribution_status();
+
+		$statuses = [
+			'publish' => __( 'Publish', 'newspack-network' ),
+			'pending' => __( 'Pending Review', 'newspack-network' ),
+			'draft'   => __( 'Draft', 'newspack-network' ),
+		];
+
+		foreach ( $statuses as $status => $label ) {
+			$checked = '';
+			if ( $status === $current ) {
+				$checked = 'checked';
+			}
+
+			printf(
+				'<p><input type="radio" name="%1$s" value="%2$s" id="distribution-status-%2$s" %3$s> <label for="distribution-status-%2$s">%4$s</label></p>',
+				esc_attr( self::DEFAULT_DISTRIBUTION_STATUS_OPTION_NAME ),
+				esc_attr( $status ),
+				esc_attr( $checked ),
+				esc_html( $label )
+			);
+		}
+
+		printf(
+			'<br/><small>%1$s</small><br/><small>%2$s</small>',
+			esc_html__( 'Select the default status for posts distributed to other sites in the network.', 'newspack-network' ),
+			esc_html__( 'Note: Editors will still be able to modify the status upon distribution of a post.', 'newspack-network' )
+		);
+	}
+
+	/**
+	 * Get the default distribution status.
+	 *
+	 * @return string
+	 */
+	public static function get_default_distribution_status() {
+		return get_option( self::DEFAULT_DISTRIBUTION_STATUS_OPTION_NAME, 'draft' );
 	}
 
 	/**

--- a/includes/content-distribution/class-admin.php
+++ b/includes/content-distribution/class-admin.php
@@ -103,6 +103,7 @@ class Admin {
 		$allowed_options[ self::SETTINGS_SECTION ] = [
 			self::CANONICAL_NODE_OPTION_NAME,
 			self::CAPABILITY_ROLES_OPTION_NAME,
+			self::DEFAULT_DISTRIBUTION_STATUS_OPTION_NAME,
 		];
 		return $allowed_options;
 	}
@@ -139,7 +140,7 @@ class Admin {
 
 		$settings[] = [
 			'key'      => self::DEFAULT_DISTRIBUTION_STATUS_OPTION_NAME,
-			'label'    => esc_html__( 'Default Distribution Post Status', 'newspack-network' ),
+			'label'    => esc_html__( 'Default Post Status for Distribution', 'newspack-network' ),
 			'callback' => [ __CLASS__, 'default_distribution_status_callback' ],
 		];
 
@@ -233,9 +234,9 @@ class Admin {
 		$current = self::get_default_distribution_status();
 
 		$statuses = [
-			'publish' => __( 'Publish', 'newspack-network' ),
-			'pending' => __( 'Pending Review', 'newspack-network' ),
 			'draft'   => __( 'Draft', 'newspack-network' ),
+			'pending' => __( 'Pending', 'newspack-network' ),
+			'publish' => __( 'Publish', 'newspack-network' ),
 		];
 
 		foreach ( $statuses as $status => $label ) {

--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -144,6 +144,7 @@ class Editor {
 			'newspack-network-outgoing-post',
 			'newspack_network_outgoing_post',
 			[
+				'default_status'   => Admin::get_default_distribution_status(),
 				'network_sites'    => Network::get_networked_urls(),
 				'distributed_meta' => Outgoing_Post::DISTRIBUTED_POST_META,
 				'post_type_label'  => get_post_type_labels( get_post_type_object( $post->post_type ) )->singular_name,

--- a/src/components/post-status.js
+++ b/src/components/post-status.js
@@ -10,7 +10,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
-import { drafts, published } from '../icons';
+import { drafts, published, pending } from '../icons';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ import PostPanelRow from './post-panel-row';
 
 const postStatusesInfo = {
 	draft: { label: __( 'Draft' ), icon: drafts },
+	pending: { label: __( 'Pending' ), icon: pending },
 	publish: { label: __( 'Published' ), icon: published },
 };
 
@@ -27,6 +28,11 @@ const STATUS_OPTIONS = [
 		label: __( 'Draft' ),
 		value: 'draft',
 		description: __( 'Not ready to publish.' ),
+	},
+	{
+		label: __( 'Pending' ),
+		value: 'pending',
+		description: __( 'Waiting for review before publishing.' ),
 	},
 	{
 		label: __( 'Published' ),

--- a/src/content-distribution/outgoing-post/index.js
+++ b/src/content-distribution/outgoing-post/index.js
@@ -17,6 +17,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import ContentDistributionPanel from '../content-distribution-panel';
 import PostStatus from '../../components/post-status';
 
+const defaultStatus = newspack_network_outgoing_post.default_status;
 const networkSites = newspack_network_outgoing_post.network_sites;
 const distributedMetaKey = newspack_network_outgoing_post.distributed_meta;
 const postTypeLabel = newspack_network_outgoing_post.post_type_label;
@@ -26,7 +27,7 @@ function OutgoingPost() {
 	const [ isDistributing, setIsDistributing ] = useState( false );
 	const [ distribution, setDistribution ] = useState( [] );
 	const [ siteSelection, setSiteSelection ] = useState( [] );
-	const [ statusOnCreate, setStatusOnCreate ] = useState( 'draft' );
+	const [ statusOnCreate, setStatusOnCreate ] = useState( defaultStatus );
 
 	const { postId, postStatus, savedUrls, hasChangedContent, isSavingPost, isCleanNewPost } = useSelect( select => {
 		const {

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -1,2 +1,3 @@
 export { default as drafts } from './drafts';
 export { default as published } from './published';
+export { default as pending } from './pending';

--- a/src/icons/pending.js
+++ b/src/icons/pending.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const pending = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M12 18.5a6.5 6.5 0 1 1 0-13 6.5 6.5 0 0 1 0 13ZM4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm8 4a4 4 0 0 1-4-4h4V8a4 4 0 0 1 0 8Z"
+		/>
+	</SVG>
+);
+
+export default pending;


### PR DESCRIPTION
Implement an option to set the default post status for distribution:

<img width="677" alt="image" src="https://github.com/user-attachments/assets/7fcfff5d-0971-4f1b-9502-e622975bcf68" />

Also adds support for "pending" to be one of the options.

### Testing

1. Draft a new post and open the Distribution panel
2. Confirm the default is `draft`
3. Navigate to Newspack Network -> Distribute
4. Confirm you see the new option as in the image above
5. Change to `pending`
6. Refresh the post editor and confirm the new default option is `pending`
7. Back to the option, change it to `publish`
8. Refresh the post editor and confirm it reflects the selected option