### PR TITLE
feat: sync membership end date

### DIFF
--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -119,6 +119,7 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 			update_post_meta( $user_membership->get_id(), Memberships_Admin::SITE_URL_META_KEY, $this->get_site() );
 		}
 		$user_membership->update_status( $status );
+		$user_membership->set_end_date( $this->get_end_date() ?? '' );
 		$user_membership->add_note(
 			sprintf(
 				// translators: %s is the site URL.
@@ -155,5 +156,14 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 	 */
 	public function get_membership_id() {
 		return $this->data->membership_id ?? null;
+	}
+
+	/**
+	 * Get the original end date of the membership
+	 *
+	 * @return ?string
+	 */
+	public function get_end_date() {
+		return $this->data->end_date ?? null;
 	}
 }

--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -98,7 +98,12 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 
 		$status     = $this->get_new_status();
 		$is_managed = get_post_meta( $user_membership->get_id(), Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
-		if ( in_array( $status, [ 'cancelled', 'expired' ], true ) && $is_managed ) {
+
+		if ( '__deleted' === $status ) {
+			wp_delete_post( $user_membership->get_id(), true );
+			Debugger::log( 'User membership deleted' );
+			return;
+		} elseif ( in_array( $status, [ 'cancelled', 'expired' ], true ) && $is_managed ) {
 			// If the membership is being cancelled or expired, and the membership is managed, we remove the managed meta fields.
 			// This is to allow the membership to be re-initiated from another site in the network.
 			delete_post_meta( $user_membership->get_id(), Memberships_Admin::NETWORK_MANAGED_META_KEY );

--- a/includes/woocommerce-memberships/class-events.php
+++ b/includes/woocommerce-memberships/class-events.php
@@ -109,6 +109,11 @@ class Events {
 	 * @return array
 	 */
 	public static function membership_saved( $plan, $args ) {
+
+		if ( self::$pause_events ) {
+			return;
+		}
+
 		// When creating the membership via admin panel, this hook is called once before the membership is actually created.
 		if ( ! $plan instanceof WC_Memberships_Membership_Plan ) {
 			return;

--- a/includes/woocommerce-memberships/class-events.php
+++ b/includes/woocommerce-memberships/class-events.php
@@ -45,21 +45,23 @@ class Events {
 			return;
 		}
 
-		Data_Events::register_listener( 'wc_memberships_user_membership_status_changed', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_granted' ] );
-		Data_Events::register_listener( 'wc_memberships_user_membership_deleted', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_deleted' ] );
-		Data_Events::register_listener( 'wc_memberships_user_membership_saved', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_revoked' ] );
+		Data_Events::register_listener( 'wc_memberships_user_membership_status_changed', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_status_changed' ] );
+		Data_Events::register_listener( 'wc_memberships_user_membership_saved', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_saved' ] );
 		Data_Events::register_listener( 'newspack_network_save_membership_plan', 'newspack_network_membership_plan_updated', [ __CLASS__, 'membership_plan_updated' ] );
 	}
 
 	/**
-	 * Triggers a data event when the membership is cancelled
+	 * Transforms the data of the wc_memberships_user_membership_status_changed to trigger the newspack_network_woo_membership_updated data event
+	 *
+	 * Fires only when the membership status changes to a non-active status to avoid multiple events for the same membership.
+	 * The occasions when a membership is set to active or updates is handled by the wc_memberships_user_membership_saved hook.
 	 *
 	 * @param WC_Memberships_User_Membership $user_membership The User Membership object.
 	 * @param string                         $old_status old status, without the `wcm-` prefix.
 	 * @param string                         $new_status new status, without the `wcm-` prefix.
 	 * @return array
 	 */
-	public static function membership_granted( $user_membership, $old_status, $new_status ) {
+	public static function membership_status_changed( $user_membership, $old_status, $new_status ) {
 
 		if ( self::$pause_events ) {
 			return;
@@ -89,21 +91,12 @@ class Events {
 			'plan_network_id' => $plan_network_id,
 			'membership_id'   => $user_membership->get_id(),
 			'new_status'      => $new_status,
+			'end_date'        => $user_membership->get_end_date(),
 		];
 	}
 
 	/**
-	 * Remove lists that require a membership plan when the membership is cancelled
-	 *
-	 * @param WC_Memberships_User_Membership $user_membership The User Membership object.
-	 * @return array
-	 */
-	public static function membership_deleted( $user_membership ) {
-		return self::membership_revoked( $user_membership, '', 'deleted' );
-	}
-
-	/**
-	 * Adds user to premium lists when a membership is granted
+	 * Transforms the data of the wc_memberships_user_membership_saved to trigger the newspack_network_woo_membership_updated data event
 	 *
 	 * @param \WC_Memberships_Membership_Plan $plan the plan that user was granted access to.
 	 * @param array                           $args {
@@ -115,12 +108,7 @@ class Events {
 	 * }
 	 * @return array
 	 */
-	public static function membership_revoked( $plan, $args ) {
-
-		if ( self::$pause_events ) {
-			return;
-		}
-
+	public static function membership_saved( $plan, $args ) {
 		// When creating the membership via admin panel, this hook is called once before the membership is actually created.
 		if ( ! $plan instanceof WC_Memberships_Membership_Plan ) {
 			return;
@@ -157,6 +145,7 @@ class Events {
 			'plan_network_id' => $plan_network_id,
 			'membership_id'   => $user_membership->get_id(),
 			'new_status'      => $user_membership->get_status(),
+			'end_date'        => $user_membership->get_end_date(),
 		];
 	}
 

--- a/includes/woocommerce-memberships/class-events.php
+++ b/includes/woocommerce-memberships/class-events.php
@@ -47,6 +47,7 @@ class Events {
 
 		Data_Events::register_listener( 'wc_memberships_user_membership_status_changed', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_status_changed' ] );
 		Data_Events::register_listener( 'wc_memberships_user_membership_saved', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_saved' ] );
+		Data_Events::register_listener( 'wc_memberships_user_membership_deleted', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_deleted' ] );
 		Data_Events::register_listener( 'newspack_network_save_membership_plan', 'newspack_network_membership_plan_updated', [ __CLASS__, 'membership_plan_updated' ] );
 	}
 
@@ -92,6 +93,38 @@ class Events {
 			'membership_id'   => $user_membership->get_id(),
 			'new_status'      => $new_status,
 			'end_date'        => $user_membership->get_end_date(),
+		];
+	}
+
+	/**
+	 * Remove lists that require a membership plan when the membership is cancelled
+	 *
+	 * @param WC_Memberships_User_Membership $user_membership The User Membership object.
+	 * @return array
+	 */
+	public static function membership_deleted( $user_membership ) {
+		if ( self::$pause_events ) {
+			return;
+		}
+
+		$user = $user_membership->get_user();
+		if ( ! $user ) {
+			return;
+		}
+		$user_email = $user->user_email;
+		$plan_id    = $user_membership->get_plan()->get_id();
+
+		$plan_network_id = get_post_meta( $plan_id, Admin::NETWORK_ID_META_KEY, true );
+		if ( ! $plan_network_id ) {
+			return;
+		}
+
+		return [
+			'email'           => $user_email,
+			'user_id'         => $user->ID,
+			'plan_network_id' => $plan_network_id,
+			'membership_id'   => $user_membership->get_id(),
+			'new_status'      => '__deleted',
 		];
 	}
 


### PR DESCRIPTION
This does 2 things:

1. Fixes the event on membership deletion. That was actually broken and was never properly implemented. 

2. Make sure we sync the membership end date. Sometimes this can be altered in the original membership and this info should be updated.

Testing:

* Having a linked membership across the network, edit the original membership and change the end_date
* Confirm the end_date is updated on the linked membership in the other site - even when the end date is set to empty
* Look for another membership and delete it from the original site
* Confirm it also gets deleted from the other sites in the network after the events are propagated

If the membership is an inactive state and you just change the end date, but not the status, the membership will not be synced. That's fine. The membership is inactive anyways and accounting for this event would create a lot of unnecessary events in the network.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209694931348944