### PR TITLE
fix(content-distribution): always distribute on API request

### DIFF
--- a/includes/content-distribution/class-api.php
+++ b/includes/content-distribution/class-api.php
@@ -142,7 +142,7 @@ class API {
 		Data_Events::dispatch( 'network_post_updated', $payload );
 
 		// Store payload hash to prevent unnecessary updates.
-		update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $outgoing_post->get_payload_hash( $payload ) );
+		update_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, $outgoing_post->get_payload_hash( $payload ) );
 
 		return rest_ensure_response( $distribution );
 	}

--- a/includes/content-distribution/class-api.php
+++ b/includes/content-distribution/class-api.php
@@ -7,6 +7,7 @@
 
 namespace Newspack_Network\Content_Distribution;
 
+use Newspack\Data_Events;
 use InvalidArgumentException;
 use Newspack_Network\Content_Distribution as Content_Distribution_Class;
 use WP_Error;
@@ -108,6 +109,10 @@ class API {
 	 * @return WP_REST_Response|WP_Error The REST response or error.
 	 */
 	public static function distribute( $request ) {
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return new WP_Error( 'newspack_network_content_distribution_error', __( 'Data Events class not found.', 'newspack-network' ), [ 'status' => 400 ] );
+		}
+
 		$post_id          = $request->get_param( 'post_id' );
 		$urls             = $request->get_param( 'urls' );
 		$status_on_create = $request->get_param( 'status_on_create' );
@@ -133,7 +138,11 @@ class API {
 			return new WP_Error( 'newspack_network_content_distribution_error', $distribution->get_error_message(), [ 'status' => 400 ] );
 		}
 
-		Content_Distribution_Class::distribute_post( $outgoing_post, $status_on_create );
+		$payload = $outgoing_post->get_payload( $status_on_create );
+		Data_Events::dispatch( 'network_post_updated', $payload );
+
+		// Store payload hash to prevent unnecessary updates.
+		update_post_meta( $post->ID, self::PAYLOAD_HASH_META, $outgoing_post->get_payload_hash( $payload ) );
 
 		return rest_ensure_response( $distribution );
 	}


### PR DESCRIPTION
The API endpoint used to set the distribution configuration and distribute a post currently uses the `distribute_post()` method. This method checks the payload hash to prevent an unnecessary update. This is not needed when using the API endpoint and risks not distributing a post in case a partial distribution reaches the server first. In this scenario, the partial distribution will:

1. [Set the payload hash](https://github.com/Automattic/newspack-network/blob/6a27fa3fb59e7a80cc95b25b739d96da1d9c3e7e/includes/class-content-distribution.php#L475-L476)
2. [Fail to reach the destination](https://github.com/Automattic/newspack-network/blob/6a27fa3fb59e7a80cc95b25b739d96da1d9c3e7e/includes/content-distribution/class-incoming-post.php#L246-L248), because the full distribution didn't happen yet
3. [Prevent `distribute_post()` to run](https://github.com/Automattic/newspack-network/blob/6a27fa3fb59e7a80cc95b25b739d96da1d9c3e7e/includes/class-content-distribution.php#L433-L436) until an update changes the hash

This PR replaces the method in the endpoint callback for a direct dispatch call.

### Testing

1. Publish a new post and distribute to a node
2. Confirm the post is created in the destination
3. Make changes and save
4. Confirm the changes also reach the destination