### PR TITLE
feat: add option to not create new terms on content distrib NPPD-134

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -416,6 +416,24 @@ class Content_Distribution {
 	}
 
 	/**
+	 * Returns a list of taxonomies that should be distributed only if the terms already exist
+	 * in the destination site. Terms from these taxonomies will not be created if they don't exist.
+	 *
+	 * @return string[] Array of taxonomy slugs that should be distributed only if terms exist
+	 */
+	public static function get_existing_terms_only_taxonomies() {
+		$existing_terms_only_taxonomies = [
+			'brand', // Newspack Multibranded Sites 'brand' taxonomy.
+		];
+		/**
+		 * Filter the taxonomies that should be distributed only if terms already exist.
+		 *
+		 * @param array $taxonomies Array of taxonomy slugs.
+		 */
+		return apply_filters( 'newspack_network_content_distribution_existing_terms_only_taxonomies', $existing_terms_only_taxonomies );
+	}
+
+	/**
 	 * Whether a given post is distributed.
 	 *
 	 * @param WP_Post|int $post The post object or ID.

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -478,6 +478,13 @@ class Incoming_Post {
 			foreach ( $terms as $term_data ) {
 				$term = get_term_by( 'name', $term_data['name'], $taxonomy, ARRAY_A );
 				if ( ! $term ) {
+
+					// If the taxonomy is in the list of taxonomies that should only
+					// have terms that already exist, skip the term creation.
+					if ( in_array( $taxonomy, Content_Distribution_Class::get_existing_terms_only_taxonomies(), true ) ) {
+						continue;
+					}
+
 					$term = wp_insert_term( $term_data['name'], $taxonomy );
 					if ( is_wp_error( $term ) ) {
 						self::log( 'Failed to insert term ' . $term_data['name'] . ' for taxonomy ' . $taxonomy . ' with message: ' . $term->get_error_message() );

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -566,4 +566,51 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		$this->expectExceptionMessage( 'Partial payload requires an existing post.' );
 		new Incoming_Post( $payload );
 	}
+
+	/**
+	 * Test existing terms only taxonomies.
+	 */
+	public function test_existing_terms_only_taxonomies() {
+		$payload = $this->get_sample_payload();
+		$taxonomy = 'existing_terms_only_tax';
+
+		// Register a taxonomy that should only use existing terms.
+		register_taxonomy( $taxonomy, 'post', [ 'public' => true ] );
+
+		// Add the taxonomy to the existing terms only list.
+		add_filter(
+			'newspack_network_content_distribution_existing_terms_only_taxonomies',
+			function( $taxonomies ) use ( $taxonomy ) {
+				$taxonomies[] = $taxonomy;
+				return $taxonomies;
+			}
+		);
+
+		// Add a non-existent term to the payload.
+		$payload['post_data']['taxonomy'][ $taxonomy ] = [
+			[
+				'name' => 'Non-existent Term',
+				'slug' => 'non-existent-term',
+			],
+		];
+
+		// Insert the linked post.
+		$post_id = $this->incoming_post->insert( $payload );
+
+		// Assert that the post does not have the term since it doesn't exist.
+		$terms = wp_get_post_terms( $post_id, $taxonomy );
+		$this->assertEmpty( $terms );
+
+		// Now create the term and try again.
+		$term = wp_insert_term( 'Non-existent Term', $taxonomy );
+		$this->assertFalse( is_wp_error( $term ) );
+
+		// Insert the linked post again.
+		$this->incoming_post->insert( $payload );
+
+		// Assert that the post now has the term since it exists.
+		$terms = wp_get_post_terms( $post_id, $taxonomy );
+		$this->assertNotEmpty( $terms );
+		$this->assertSame( 'Non-existent Term', $terms[0]->name );
+	}
 }


### PR DESCRIPTION
Add a new check to define taxonomies that should be distributed but for which we don't want to create new terms in the target site if they don't exist.

This is useful for the integration with Multibranded sites plugin, in which we don't want to propagate all the brands from all the sites all other sites. We just want to keep the posts in the same brand if they exist in more than one site.

Read the code and see the tests.

If you really want to test it:

* Activate Multibranded site in 2 sites in the network
* Create 2 brands in site A
* Creates 2 brand in site B, being one of the existing brands in site A
* On site A, mark the post in both brands and distribute it to site B
* Confirm that on site B the post is assigned to the existing brand, but the second brand is not created (on trunk, the second brand will be created)