### PR TITLE
feat: sync post modified date on post ditribution

### DIFF
--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -691,6 +691,9 @@ class Incoming_Post {
 
 			// Handle taxonomy terms.
 			$this->update_taxonomy_terms();
+
+			// Handle the post modified date.
+			$this->update_post_modified_date();
 		}
 
 		update_post_meta( $this->ID, self::PAYLOAD_META, $this->payload );
@@ -706,5 +709,37 @@ class Incoming_Post {
 		do_action( 'newspack_network_incoming_post_inserted', $this->ID, $this->is_linked(), $this->payload );
 
 		return $this->ID;
+	}
+
+	/**
+	 * Update the post modified date.
+	 *
+	 * Need to update directly into the database after the post is inserted/updated
+	 * to override the automatic date update.
+	 *
+	 * @return void
+	 */
+	protected function update_post_modified_date() {
+		$post_data = $this->payload['post_data'];
+		if ( ! empty( $post_data['modified_gmt'] ) ) {
+			$post_modified_gmt = $post_data['modified_gmt'];
+
+			// calculate the local time of the post modified date.
+			$post_modified = get_date_from_gmt( $post_modified_gmt );
+
+			// update the post modified date.
+			global $wpdb;
+			$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+				$wpdb->posts,
+				[
+					'post_modified'     => $post_modified,
+					'post_modified_gmt' => $post_modified_gmt,
+				],
+				[ 'ID' => $this->ID ]
+			);
+
+			// Clear the post cache.
+			wp_cache_delete( $this->ID, 'posts' );
+		}
 	}
 }

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -613,4 +613,32 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $terms );
 		$this->assertSame( 'Non-existent Term', $terms[0]->name );
 	}
+
+	/**
+	 * Test updating the post modified date.
+	 */
+	public function test_update_post_modified_date() {
+
+		$payload_old_dates = $this->get_sample_payload();
+
+		$payload_old_dates['post_data']['modified_gmt'] = '2020-01-01 00:00:00';
+		$payload_old_dates['post_data']['date_gmt'] = '2020-01-01 00:00:00';
+
+		$incoming_post = new Incoming_Post( $payload_old_dates );
+
+		$post_id = $incoming_post->insert();
+
+		$this->assertSame( '2020-01-01 00:00:00', get_post_field( 'post_modified_gmt', $post_id ) );
+		$this->assertSame( '2020-01-01 00:00:00', get_post_field( 'post_date_gmt', $post_id ) );
+
+		// Modify the post payload to simulate an update.
+		$payload_old_dates['post_data']['title'] = 'New Title';
+		$payload_old_dates['post_data']['modified_gmt'] = '2020-10-01 00:00:00';
+
+		// Insert the updated linked post.
+		$post_id = $this->incoming_post->insert( $payload_old_dates );
+
+		$this->assertSame( 'New Title', get_the_title( $post_id ) );
+		$this->assertSame( '2020-10-01 00:00:00', get_post_field( 'post_modified_gmt', $post_id ) );
+	}
 }


### PR DESCRIPTION
On Content Distrbution, when processing an incoming post, make sure that the post modified date is kept in sync with the original post.

## Testing

1. Distribute a post
2. Check the post in the destination and confirm it has the exact same post_modified date from the original
3. Make changes to the original post and save
4. Confirm that the new modified date is synced