### PR TITLE
feat: add support to yoast primary cat in content distribution

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -17,6 +17,7 @@ use Newspack_Network\Content_Distribution\Distributor_Migrator;
 use Newspack_Network\Content_Distribution\Editor;
 use Newspack_Network\Content_Distribution\Incoming_Post;
 use Newspack_Network\Content_Distribution\Outgoing_Post;
+use Newspack_Network\Content_Distribution\Yoast_Primary_Cat;
 use WP_Post;
 
 /**
@@ -66,6 +67,7 @@ class Content_Distribution {
 		Canonical_Url::init();
 		Distributor_Migrator::init();
 		Cap_Authors::init();
+		Yoast_Primary_Cat::init();
 	}
 
 	/**

--- a/includes/content-distribution/class-yoast-primary-cat.php
+++ b/includes/content-distribution/class-yoast-primary-cat.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Newspack Network Distributor Yoast Primary Category on Content Distribution
+ *
+ * @package newspack-network
+ */
+
+namespace Newspack_Network\Content_Distribution;
+
+/**
+ * Class to handle Yoast's primary category metadata distribution
+ */
+class Yoast_Primary_Cat {
+
+	/**
+	 * The meta name for the primary category slug.
+	 *
+	 * @var string
+	 */
+	const PRIMARY_CAT_SLUG_META_NAME = '_newspack_network_primary_cat_slug';
+
+	/**
+	 * Initialize the class.
+	 */
+	public static function init() {
+		add_filter( 'newspack_network_distributed_post_meta', [ __CLASS__, 'filter_outgoing_post' ], 10, 2 );
+		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'after_incoming_post_inserted' ], 10, 3 );
+	}
+
+	/**
+	 * Filter the outgoing post meta.
+	 *
+	 * @param array   $meta The post meta.
+	 * @param WP_Post $post The post object.
+	 * @return array
+	 */
+	public static function filter_outgoing_post( $meta, $post ) {
+
+		if ( ! class_exists( 'WPSEO_Primary_Term' ) ) {
+			return $meta;
+		}
+
+
+		$primary_term = new \WPSEO_Primary_Term( 'category', $post->ID );
+		$category_id  = $primary_term->get_primary_term();
+		if ( $category_id ) {
+			$category = get_term( $category_id );
+			if ( $category instanceof \WP_Term ) {
+				$meta[ self::PRIMARY_CAT_SLUG_META_NAME ] = [ $category->slug ];
+			}
+		}
+
+		return $meta;
+	}
+
+	/**
+	 * After the incoming post is inserted.
+	 *
+	 * @param int   $post_id The post ID.
+	 * @param bool  $is_linked Whether the post is linked.
+	 * @param array $payload The payload.
+	 */
+	public static function after_incoming_post_inserted( $post_id, $is_linked, $payload ) {
+		if ( ! $is_linked ) {
+			return;
+		}
+
+		$primary_cat_slug = get_post_meta( $post_id, self::PRIMARY_CAT_SLUG_META_NAME, true );
+		if ( ! $primary_cat_slug ) {
+			return;
+		}
+
+		// get term by slug.
+		$term = get_term_by( 'slug', $primary_cat_slug, 'category' );
+		if ( ! $term ) {
+			return;
+		}
+
+		$primary_term = new \WPSEO_Primary_Term( 'category', $post_id );
+		$primary_term->set_primary_term( $term->term_id );
+	}
+}

--- a/includes/content-distribution/class-yoast-primary-cat.php
+++ b/includes/content-distribution/class-yoast-primary-cat.php
@@ -61,6 +61,11 @@ class Yoast_Primary_Cat {
 	 * @param array $payload The payload.
 	 */
 	public static function after_incoming_post_inserted( $post_id, $is_linked, $payload ) {
+
+		if ( ! class_exists( 'WPSEO_Primary_Term' ) ) {
+			return;
+		}
+
 		if ( ! $is_linked ) {
 			return;
 		}

--- a/tests/unit-tests/content-distribution/mock-yoast-primary-term.php
+++ b/tests/unit-tests/content-distribution/mock-yoast-primary-term.php
@@ -1,0 +1,59 @@
+<?php // phpcs:ignore
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO
+ */
+
+/**
+ * Represents a post's primary term.
+ */
+class WPSEO_Primary_Term {
+
+	const META_NAME = '_yoast_wpseo_primary_category';
+
+	/**
+	 * Taxonomy name for the term.
+	 *
+	 * @var string
+	 */
+	protected $taxonomy_name;
+
+	/**
+	 * Post ID for the term.
+	 *
+	 * @var int
+	 */
+	protected $post_ID;
+
+	/**
+	 * The taxonomy this term is part of.
+	 *
+	 * @param string $taxonomy_name Taxonomy name for the term.
+	 * @param int    $post_id       Post ID for the term.
+	 */
+	public function __construct( $taxonomy_name, $post_id ) {
+		$this->taxonomy_name = $taxonomy_name;
+		$this->post_ID       = $post_id;
+	}
+
+	/**
+	 * Returns the primary term ID.
+	 *
+	 * @return int|bool
+	 */
+	public function get_primary_term() {
+		return get_post_meta( $this->post_ID, self::META_NAME, true );
+	}
+
+	/**
+	 * Sets the new primary term ID.
+	 *
+	 * @param int $new_primary_term New primary term ID.
+	 *
+	 * @return void
+	 */
+	public function set_primary_term( $new_primary_term ) {
+		update_post_meta( $this->post_ID, self::META_NAME, $new_primary_term );
+	}
+}

--- a/tests/unit-tests/content-distribution/test-yoast-primary-cat.php
+++ b/tests/unit-tests/content-distribution/test-yoast-primary-cat.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Class TestOutgoingPost
+ *
+ * @package Newspack_Network
+ */
+
+namespace Test\Content_Distribution;
+
+use Newspack_Network\Content_Distribution\Outgoing_Post;
+use Newspack_Network\Content_Distribution\Incoming_Post;
+use Newspack_Network\Content_Distribution\Yoast_Primary_Cat;
+
+require_once __DIR__ . '/mock-yoast-primary-term.php';
+
+/**
+ * Test the Outgoing_Post class.
+ */
+class TestYoastPrimaryCat extends \WP_UnitTestCase {
+
+	/**
+	 * Test category slug used in the test. It's part of the sample payload.
+	 */
+	const TEST_CATEGORY_SLUG = 'category-2';
+
+	/**
+	 * Test the outgoing post.
+	 */
+	public function test_outgoing_post() {
+		$post_id = self::factory()->post->create();
+
+		$category_id = self::factory()->category->create( [ 'slug' => self::TEST_CATEGORY_SLUG ] );
+
+		$primary_term = new \WPSEO_Primary_Term( 'category', $post_id );
+		$primary_term->set_primary_term( $category_id );
+
+		$outgoing_post = new Outgoing_Post( $post_id );
+
+		$outgoing_meta = $outgoing_post->get_payload()['post_data']['post_meta'];
+
+		$meta_name = Yoast_Primary_Cat::PRIMARY_CAT_SLUG_META_NAME;
+
+		$this->assertArrayHasKey( $meta_name, $outgoing_meta );
+		$this->assertEquals( self::TEST_CATEGORY_SLUG, $outgoing_meta[ $meta_name ][0], 'The primary category slug should be part of the outgoing post meta' );
+	}
+
+	/**
+	 * Test the incoming post.
+	 */
+	public function test_incoming_post() {
+		$payload = get_sample_payload( 'https://node1.test', 'https://node2.test' );
+
+		// Set the site URL for the node that receives posts.
+		update_option( 'siteurl', 'https://node2.test' );
+		update_option( 'home', 'https://node2.test' );
+
+		$meta_name = Yoast_Primary_Cat::PRIMARY_CAT_SLUG_META_NAME;
+
+		$payload['post_data']['post_meta'][ $meta_name ] = [ self::TEST_CATEGORY_SLUG ];
+
+		$incoming_post = new Incoming_Post( $payload );
+
+		$post_id = $incoming_post->insert();
+
+		$primary_term = new \WPSEO_Primary_Term( 'category', $post_id );
+		$primary_term_id = $primary_term->get_primary_term();
+
+		$primary_term_category = get_term( $primary_term_id, 'category' );
+
+		$this->assertEquals( self::TEST_CATEGORY_SLUG, $primary_term_category->slug, 'The primary category should be correctly set in the created post' );
+	}
+}


### PR DESCRIPTION
On content distribution, distribute Yoast's primary category if present

## Testing

1. Test Content distribution without Yoast and confirm it still works
2. enable Yoast
3. Create a post with multiple categories and set a primary category
4. Distribute the post
5. Confirm that in the destination the correct primary category is set, even if the ID is not the same in both sites
6. Update the post and change the primary category
7. confirm the update also works