### PR TITLE
feat(content-distribution): remove distribution on incoming post deletion

### DIFF
--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -42,6 +42,7 @@ class Accepted_Actions {
 		'newspack_network_membership_plan_updated' => 'Membership_Plan_Updated',
 		'network_post_updated'                     => 'Network_Post_Updated',
 		'network_post_deleted'                     => 'Network_Post_Deleted',
+		'network_incoming_post_deleted'            => 'Network_Incoming_Post_Deleted',
 		'newspack_network_distributor_migrate_incoming_posts' => 'Distributor_Migrate_Incoming_Posts',
 	];
 
@@ -66,6 +67,7 @@ class Accepted_Actions {
 		'newspack_network_membership_plan_updated',
 		'network_post_updated',
 		'network_post_deleted',
+		'network_incoming_post_deleted',
 		'newspack_network_distributor_migrate_incoming_posts',
 	];
 }

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -55,7 +55,8 @@ class Content_Distribution {
 		add_action( 'updated_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'added_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'deleted_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
-		add_action( 'before_delete_post', [ __CLASS__, 'handle_post_deleted' ] );
+		add_action( 'before_delete_post', [ __CLASS__, 'handle_outgoing_post_deleted' ] );
+		add_action( 'before_delete_post', [ __CLASS__, 'handle_incoming_post_deleted' ] );
 		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'handle_incoming_post_inserted' ], 10, 3 );
 
 		Admin::init();
@@ -79,6 +80,7 @@ class Content_Distribution {
 		Data_Events::register_action( 'network_post_updated' );
 		Data_Events::register_action( 'network_post_deleted' );
 		Data_Events::register_action( 'network_incoming_post_inserted' );
+		Data_Events::register_action( 'network_incoming_post_deleted' );
 	}
 
 	/**
@@ -172,6 +174,10 @@ class Content_Distribution {
 			return $check;
 		}
 
+		if ( ! is_array( $meta_value ) ) {
+			return false;
+		}
+
 		// Ensure the post type can be distributed.
 		$post_types = self::get_distributed_post_types();
 		if ( ! in_array( get_post_type( $object_id ), $post_types, true ) ) {
@@ -182,9 +188,20 @@ class Content_Distribution {
 			return false;
 		}
 
-		// Prevent removing existing distributions.
-		if ( ! empty( array_diff( empty( $current_value ) ? [] : $current_value, $meta_value ) ) ) {
-			return false;
+		// Manage removing existing distributions.
+		$diff = array_diff( empty( $current_value ) ? [] : $current_value, $meta_value );
+		if ( ! empty( $diff ) ) {
+			if ( 1 < count( $diff ) ) {
+				return false;
+			}
+
+			// Ensure there's an intention to remove the distribution.
+			$removing = get_post_meta( $object_id, 'newspack_network_remove_distribution', true );
+			delete_post_meta( $object_id, 'newspack_network_remove_distribution' ); // Remove deletion meta after reading.
+
+			if ( ! $removing || $removing !== $diff[0] ) {
+				return false;
+			}
 		}
 
 		return $check;
@@ -248,7 +265,7 @@ class Content_Distribution {
 	 *
 	 * @return void
 	 */
-	public static function handle_post_deleted( $post_id ) {
+	public static function handle_outgoing_post_deleted( $post_id ) {
 		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
 			return;
 		}
@@ -285,6 +302,42 @@ class Content_Distribution {
 			],
 		];
 		Data_Events::dispatch( 'network_incoming_post_inserted', $data );
+	}
+
+	/**
+	 * Handle incoming post deletion.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return void
+	 */
+	public static function handle_incoming_post_deleted( $post_id ) {
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return;
+		}
+		if ( ! self::is_post_incoming( $post_id ) ) {
+			return;
+		}
+		$incoming_post = new Incoming_Post( $post_id );
+		$payload       = $incoming_post->get_post_payload();
+		if ( empty( $payload ) ) {
+			return;
+		}
+		$data = [
+			'network_post_id' => $payload['network_post_id'],
+			'outgoing'        => [
+				'site_url' => $payload['site_url'],
+				'post_id'  => $payload['post_id'],
+				'post_url' => $payload['post_url'],
+			],
+			'incoming'        => [
+				'site_url'  => get_bloginfo( 'url' ),
+				'post_id'   => $post_id,
+				'post_url'  => get_permalink( $post_id ),
+				'is_linked' => $incoming_post->is_linked(),
+			],
+		];
+		Data_Events::dispatch( 'network_incoming_post_deleted', $data );
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -189,7 +189,7 @@ class Content_Distribution {
 		}
 
 		// Manage removing existing distributions.
-		$diff = array_diff( empty( $current_value ) ? [] : $current_value, $meta_value );
+		$diff = array_values( array_diff( empty( $current_value ) ? [] : $current_value, $meta_value ) );
 		if ( ! empty( $diff ) ) {
 			if ( 1 < count( $diff ) ) {
 				return false;

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -227,7 +227,7 @@ class Incoming_Post {
 	 *
 	 * @return array The stored payload.
 	 */
-	protected function get_post_payload() {
+	public function get_post_payload() {
 		if ( ! $this->ID ) {
 			return [];
 		}

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -123,10 +123,6 @@ class Outgoing_Post {
 	 * @return true|WP_Error True on success, WP_Error on failure.
 	 */
 	public static function validate_distribution( $urls ) {
-		if ( empty( $urls ) ) {
-			return new WP_Error( 'no_site_urls', __( 'No site URLs provided.', 'newspack-network' ) );
-		}
-
 		if ( in_array( get_bloginfo( 'url' ), $urls, true ) ) {
 			return new WP_Error( 'no_own_site', __( 'Cannot distribute to own site.', 'newspack-network' ) );
 		}
@@ -154,6 +150,10 @@ class Outgoing_Post {
 	 * @return array|WP_Error Config array on success, WP_Error on failure.
 	 */
 	public function set_distribution( $site_urls ) {
+		if ( empty( $site_urls ) ) {
+			return new WP_Error( 'no_site_urls', __( 'No site URLs provided.', 'newspack-network' ) );
+		}
+
 		$error = self::validate_distribution( $site_urls );
 		if ( is_wp_error( $error ) ) {
 			return $error;
@@ -169,6 +169,38 @@ class Outgoing_Post {
 		$distribution = array_unique( array_merge( $distribution, $site_urls ) );
 
 		$updated = update_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, $distribution );
+
+		if ( ! $updated ) {
+			return new WP_Error( 'update_failed', __( 'Failed to update post distribution.', 'newspack-network' ) );
+		}
+
+		return $distribution;
+	}
+
+	/**
+	 * Remove a site URL from the distribution configuration for a given post.
+	 *
+	 * @param string $site_url The site URL to remove.
+	 *
+	 * @return array|WP_Error Config array on success, WP_Error on failure.
+	 */
+	public function remove_distribution( $site_url ) {
+		$distribution = get_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, true );
+		if ( ! is_array( $distribution ) ) {
+			$distribution = [];
+		}
+
+		$index = array_search( $site_url, $distribution, true );
+		if ( false === $index ) {
+			return new WP_Error( 'site_not_found', __( 'Site URL not found in post distribution.', 'newspack-network' ) );
+		}
+
+		unset( $distribution[ $index ] );
+
+		// Add a meta to allow bypassing the short circuit validation.
+		update_post_meta( $this->post->ID, 'newspack_network_remove_distribution', $site_url );
+
+		$updated = update_post_meta( $this->post->ID, self::DISTRIBUTED_POST_META, array_values( $distribution ) );
 
 		if ( ! $updated ) {
 			return new WP_Error( 'update_failed', __( 'Failed to update post distribution.', 'newspack-network' ) );

--- a/includes/incoming-events/class-network-incoming-post-deleted.php
+++ b/includes/incoming-events/class-network-incoming-post-deleted.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Newspack Network Content Distribution Incoming Post Delete.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Debugger;
+use Newspack_Network\Content_Distribution\Outgoing_Post;
+
+/**
+ * Class to handle the network incoming post delete.
+ */
+class Network_Incoming_Post_Deleted extends Abstract_Incoming_Event {
+	/**
+	 * Processes the event
+	 *
+	 * @return void
+	 */
+	public function post_process_in_hub() {
+		$this->process_incoming_post_deleted();
+	}
+
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		$this->process_incoming_post_deleted();
+	}
+
+	/**
+	 * Process incoming post deleted
+	 */
+	protected function process_incoming_post_deleted() {
+		$data = (array) $this->get_data();
+
+		// Bail if origin is not here.
+		if ( get_bloginfo( 'url' ) !== $data['outgoing']['site_url'] ) {
+			return;
+		}
+
+		Debugger::log( 'Processing network_incoming_post_deleted ' . wp_json_encode( $data ) );
+
+		try {
+			$outgoing_post = new Outgoing_Post( $data['outgoing']['post_id'] );
+		} catch ( \Exception $e ) {
+			Debugger::log( 'Error processing network_incoming_post_deleted: ' . $e->getMessage() );
+			return;
+		}
+
+		$result = $outgoing_post->remove_distribution( $data['incoming']['site_url'] );
+		if ( is_wp_error( $result ) ) {
+			Debugger::log( 'Error processing network_incoming_post_deleted: ' . $result->get_error_message() );
+		}
+	}
+}

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -94,6 +94,16 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test remove distribution.
+	 */
+	public function test_remove_distribution() {
+		$this->outgoing_post->set_distribution( [ $this->network[1]['url'] ] );
+		$result = $this->outgoing_post->remove_distribution( $this->network[1]['url'] );
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertFalse( in_array( $this->network[1]['url'], $this->outgoing_post->get_distribution(), true ) );
+	}
+
+	/**
 	 * Test get post distribution.
 	 */
 	public function test_get_distribution() {


### PR DESCRIPTION
Sends the linked post deletion to the distribution origin so it's removed from the post's distribution configuration. This prevents the post from getting recreated on updates, assuming that the intention of that deletion is to no longer distribute the post to that site.

Our short-circuit strategy prevents a distribution URL from getting removed on post meta updates. To preserve that layer of protection, a `newspack_network_remove_distribution` meta is being introduced for the `remove_distribution( $site_url )` method. This meta contains the URL that's getting intentionally removed to be checked against in the short-circuit callback.

### Testing

1. Distribute a post to a node
2. In the node, permanently delete the post
3. Wait for the `network_incoming_post_deleted` event to reach the origin site
4. Edit the post in the origin site and confirm it's no longer distributing to that node