### PR TITLE
feat: adjust capabilities

### DIFF
--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -24,6 +24,11 @@ class Admin {
 	const LINK_ACTION_NAME = 'newspack-network-link-site';
 
 	/**
+	 * Capability required to administer here.
+	 */
+	const REQUIRED_CAPABILITY = 'newspack_network_admin';
+
+	/**
 	 * Runs the initialization.
 	 */
 	public static function init() {
@@ -120,7 +125,7 @@ class Admin {
 		$page_suffix = add_menu_page(
 			__( 'Newspack Network', 'newspack-network' ),
 			__( 'Newspack Network', 'newspack-network' ),
-			'manage_options',
+			self::REQUIRED_CAPABILITY,
 			self::PAGE_SLUG,
 			array( __CLASS__, 'render_page' ),
 			$icon,
@@ -145,7 +150,7 @@ class Admin {
 			self::PAGE_SLUG,
 			$title,
 			$title,
-			'manage_options',
+			self::REQUIRED_CAPABILITY,
 			$slug,
 			$callback
 		);

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -24,9 +24,9 @@ class Admin {
 	const LINK_ACTION_NAME = 'newspack-network-link-site';
 
 	/**
-	 * Capability required to administer here.
+	 * Capability required to administer here (unless Newspack Plugin's capability methods are unavailable).
 	 */
-	const REQUIRED_CAPABILITY = 'newspack_network_admin';
+	const CAPABILITY = 'newspack_network_admin';
 
 	/**
 	 * Runs the initialization.
@@ -35,6 +35,30 @@ class Admin {
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu' ) );
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
+		add_filter( 'newspack_capabilities_map', [ __CLASS__, 'newspack_capabilities_map' ] );
+		add_filter( 'newspack_capabilities_in_cme_plugin', [ __CLASS__, 'newspack_capabilities_in_cme_plugin' ] );
+	}
+
+	/**
+	 * Get the capability required to administrate.
+	 * If Newspack Plugin capability mapping is available, use the granular capability.
+	 * Otherwise, use the generic 'manage_options' capability.
+	 */
+	public static function get_admin_cap() {
+		if ( method_exists( '\Newspack\Capabilities', 'map_capabilities' ) ) {
+			return self::CAPABILITY;
+		}
+		return 'manage_options';
+	}
+
+	/**
+	 * Map this wizard capability from 'manage_options' capability.
+	 *
+	 * @param array $capabilities_map Mapping of capabilities.
+	 */
+	public static function newspack_capabilities_map( $capabilities_map ) {
+		$capabilities_map[ self::CAPABILITY ] = 'manage_options';
+		return $capabilities_map;
 	}
 
 	/**
@@ -56,7 +80,6 @@ class Admin {
 	 * @return void
 	 */
 	public static function register_settings() {
-
 		add_settings_section(
 			self::SETTINGS_SECTION,
 			esc_html__( 'Newspack Network Settings', 'newspack-network' ),
@@ -125,7 +148,7 @@ class Admin {
 		$page_suffix = add_menu_page(
 			__( 'Newspack Network', 'newspack-network' ),
 			__( 'Newspack Network', 'newspack-network' ),
-			self::REQUIRED_CAPABILITY,
+			self::get_admin_cap(),
 			self::PAGE_SLUG,
 			array( __CLASS__, 'render_page' ),
 			$icon,
@@ -150,7 +173,7 @@ class Admin {
 			self::PAGE_SLUG,
 			$title,
 			$title,
-			self::REQUIRED_CAPABILITY,
+			self::get_admin_cap(),
 			$slug,
 			$callback
 		);
@@ -202,5 +225,15 @@ class Admin {
 	 */
 	public static function use_experimental_auditing_features() {
 		return defined( 'NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_FEATURES' ) ? NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_FEATURES : false;
+	}
+
+	/**
+	 * Register this capability in Newspack capabilities list in the capability-manager-enhanced plugin.
+	 *
+	 * @param array $capabilities Mapping of capabilities.
+	 */
+	public static function newspack_capabilities_in_cme_plugin( $capabilities ) {
+		$capabilities[] = self::CAPABILITY;
+		return $capabilities;
 	}
 }

--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -143,6 +143,9 @@ class Nodes {
 			'show_in_menu'         => Network_Admin::PAGE_SLUG,
 			'can_export'           => false,
 			'capability_type'      => 'page',
+			'capabilities'         => [
+				'edit_posts' => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
+			],
 			'show_in_rest'         => false,
 			'delete_with_user'     => false,
 			'register_meta_box_cb' => [ __CLASS__, 'add_metabox' ],
@@ -344,19 +347,19 @@ class Nodes {
 	 * Highlight the correct submenu item.
 	 *
 	 * @param string $submenu_file The current submenu file.
-	 * 
+	 *
 	 * @return string
 	 */
 	public static function submenu_file( $submenu_file ) {
 		global $pagenow;
 
 		// Highlight "Nodes" submenu on Add New Node screen.
-		if ( $submenu_file === Network_Admin::PAGE_SLUG 
-			&& $pagenow === 'post-new.php' 
+		if ( $submenu_file === Network_Admin::PAGE_SLUG
+			&& $pagenow === 'post-new.php'
 			&& self::POST_TYPE_SLUG === filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ) {
 			return 'edit.php?post_type=newspack_hub_nodes';
 		}
-		
+
 		return $submenu_file;
 	}
 }

--- a/includes/hub/class-nodes.php
+++ b/includes/hub/class-nodes.php
@@ -144,7 +144,7 @@ class Nodes {
 			'can_export'           => false,
 			'capability_type'      => 'page',
 			'capabilities'         => [
-				'edit_posts' => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
+				'edit_posts' => \Newspack_Network\Admin::get_admin_cap(),
 			],
 			'show_in_rest'         => false,
 			'delete_with_user'     => false,

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -81,7 +81,9 @@ class Orders {
 			'can_export'       => false,
 			'capability_type'  => 'post',
 			'capabilities'     => [
-				'create_posts' => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
+				'create_posts'      => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
+				'edit_posts'        => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
+				'edit_others_posts' => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -82,8 +82,8 @@ class Orders {
 			'capability_type'  => 'post',
 			'capabilities'     => [
 				'create_posts'      => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
-				'edit_posts'        => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
-				'edit_others_posts' => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
+				'edit_posts'        => \Newspack_Network\Admin::get_admin_cap(),
+				'edit_others_posts' => \Newspack_Network\Admin::get_admin_cap(),
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -82,8 +82,8 @@ class Orders {
 			'capability_type'  => 'post',
 			'capabilities'     => [
 				'create_posts'      => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
-				'edit_posts'        => \Newspack_Network\Admin::get_admin_cap(),
-				'edit_others_posts' => \Newspack_Network\Admin::get_admin_cap(),
+				'edit_posts'        => Network_Admin::get_admin_cap(),
+				'edit_others_posts' => Network_Admin::get_admin_cap(),
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -82,8 +82,8 @@ class Subscriptions {
 			'capability_type'  => 'post',
 			'capabilities'     => [
 				'create_posts'      => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
-				'edit_posts'        => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
-				'edit_others_posts' => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
+				'edit_posts'        => \Newspack_Network\Admin::get_admin_cap(),
+				'edit_others_posts' => \Newspack_Network\Admin::get_admin_cap(),
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -81,7 +81,9 @@ class Subscriptions {
 			'can_export'       => false,
 			'capability_type'  => 'post',
 			'capabilities'     => [
-				'create_posts' => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
+				'create_posts'      => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
+				'edit_posts'        => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
+				'edit_others_posts' => \Newspack_Network\Admin::REQUIRED_CAPABILITY,
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -82,8 +82,8 @@ class Subscriptions {
 			'capability_type'  => 'post',
 			'capabilities'     => [
 				'create_posts'      => 'not_a_real_capability', // Set to a fake capability to remove "add new" button.
-				'edit_posts'        => \Newspack_Network\Admin::get_admin_cap(),
-				'edit_others_posts' => \Newspack_Network\Admin::get_admin_cap(),
+				'edit_posts'        => Network_Admin::get_admin_cap(),
+				'edit_others_posts' => Network_Admin::get_admin_cap(),
 			],
 			'show_in_rest'     => false,
 			'delete_with_user' => false,

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -487,7 +487,7 @@ class Settings {
 			return;
 		}
 
-		if ( ! current_user_can( \Newspack_Network\Admin::get_admin_cap() ) ) {
+		if ( ! current_user_can( Admin::get_admin_cap() ) ) {
 			return;
 		}
 

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -487,7 +487,7 @@ class Settings {
 			return;
 		}
 
-		if ( ! current_user_can( \Newspack_Network\Admin::REQUIRED_CAPABILITY ) ) {
+		if ( ! current_user_can( \Newspack_Network\Admin::get_admin_cap() ) ) {
 			return;
 		}
 

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -487,7 +487,7 @@ class Settings {
 			return;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( \Newspack_Network\Admin::REQUIRED_CAPABILITY ) ) {
 			return;
 		}
 
@@ -580,7 +580,7 @@ class Settings {
 			</div>
 		<?php
 	}
-	
+
 	/**
 	 * Adds the nodes and their bookmarks to the Admin Bar menu
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts caps, so the unavailable menu options are hidden for non-admins.

_Dependent on https://github.com/Automattic/newspack-plugin/pull/3920_

### How to test the changes in this Pull Request:

1. On `trunk`, 
2. Create a new author user and log in as them
4. Observe the Network → Subscriptions and → Orders admin menus are displayed

<img width="356" alt="image" src="https://github.com/user-attachments/assets/573aba2c-76e7-4c02-a61a-3816556685d3" />

4. Switch to this branch, observe these items are not displayed
5. Log in a the site administrator, confirm you can access these and other Network page via the admin menu


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->