### PR TITLE
fix: build on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"lint:php": "./vendor/bin/phpcs .",
 		"format:php": "./vendor/bin/phpcbf .",
 		"lint:php:staged": "./vendor/bin/phpcs",
-		"release": "npm run semantic-release",
+		"release": "npm run build && npm run semantic-release",
 		"release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/newspack-network --exclude-from='./.distignore' && cd release && zip -r newspack-network.zip newspack-network"
 	},
 	"lint-staged": {


### PR DESCRIPTION
Because of content distribution, we just recently started using js assets in the plugin. Releases are missing the `dist/` directory because we're not building the assets on release. This PR fixes that.

See the CI job for reference: https://github.com/Automattic/newspack-scripts/blob/trunk/src/jobs/release.yml#L17