### PR TITLE
feat(event-log): migrate `data` db column to `longtext`

### DIFF
--- a/includes/hub/database/class-event-log.php
+++ b/includes/hub/database/class-event-log.php
@@ -48,9 +48,9 @@ class Event_Log {
 	 */
 	protected static function maybe_update_db() {
 		$db_version = absint( get_option( self::get_current_option_name(), 0 ) );
+		update_option( self::get_current_option_name(), self::DB_VERSION );
 		if ( $db_version < self::DB_VERSION ) {
 			self::update_db();
-			update_option( self::get_current_option_name(), self::DB_VERSION );
 		}
 	}
 

--- a/includes/hub/database/class-event-log.php
+++ b/includes/hub/database/class-event-log.php
@@ -50,17 +50,19 @@ class Event_Log {
 		$db_version = absint( get_option( self::get_current_option_name(), 0 ) );
 		update_option( self::get_current_option_name(), self::DB_VERSION );
 		if ( $db_version < self::DB_VERSION ) {
-			self::create_db();
+			self::update_db();
 			update_option( self::get_current_option_name(), self::DB_VERSION );
 		}
 	}
 
 	/**
-	 * Creates the database
+	 * Updates the database.
+	 *
+	 * This method uses dbDelta to create or update the database table.
 	 *
 	 * @return void
 	 */
-	protected static function create_db() {
+	protected static function update_db() {
 		Debugger::log( 'Creating or updating the database table' );
 		global $wpdb;
 		$table_name      = self::get_table_name();

--- a/includes/hub/database/class-event-log.php
+++ b/includes/hub/database/class-event-log.php
@@ -19,7 +19,7 @@ class Event_Log {
 	 *
 	 * @var int
 	 */
-	const DB_VERSION = 1;
+	const DB_VERSION = 2;
 
 	/**
 	 * Returns the table name
@@ -47,10 +47,11 @@ class Event_Log {
 	 * @return void
 	 */
 	protected static function maybe_update_db() {
-		$db_version = get_option( self::get_current_option_name(), 0 );
+		$db_version = absint( get_option( self::get_current_option_name(), 0 ) );
 		update_option( self::get_current_option_name(), self::DB_VERSION );
-		if ( 0 === $db_version ) {
+		if ( $db_version < self::DB_VERSION ) {
 			self::create_db();
+			update_option( self::get_current_option_name(), self::DB_VERSION );
 		}
 	}
 
@@ -60,19 +61,23 @@ class Event_Log {
 	 * @return void
 	 */
 	protected static function create_db() {
-		Debugger::log( 'Creating database' );
+		Debugger::log( 'Creating or updating the database table' );
 		global $wpdb;
 		$table_name      = self::get_table_name();
 		$charset_collate = $wpdb->get_charset_collate();
-		$sql             = "CREATE TABLE IF NOT EXISTS $table_name (
-            id int(11) NOT NULL AUTO_INCREMENT,
-            action_name varchar(100) NOT NULL,
-            node_id int(11) NOT NULL,
-            email varchar(100) NULL,
-            data text NOT NULL,
-            timestamp int(11) NOT NULL,
-            PRIMARY KEY  (id)
-        ) $charset_collate;";
-		$wpdb->query( $sql ); //phpcs:ignore
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$sql = "CREATE TABLE $table_name (
+			id int(11) NOT NULL AUTO_INCREMENT,
+			action_name varchar(100) NOT NULL,
+			node_id int(11) NOT NULL,
+			email varchar(100) NULL,
+			data longtext NOT NULL,
+			timestamp int(11) NOT NULL,
+			PRIMARY KEY  (id)
+		) $charset_collate;";
+
+		dbDelta( $sql );
 	}
 }

--- a/includes/hub/database/class-event-log.php
+++ b/includes/hub/database/class-event-log.php
@@ -48,7 +48,6 @@ class Event_Log {
 	 */
 	protected static function maybe_update_db() {
 		$db_version = absint( get_option( self::get_current_option_name(), 0 ) );
-		update_option( self::get_current_option_name(), self::DB_VERSION );
 		if ( $db_version < self::DB_VERSION ) {
 			self::update_db();
 			update_option( self::get_current_option_name(), self::DB_VERSION );


### PR DESCRIPTION
The introduction of content distribution requires the event log data column to hold contents much larger than 64kb. The column type should be migrated to `longtext`. This PR also introduces the use of [dbDelta()](https://developer.wordpress.org/reference/functions/dbdelta/) to manage table changes.

## Testing

1. While on `trunk`, publish a post ensuring it exceeds 64kb in text (you can generate text using https://lipsum.com/)
2. Attempt to distribute that post to a node and confirm the event log is never created and the post doesn't reach the destination
3. Checkout this branch, publish a new post exceeding 64kb and distribute to a node
4. Confirm the event log item is created and the post reaches the destination
5. Run `wp option get newspack_db_version_event_log` and confirm the value is `2`
6. Run `wp db columns wp_newspack_hub_event_log` and confirm `data` is `longtext`