### PR TITLE
fix(event-log): copy to clipboard

### DIFF
--- a/includes/hub/admin/js/event-log.js
+++ b/includes/hub/admin/js/event-log.js
@@ -3,21 +3,25 @@
   $( document ).ready( function() {
     const dataColumns = document.querySelectorAll( '.newspack-network-data-column' );
     dataColumns.forEach( function( column ) {
-      const button = column.querySelector( 'button' );
-      const text = column.querySelector( 'textarea' ).value;
-      button.addEventListener( 'click', function( ev ) {
+      const buttonEl = column.querySelector( 'button' );
+      const textEl = column.querySelector( 'textarea' );
+      if (!buttonEl || !textEl) {
+        return;
+      }
+      const text = textEl.value
+      buttonEl.addEventListener( 'click', function( ev ) {
         ev.preventDefault();
-        button.textContent = newspackNetworkEventLogLabels.copying;
-        button.disabled = true;
+        buttonEl.textContent = newspackNetworkEventLogLabels.copying;
+        buttonEl.disabled = true;
         navigator.clipboard.writeText( text ).then( function() {
-          button.textContent = newspackNetworkEventLogLabels.copied;
+          buttonEl.textContent = newspackNetworkEventLogLabels.copied;
           setTimeout( function() {
-            button.textContent = newspackNetworkEventLogLabels.copy;
-            button.disabled = false;
+            buttonEl.textContent = newspackNetworkEventLogLabels.copy;
+            buttonEl.disabled = false;
           }, 1000 );
         } ).catch( function( err ) {
           console.error( 'Failed to copy: ', err );
-          button.disabled = false;
+          buttonEl.disabled = false;
         } );
       } );
     } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with the "Copy to clipboard" button in the event log. Adds check before attaching event listener.

Otherwise, if an item in the table has a Data cell with less than 300 chars, it will break the subsequent "Copy to clipboard" buttons.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->