### PR TITLE
fix(content-distribution): ignore unchanged values when shortcircuiting meta

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -166,6 +166,12 @@ class Content_Distribution {
 			return $check;
 		}
 
+		// Ignore unchanged values.
+		$current_value = get_post_meta( $object_id, $meta_key, true );
+		if ( $current_value === $meta_value || ( empty( $current_value ) && empty( $meta_value ) ) ) {
+			return $check;
+		}
+
 		// Ensure the post type can be distributed.
 		$post_types = self::get_distributed_post_types();
 		if ( ! in_array( get_post_type( $object_id ), $post_types, true ) ) {
@@ -177,7 +183,6 @@ class Content_Distribution {
 		}
 
 		// Prevent removing existing distributions.
-		$current_value = get_post_meta( $object_id, $meta_key, true );
 		if ( ! empty( array_diff( empty( $current_value ) ? [] : $current_value, $meta_value ) ) ) {
 			return false;
 		}

--- a/tests/unit-tests/content-distribution/test-content-distribution.php
+++ b/tests/unit-tests/content-distribution/test-content-distribution.php
@@ -49,6 +49,10 @@ class TestContentDistribution extends \WP_UnitTestCase {
 	public function test_update_distributed_post_meta() {
 		$post_id = $this->factory->post->create();
 
+		// Assert that an empty value is allowed.
+		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [] );
+		$this->assertNotFalse( $result );
+
 		// Assert that you're not allowed to update the meta with a non-network site.
 		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [ 'http://non-network-site.com' ] );
 		$this->assertFalse( $result );

--- a/tests/unit-tests/content-distribution/test-content-distribution.php
+++ b/tests/unit-tests/content-distribution/test-content-distribution.php
@@ -68,6 +68,10 @@ class TestContentDistribution extends \WP_UnitTestCase {
 		// Assert that you can add a site to distribution.
 		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [ 'https://node.test', 'https://other-node.test' ] );
 		$this->assertNotFalse( $result );
+
+		// Assert that an empty value is not allowed if the post is distributed.
+		$result = update_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, [] );
+		$this->assertFalse( $result );
 	}
 
 	/**


### PR DESCRIPTION
Do not shortcircuit the distribution meta if it's unchanged or empty values. Gutenberg may send an empty array for `newspack_network_distributed_sites`, which will reach the shortcircuit strategy and prevent the entire post save.

### Testing

I can't consistently reproduce the editor sending that empty array. Double-checking the new test assertions should be enough.