### PR TITLE
fix(content-distribution): handle incoming post object error

### DIFF
--- a/includes/incoming-events/class-network-post-deleted.php
+++ b/includes/incoming-events/class-network-post-deleted.php
@@ -45,7 +45,14 @@ class Network_Post_Deleted extends Abstract_Incoming_Event {
 			Debugger::log( 'Error processing network_post_deleted: ' . $error->get_error_message() );
 			return;
 		}
-		$incoming_post = new Incoming_Post( $payload );
+
+		try {
+			$incoming_post = new Incoming_Post( $payload );
+		} catch ( \Exception $e ) {
+			Debugger::log( 'Error processing network_post_deleted: ' . $e->getMessage() );
+			return;
+		}
+
 		$incoming_post->delete();
 	}
 }

--- a/includes/incoming-events/class-network-post-updated.php
+++ b/includes/incoming-events/class-network-post-updated.php
@@ -45,7 +45,14 @@ class Network_Post_Updated extends Abstract_Incoming_Event {
 			Debugger::log( 'Error processing network_post_updated: ' . $error->get_error_message() );
 			return;
 		}
-		$incoming_post = new Incoming_Post( $payload );
+
+		try {
+			$incoming_post = new Incoming_Post( $payload );
+		} catch ( \Exception $e ) {
+			Debugger::log( 'Error processing network_post_updated: ' . $e->getMessage() );
+			return;
+		}
+
 		$post_id = $incoming_post->insert();
 
 		if ( ! is_wp_error( $post_id ) ) {


### PR DESCRIPTION
An exception might get thrown when instantiating an incoming post and it should be handled when processing the incoming events.

### Testing

1. Make sure you have `define( 'NEWSPACK_NETWORK_DEBUG', true );` in your `wp-config.php`
2. While on `release`, distribute a post to a node
3. In the destination node, **permanently delete** (not just trash) the received post
4. In the origin site, dispatch a partial update by updating a post meta: `wp post meta update {post_id} test_meta test_value`
5. Confirm a fatal error is logged in the receiving node when processing the `network_post_updated` event
6. Checkout this branch and repeat step 4
7. Confirm the error is logged via the `Debugger` class