### PR TITLE
fix(woocommerce): tweaks for membership and subscription events

### DIFF
--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -127,8 +127,9 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 		$user_membership->set_end_date( $this->get_end_date() ?? '' );
 		$user_membership->add_note(
 			sprintf(
-				// translators: %s is the site URL.
-				__( 'Membership status updated via Newspack Network. Status propagated from %s', 'newspack-network' ),
+				// translators: 1: membership status, 2: site URL.
+				__( 'Membership status updated to %1$s via Newspack Network. Propagated from %2$s.', 'newspack-network' ),
+				$status,
 				$this->get_site()
 			)
 		);

--- a/includes/woocommerce/class-events.php
+++ b/includes/woocommerce/class-events.php
@@ -97,7 +97,7 @@ class Events {
 		$result['start_date'] = $item->get_date( 'start_date' );
 		$result['trial_end_date'] = $item->get_date( 'trial_end_date' );
 		$result['next_payment_date'] = $item->get_date( 'next_payment_date' );
-		$result['last_payment_date'] = $item->get_date( 'last_payment_date' );
+		$result['last_payment_date'] = $item->get_date( 'last_order_date_paid' );
 		$result['end_date'] = $item->get_date( 'end_date' );
 		$result['products'] = [];
 

--- a/includes/woocommerce/class-events.php
+++ b/includes/woocommerce/class-events.php
@@ -97,7 +97,7 @@ class Events {
 		$result['start_date'] = $item->get_date( 'start_date' );
 		$result['trial_end_date'] = $item->get_date( 'trial_end_date' );
 		$result['next_payment_date'] = $item->get_date( 'next_payment_date' );
-		$result['last_payment_date'] = $item->get_date( 'last_order_date_paid' );
+		$result['last_payment_date'] = $item->get_date( 'last_order_date_created' );
 		$result['end_date'] = $item->get_date( 'end_date' );
 		$result['products'] = [];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Two small tweaks:

1. When a membership is updated via the network, the membership note is not specifying which status was propagated (only the fact of status change). This PR adds the status name to the note.
2. Fixes a deprecation warning when using `last_payment_date`:

```
PHP Deprecated:  Function WC_Subscription::get_date was called with an argument that is <strong>deprecated</strong> since version 2.2.0! The &quot;last_payment&quot; date type parameter has been deprecated due to ambiguity (it actually returns the date created for the last order) and to align date types with improvements to date APIs in WooCommerce 3.0, specifically the introduction of a new &quot;date_paid&quot; API. Use &quot;last_order_date_created&quot; or &quot;last_order_date_paid&quot;
```

### How to test the changes in this Pull Request:

1. On `trunk`, renew a subscription*. Observe a deprecation warning logged. 
4. On this branch, observe no deprecation warning. 
5. Update a status of a network-propagated membership, observe the membership note on the "non-original" site (the one where the membership is only mirrored) contains the status. 

\* "process renewal" in "Order actions":

<img width="335" alt="image" src="https://github.com/user-attachments/assets/f5c71b98-cf92-4269-9e76-d8350cdc770f" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->