### PR TITLE
feat(content-distribution): support page post type

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -351,7 +351,7 @@ class Content_Distribution {
 		 *
 		 * @param array $post_types Array of post types.
 		 */
-		return apply_filters( 'newspack_network_distributed_post_types', [ 'post' ] );
+		return apply_filters( 'newspack_network_distributed_post_types', [ 'post', 'page' ] );
 	}
 
 	/**

--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -112,6 +112,7 @@ class Editor {
 				'originalSiteUrl'     => $incoming->get_original_site_url(),
 				'originalPostEditUrl' => $incoming->get_original_post_edit_url(),
 				'unlinked'            => ! $incoming->is_linked(),
+				'postTypeLabel'       => get_post_type_labels( get_post_type_object( $post->post_type ) )->singular_name,
 			]
 		);
 	}

--- a/src/content-distribution/incoming-post/index.js
+++ b/src/content-distribution/incoming-post/index.js
@@ -113,12 +113,20 @@ function IncomingPost() {
 			toggleUnlinkedState( unlinked )
 				.then( () => {
 					setIsUnLinkedToggling( false );
-					createNotice( 'info', __( 'Post has been unlinked', 'newspack-network' ), {
-						type: 'snackbar',
-						isDismissible: true,
-						autoDismiss: true,
-						autoDismissTimeout: 3000,
-					} );
+					createNotice(
+						'info',
+						sprintf(
+							// translators: %s: post type
+							__( '%s has been unlinked', 'newspack-network' ),
+							newspack_network_incoming_post.postTypeLabel
+						),
+						{
+							type: 'snackbar',
+							isDismissible: true,
+							autoDismiss: true,
+							autoDismissTimeout: 3000,
+						}
+					);
 				} );
 		}
 	};
@@ -127,13 +135,20 @@ function IncomingPost() {
 		<>
 			<ContentDistributionPanel
 				header={
-					isUnLinked ? __(
-							'This post has been unlinked from its origin. Edits to the origin post will not update this version.',
-							'newspack-network'
+					isUnLinked ? sprintf(
+							__(
+								'This %1$s has been unlinked from its origin. Edits to the origin %1$s will not update this version.',
+								'newspack-network'
+							),
+							newspack_network_incoming_post.postTypeLabel.toLowerCase()
 						)
-						: __(
-							'This post is linked to its origin. Edits to the origin post will update this version.',
+						: sprintf(
+							// translators: %s: post type
+							__(
+							'This %1$s is linked to its origin. Edits to the origin %1$s will update this version.',
 							'newspack-network'
+							),
+							newspack_network_incoming_post.postTypeLabel.toLowerCase()
 						)
 				}
 				buttons={
@@ -143,7 +158,11 @@ function IncomingPost() {
 							target="_blank"
 							href={ originalPostEditUrl }
 						>
-							{ __( 'Edit origin post', 'newspack-network' ) }
+							{ sprintf(
+								// translators: %s: post type
+								__( 'Edit origin %s', 'newspack-network' ),
+								newspack_network_incoming_post.postTypeLabel.toLowerCase()
+	 						) }
 						</Button>
 						<Button
 							variant={ isUnLinked ? 'primary' : 'secondary' }
@@ -153,7 +172,25 @@ function IncomingPost() {
 								setShowConfirmDialog( true );
 							} }
 						>
-							{ isUnLinkedToggling ? (isUnLinked ? __( 'Relinking...', 'newspack-network' ) : __( 'Unlinking...', 'newspack-network' )) : (!isUnLinked ? __( 'Unlink from origin post', 'newspack-network' ) : __( 'Relink to origin post', 'newspack-network' )) }
+							{
+								isUnLinkedToggling ? (
+									isUnLinked ?
+										__( 'Relinking...', 'newspack-network' ) :
+										__( 'Unlinking...', 'newspack-network' )
+								) : (
+									! isUnLinked ?
+										sprintf(
+											// translators: %s: post type
+											__( 'Unlink from origin %s', 'newspack-network' ),
+											newspack_network_incoming_post.postTypeLabel.toLowerCase()
+										) :
+										sprintf(
+											// translators: %s: post type
+											__( 'Relink to origin %s', 'newspack-network' ),
+											newspack_network_incoming_post.postTypeLabel.toLowerCase()
+										)
+								)
+							}
 						</Button>
 					</>
 				}
@@ -169,8 +206,16 @@ function IncomingPost() {
 				size="small"
 			>
 				{ isUnLinked ?
-					__( 'Are you sure you want to relink this post to its origin? Any changes you\'ve made will be lost.', 'newspack-network' ) :
-					__( 'Are you sure you want to unlink this post from its origin?', 'newspack-network' )
+					sprintf(
+						// translators: %s: post type
+						__( 'Are you sure you want to relink this %s to its origin? Any changes you\'ve made will be lost.', 'newspack-network' ),
+						newspack_network_incoming_post.postTypeLabel.toLowerCase()
+					) :
+					sprintf(
+						// translators: %s: post type
+						__( 'Are you sure you want to unlink this %s from its origin?', 'newspack-network' ),
+						newspack_network_incoming_post.postTypeLabel.toLowerCase()
+					)
 				}
 			</ConfirmDialog>
 		</>


### PR DESCRIPTION
Support page distribution.

### Testing

1. Draft a new page and confirm you see the <img width="30" alt="image" src="https://github.com/user-attachments/assets/439b2b2a-2b53-49f3-ba05-8c53f85b1a07" /> plugin icon
2. Publish the page and distribute it to a node
3. In the destination confirm the page has been created 
4. Click to edit the page and confirm it's linked and the editor locked
5. Confirm all the labels refer to "page" instead of "post"
6. Unlink and confirm the editor becomes available and you're able to make changes
