### PR TITLE
Distribution tax hierarchy

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -400,42 +400,6 @@ class Content_Distribution {
 	}
 
 	/**
-	 * Get taxonomies that should not be distributed.
-	 *
-	 * @return string[] The ignored taxonomies.
-	 */
-	public static function get_ignored_taxonomies() {
-		$ignored_taxonomies = [
-			'author', // Co-Authors Plus 'author' taxonomy should be ignored as it requires custom handling.
-		];
-
-		/**
-		 * Filters the ignored taxonomies that should not be distributed.
-		 *
-		 * @param string[] $ignored_taxonomies The ignored taxonomies.
-		 */
-		return apply_filters( 'newspack_network_content_distribution_ignored_taxonomies', $ignored_taxonomies );
-	}
-
-	/**
-	 * Returns a list of taxonomies that should be distributed only if the terms already exist
-	 * in the destination site. Terms from these taxonomies will not be created if they don't exist.
-	 *
-	 * @return string[] Array of taxonomy slugs that should be distributed only if terms exist
-	 */
-	public static function get_existing_terms_only_taxonomies() {
-		$existing_terms_only_taxonomies = [
-			'brand', // Newspack Multibranded Sites 'brand' taxonomy.
-		];
-		/**
-		 * Filter the taxonomies that should be distributed only if terms already exist.
-		 *
-		 * @param array $taxonomies Array of taxonomy slugs.
-		 */
-		return apply_filters( 'newspack_network_content_distribution_existing_terms_only_taxonomies', $existing_terms_only_taxonomies );
-	}
-
-	/**
 	 * Whether a given post is distributed.
 	 *
 	 * @param WP_Post|int $post The post object or ID.

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -474,27 +474,15 @@ class Incoming_Post {
 			if ( ! taxonomy_exists( $taxonomy ) ) {
 				continue;
 			}
-			$term_ids = [];
-			foreach ( $terms as $term_data ) {
-				$term = get_term_by( 'name', $term_data['name'], $taxonomy, ARRAY_A );
-				if ( ! $term ) {
+			$term_ids = Taxonomy_Terms::get_or_create_term_ids( $terms, $taxonomy );
 
-					// If the taxonomy is in the list of taxonomies that should only
-					// have terms that already exist, skip the term creation.
-					if ( in_array( $taxonomy, Content_Distribution_Class::get_existing_terms_only_taxonomies(), true ) ) {
-						continue;
-					}
-
-					$term = wp_insert_term( $term_data['name'], $taxonomy );
-					if ( is_wp_error( $term ) ) {
-						self::log( 'Failed to insert term ' . $term_data['name'] . ' for taxonomy ' . $taxonomy . ' with message: ' . $term->get_error_message() );
-						continue;
-					}
-					$term = get_term_by( 'id', $term['term_id'], $taxonomy, ARRAY_A );
-				}
-				$term_ids[] = $term['term_id'];
+			if ( is_wp_error( $term_ids ) ) {
+				self::log( 'Failed to get or create term IDs for taxonomy ' . $taxonomy . ' with message: ' . $term_ids->get_error_message() );
+				continue;
 			}
-			wp_set_object_terms( $this->ID, $term_ids, $taxonomy );
+			if ( $term_ids ) {
+				wp_set_object_terms( $this->ID, $term_ids, $taxonomy );
+			}
 		}
 	}
 

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -465,7 +465,7 @@ class Incoming_Post {
 	 * @return void
 	 */
 	protected function update_taxonomy_terms() {
-		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
+		$ignored_taxonomies = Taxonomy_Terms::get_ignored_taxonomies();
 		$data               = $this->payload['post_data']['taxonomy'];
 		foreach ( $data as $taxonomy => $terms ) {
 			if ( in_array( $taxonomy, $ignored_taxonomies, true ) ) {

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -372,31 +372,7 @@ class Outgoing_Post {
 	 * @return array The taxonomy term data.
 	 */
 	protected function get_post_taxonomy_terms() {
-		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
-		$taxonomies         = get_object_taxonomies( $this->post->post_type, 'objects' );
-		$data                = [];
-		foreach ( $taxonomies as $taxonomy ) {
-			if ( in_array( $taxonomy->name, $ignored_taxonomies, true ) ) {
-				continue;
-			}
-			if ( ! $taxonomy->public ) {
-				continue;
-			}
-			$terms = get_the_terms( $this->post->ID, $taxonomy->name );
-			if ( ! $terms ) {
-				continue;
-			}
-			$data[ $taxonomy->name ] = array_map(
-				function( $term ) {
-					return [
-						'name' => $term->name,
-						'slug' => $term->slug,
-					];
-				},
-				$terms
-			);
-		}
-		return $data;
+		return Taxonomy_Terms::get_post_taxonomy_terms( $this->post );
 	}
 
 	/**

--- a/includes/content-distribution/class-taxonomy-terms.php
+++ b/includes/content-distribution/class-taxonomy-terms.php
@@ -77,8 +77,6 @@ class Taxonomy_Terms {
 	 * @return array|WP_Error The term IDs on success, WP_Error on failure.
 	 */
 	public static function get_or_create_term_ids( $terms, $taxonomy ) {
-		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
-
 		$term_ids = [];
 
 		foreach ( $terms as $term_data ) {

--- a/includes/content-distribution/class-taxonomy-terms.php
+++ b/includes/content-distribution/class-taxonomy-terms.php
@@ -17,13 +17,49 @@ class Taxonomy_Terms {
 	const SEPARATOR = '|--|';
 
 	/**
+	 * Get taxonomies that should not be distributed.
+	 *
+	 * @return string[] The ignored taxonomies.
+	 */
+	public static function get_ignored_taxonomies() {
+		$ignored_taxonomies = [
+			'author', // Co-Authors Plus 'author' taxonomy should be ignored as it requires custom handling.
+		];
+
+		/**
+		 * Filters the ignored taxonomies that should not be distributed.
+		 *
+		 * @param string[] $ignored_taxonomies The ignored taxonomies.
+		 */
+		return apply_filters( 'newspack_network_content_distribution_ignored_taxonomies', $ignored_taxonomies );
+	}
+
+	/**
+	 * Returns a list of taxonomies that should be distributed only if the terms already exist
+	 * in the destination site. Terms from these taxonomies will not be created if they don't exist.
+	 *
+	 * @return string[] Array of taxonomy slugs that should be distributed only if terms exist
+	 */
+	public static function get_existing_terms_only_taxonomies() {
+		$existing_terms_only_taxonomies = [
+			'brand', // Newspack Multibranded Sites 'brand' taxonomy.
+		];
+		/**
+		 * Filter the taxonomies that should be distributed only if terms already exist.
+		 *
+		 * @param array $taxonomies Array of taxonomy slugs.
+		 */
+		return apply_filters( 'newspack_network_content_distribution_existing_terms_only_taxonomies', $existing_terms_only_taxonomies );
+	}
+
+	/**
 	 * Get post taxonomy terms for distribution.
 	 *
 	 * @param \WP_Post $post The post object.
 	 * @return array The taxonomy term data.
 	 */
 	public static function get_post_taxonomy_terms( \WP_Post $post ) {
-		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
+		$ignored_taxonomies = self::get_ignored_taxonomies();
 		$taxonomies         = get_object_taxonomies( $post->post_type, 'objects' );
 		$data                = [];
 		foreach ( $taxonomies as $taxonomy ) {
@@ -126,7 +162,7 @@ class Taxonomy_Terms {
 
 				// If the taxonomy is in the list of taxonomies that should only
 				// have terms that already exist, skip the term creation.
-				if ( in_array( $taxonomy, Content_Distribution_Class::get_existing_terms_only_taxonomies(), true ) ) {
+				if ( in_array( $taxonomy, self::get_existing_terms_only_taxonomies(), true ) ) {
 					$term_id = false;
 					break;
 				}

--- a/includes/content-distribution/class-taxonomy-terms.php
+++ b/includes/content-distribution/class-taxonomy-terms.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Newspack Content Distribution Taxonomy Terms Handler
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Content_Distribution;
+
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
+
+/**
+ * Class to filter the canonical URLs for distributed content.
+ */
+class Taxonomy_Terms {
+
+	const SEPARATOR = '|--|';
+
+	/**
+	 * Get post taxonomy terms for distribution.
+	 *
+	 * @param \WP_Post $post The post object.
+	 * @return array The taxonomy term data.
+	 */
+	public static function get_post_taxonomy_terms( \WP_Post $post ) {
+		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
+		$taxonomies         = get_object_taxonomies( $post->post_type, 'objects' );
+		$data                = [];
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( in_array( $taxonomy->name, $ignored_taxonomies, true ) ) {
+				continue;
+			}
+			if ( ! $taxonomy->public ) {
+				continue;
+			}
+			$terms = get_the_terms( $post->ID, $taxonomy->name );
+			if ( ! $terms ) {
+				continue;
+			}
+
+			$data[ $taxonomy->name ] = array_map(
+				function( $term ) {
+					return [
+						'name' => self::recursively_get_term_name( $term ),
+						'slug' => $term->slug,
+					];
+				},
+				$terms
+			);
+		}
+		return $data;
+	}
+
+	/**
+	 * Recursively get the term name.
+	 *
+	 * @param \WP_Term $term The term.
+	 * @return string The term name.
+	 */
+	public static function recursively_get_term_name( \WP_Term $term ) {
+		if ( $term->parent ) {
+			return self::recursively_get_term_name( get_term( $term->parent, $term->taxonomy ) ) . self::SEPARATOR . $term->name;
+		}
+		return $term->name;
+	}
+
+	/**
+	 * Get or create term IDs.
+	 *
+	 * Given a term definition created by recursively_get_term_name(),
+	 * this function will get the term IDs for the terms based on their names.
+	 * If the term does not exist, it will be created, unless the taxonomy is
+	 * in the list of taxonomies that should only have terms that already exist.
+	 *
+	 * @param array  $terms The terms.
+	 * @param string $taxonomy The taxonomy.
+	 * @return array|WP_Error The term IDs on success, WP_Error on failure.
+	 */
+	public static function get_or_create_term_ids( $terms, $taxonomy ) {
+		$ignored_taxonomies = Content_Distribution_Class::get_ignored_taxonomies();
+
+		$term_ids = [];
+
+		foreach ( $terms as $term_data ) {
+			$term_id = self::recursively_get_and_create_term_id( $term_data['name'], $taxonomy );
+
+			if ( is_wp_error( $term_id ) ) {
+				return $term_id;
+			}
+
+			if ( $term_id ) {
+				$term_ids[] = $term_id;
+			}
+		}
+
+		return $term_ids;
+	}
+
+	/**
+	 * Recursively get and create term ID.
+	 *
+	 * Given a term name, this function will recursively get the term ID.
+	 * If the term does not exist, it will be created, unless the taxonomy is
+	 * in the list of taxonomies that should only have terms that already exist.
+	 *
+	 * @param string $term_name The term name.
+	 * @param string $taxonomy The taxonomy.
+	 * @return int|false|WP_Error The term ID on success, false if the term does not exist and should not be created, WP_Error on failure.
+	 */
+	public static function recursively_get_and_create_term_id( $term_name, $taxonomy ) {
+
+		$term_name_parts = explode( self::SEPARATOR, $term_name );
+		$parent = 0;
+		$term_id = false;
+
+		foreach ( $term_name_parts as $term_name_part ) {
+			$found_terms = get_terms(
+				[
+					'name'       => $term_name_part,
+					'taxonomy'   => $taxonomy,
+					'hide_empty' => false,
+					'parent'     => $parent,
+					'fields'     => 'ids',
+				]
+			);
+
+			if ( empty( $found_terms ) ) {
+
+				// If the taxonomy is in the list of taxonomies that should only
+				// have terms that already exist, skip the term creation.
+				if ( in_array( $taxonomy, Content_Distribution_Class::get_existing_terms_only_taxonomies(), true ) ) {
+					$term_id = false;
+					break;
+				}
+
+				$term = wp_insert_term( $term_name_part, $taxonomy, [ 'parent' => $parent ] );
+				if ( is_wp_error( $term ) ) {
+					return new \WP_Error( 'error_creating_term', 'Failed to insert term ' . $term_name_part . ' for taxonomy ' . $taxonomy . ' with message: ' . $term->get_error_message() );
+				}
+
+				$term_id = $term['term_id'];
+				$parent = $term_id;
+			} else {
+				$term_id = $found_terms[0];
+				$parent = $term_id;
+			}
+		}
+
+		return $term_id;
+	}
+}

--- a/includes/content-distribution/class-yoast-primary-cat.php
+++ b/includes/content-distribution/class-yoast-primary-cat.php
@@ -17,7 +17,7 @@ class Yoast_Primary_Cat {
 	 *
 	 * @var string
 	 */
-	const PRIMARY_CAT_SLUG_META_NAME = '_newspack_network_primary_cat_slug';
+	const PRIMARY_CAT_NAME_META_NAME = '_newspack_network_primary_cat_name';
 
 	/**
 	 * Initialize the class.
@@ -46,7 +46,7 @@ class Yoast_Primary_Cat {
 		if ( $category_id ) {
 			$category = get_term( $category_id );
 			if ( $category instanceof \WP_Term ) {
-				$meta[ self::PRIMARY_CAT_SLUG_META_NAME ] = [ $category->slug ];
+				$meta[ self::PRIMARY_CAT_NAME_META_NAME ] = [ Taxonomy_Terms::recursively_get_term_name( $category ) ];
 			}
 		}
 
@@ -70,18 +70,17 @@ class Yoast_Primary_Cat {
 			return;
 		}
 
-		$primary_cat_slug = get_post_meta( $post_id, self::PRIMARY_CAT_SLUG_META_NAME, true );
-		if ( ! $primary_cat_slug ) {
+		$primary_cat_name = get_post_meta( $post_id, self::PRIMARY_CAT_NAME_META_NAME, true );
+		if ( ! $primary_cat_name ) {
 			return;
 		}
 
-		// get term by slug.
-		$term = get_term_by( 'slug', $primary_cat_slug, 'category' );
-		if ( ! $term ) {
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( $primary_cat_name, 'category' );
+		if ( is_wp_error( $term_id ) ) {
 			return;
 		}
 
 		$primary_term = new \WPSEO_Primary_Term( 'category', $post_id );
-		$primary_term->set_primary_term( $term->term_id );
+		$primary_term->set_primary_term( $term_id );
 	}
 }

--- a/tests/unit-tests/content-distribution/test-taxonomy-terms.php
+++ b/tests/unit-tests/content-distribution/test-taxonomy-terms.php
@@ -1,0 +1,677 @@
+<?php
+/**
+ * Class TestTaxonomyTerms
+ *
+ * @package Newspack_Network
+ */
+
+namespace Test\Content_Distribution;
+
+use Newspack_Network\Content_Distribution\Taxonomy_Terms;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Test the Taxonomy_Terms class.
+ */
+class TestTaxonomyTerms extends \WP_UnitTestCase {
+
+	/**
+	 * The Taxonomy_Terms instance.
+	 *
+	 * @var Taxonomy_Terms
+	 */
+	protected $taxonomy_terms;
+
+	/**
+	 * Test get_post_taxonomy_terms with basic terms.
+	 */
+	public function test_get_post_taxonomy_terms_basic() {
+		// Create a post.
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Test Post' ] );
+		$post = get_post( $post_id );
+
+		// Create categories and tags.
+		$category_1 = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Category 1',
+			]
+		);
+		$category_2 = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Category 2',
+			]
+		);
+		$tag_1 = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name'     => 'Tag 1',
+			]
+		);
+		$tag_2 = $this->factory->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name'     => 'Tag 2',
+			]
+		);
+
+		// Assign terms to the post.
+		wp_set_post_terms( $post_id, [ $category_1, $category_2 ], 'category' );
+		wp_set_post_terms( $post_id, [ $tag_1, $tag_2 ], 'post_tag' );
+
+		// Get taxonomy terms.
+		$terms = Taxonomy_Terms::get_post_taxonomy_terms( $post );
+
+		// Assert categories.
+		$this->assertArrayHasKey( 'category', $terms );
+		$this->assertCount( 2, $terms['category'] );
+		$this->assertSame( 'Category 1', $terms['category'][0]['name'] );
+		$this->assertSame( 'category-1', $terms['category'][0]['slug'] );
+		$this->assertSame( 'Category 2', $terms['category'][1]['name'] );
+		$this->assertSame( 'category-2', $terms['category'][1]['slug'] );
+
+		// Assert tags.
+		$this->assertArrayHasKey( 'post_tag', $terms );
+		$this->assertCount( 2, $terms['post_tag'] );
+		$this->assertSame( 'Tag 1', $terms['post_tag'][0]['name'] );
+		$this->assertSame( 'tag-1', $terms['post_tag'][0]['slug'] );
+		$this->assertSame( 'Tag 2', $terms['post_tag'][1]['name'] );
+		$this->assertSame( 'tag-2', $terms['post_tag'][1]['slug'] );
+	}
+
+	/**
+	 * Test get_post_taxonomy_terms with hierarchical terms.
+	 */
+	public function test_get_post_taxonomy_terms_hierarchical() {
+		// Create a post.
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Test Post' ] );
+		$post = get_post( $post_id );
+
+		// Create parent and child categories.
+		$parent_category = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Parent Category',
+				'slug'     => 'parent-category',
+			]
+		);
+		$child_category = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Child Category',
+				'slug'     => 'child-category',
+				'parent'   => $parent_category,
+			]
+		);
+		$grandchild_category = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Grandchild Category',
+				'slug'     => 'grandchild-category',
+				'parent'   => $child_category,
+			]
+		);
+
+		// Assign the grandchild category to the post.
+		wp_set_post_terms( $post_id, [ $grandchild_category ], 'category' );
+
+		// Get taxonomy terms.
+		$terms = Taxonomy_Terms::get_post_taxonomy_terms( $post );
+
+		// Assert hierarchical category name.
+		$this->assertArrayHasKey( 'category', $terms );
+		$this->assertCount( 1, $terms['category'] );
+		$expected_name = 'Parent Category' . Taxonomy_Terms::SEPARATOR . 'Child Category' . Taxonomy_Terms::SEPARATOR . 'Grandchild Category';
+		$this->assertSame( $expected_name, $terms['category'][0]['name'] );
+		$this->assertSame( 'grandchild-category', $terms['category'][0]['slug'] );
+	}
+
+	/**
+	 * Test get_post_taxonomy_terms with ignored taxonomies.
+	 */
+	public function test_get_post_taxonomy_terms_ignored_taxonomies() {
+		// Create a post.
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Test Post' ] );
+		$post = get_post( $post_id );
+
+		// Register a custom taxonomy.
+		register_taxonomy( 'test_taxonomy', 'post', [ 'public' => true ] );
+
+		// Create terms.
+		$category = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Test Category',
+			]
+		);
+		$custom_term = $this->factory->term->create(
+			[
+				'taxonomy' => 'test_taxonomy',
+				'name'     => 'Test Custom Term',
+			]
+		);
+
+		// Assign terms to the post.
+		wp_set_post_terms( $post_id, [ $category ], 'category' );
+		wp_set_post_terms( $post_id, [ $custom_term ], 'test_taxonomy' );
+
+		// Mock the ignored taxonomies filter.
+		add_filter(
+			'newspack_network_content_distribution_ignored_taxonomies',
+			function( $taxonomies ) {
+				$taxonomies[] = 'test_taxonomy';
+				return $taxonomies;
+			}
+		);
+
+		// Get taxonomy terms.
+		$terms = Taxonomy_Terms::get_post_taxonomy_terms( $post );
+
+		// Assert that category is included but test_taxonomy is ignored.
+		$this->assertArrayHasKey( 'category', $terms );
+		$this->assertArrayNotHasKey( 'test_taxonomy', $terms );
+	}
+
+	/**
+	 * Test get_post_taxonomy_terms with non-public taxonomies.
+	 */
+	public function test_get_post_taxonomy_terms_non_public_taxonomies() {
+		// Create a post.
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Test Post' ] );
+		$post = get_post( $post_id );
+
+		// Register a non-public taxonomy.
+		register_taxonomy( 'private_taxonomy', 'post', [ 'public' => false ] );
+
+		// Create terms.
+		$category = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Test Category',
+			]
+		);
+		$private_term = $this->factory->term->create(
+			[
+				'taxonomy' => 'private_taxonomy',
+				'name'     => 'Private Term',
+			]
+		);
+
+		// Assign terms to the post.
+		wp_set_post_terms( $post_id, [ $category ], 'category' );
+		wp_set_post_terms( $post_id, [ $private_term ], 'private_taxonomy' );
+
+		// Get taxonomy terms.
+		$terms = Taxonomy_Terms::get_post_taxonomy_terms( $post );
+
+		// Assert that category is included but private_taxonomy is not.
+		$this->assertArrayHasKey( 'category', $terms );
+		$this->assertArrayNotHasKey( 'private_taxonomy', $terms );
+	}
+
+	/**
+	 * Test recursively_get_term_name with single term.
+	 */
+	public function test_recursively_get_term_name_single() {
+		// Create a single term.
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Single Term',
+				'slug'     => 'single-term',
+			]
+		);
+		$term = get_term( $term_id );
+
+		// Get the term name.
+		$name = Taxonomy_Terms::recursively_get_term_name( $term );
+
+		// Assert the name.
+		$this->assertSame( 'Single Term', $name );
+	}
+
+	/**
+	 * Test recursively_get_term_name with hierarchical terms.
+	 */
+	public function test_recursively_get_term_name_hierarchical() {
+		// Create parent term.
+		$parent_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Parent Term',
+				'slug'     => 'parent-term',
+			]
+		);
+
+		// Create child term.
+		$child_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Child Term',
+				'slug'     => 'child-term',
+				'parent'   => $parent_id,
+			]
+		);
+
+		// Create grandchild term.
+		$grandchild_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Grandchild Term',
+				'slug'     => 'grandchild-term',
+				'parent'   => $child_id,
+			]
+		);
+
+		$grandchild_term = get_term( $grandchild_id );
+
+		// Get the hierarchical term name.
+		$name = Taxonomy_Terms::recursively_get_term_name( $grandchild_term );
+
+		// Assert the hierarchical name.
+		$expected_name = 'Parent Term' . Taxonomy_Terms::SEPARATOR . 'Child Term' . Taxonomy_Terms::SEPARATOR . 'Grandchild Term';
+		$this->assertSame( $expected_name, $name );
+	}
+
+	/**
+	 * Test recursively_get_term_name with two-level hierarchy.
+	 */
+	public function test_recursively_get_term_name_two_levels() {
+		// Create parent term.
+		$parent_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Parent Term',
+				'slug'     => 'parent-term',
+			]
+		);
+
+		// Create child term.
+		$child_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Child Term',
+				'slug'     => 'child-term',
+				'parent'   => $parent_id,
+			]
+		);
+
+		$child_term = get_term( $child_id );
+
+		// Get the hierarchical term name.
+		$name = Taxonomy_Terms::recursively_get_term_name( $child_term );
+
+		// Assert the hierarchical name.
+		$expected_name = 'Parent Term' . Taxonomy_Terms::SEPARATOR . 'Child Term';
+		$this->assertSame( $expected_name, $name );
+	}
+
+	/**
+	 * Test the SEPARATOR constant.
+	 */
+	public function test_separator_constant() {
+		$this->assertSame( '|--|', Taxonomy_Terms::SEPARATOR );
+	}
+
+	/**
+	 * Test get_or_create_term_ids with existing terms.
+	 */
+	public function test_get_or_create_term_ids_existing_terms() {
+		// Create existing terms.
+		$category_1_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Existing Category 1',
+				'slug'     => 'existing-category-1',
+			]
+		);
+		$category_2_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Existing Category 2',
+				'slug'     => 'existing-category-2',
+			]
+		);
+
+		// Prepare terms data.
+		$terms = [
+			[
+				'name' => 'Existing Category 1',
+				'slug' => 'existing-category-1',
+			],
+			[
+				'name' => 'Existing Category 2',
+				'slug' => 'existing-category-2',
+			],
+		];
+
+		// Get term IDs.
+		$term_ids = Taxonomy_Terms::get_or_create_term_ids( $terms, 'category' );
+
+		// Assert that the correct term IDs are returned.
+		$this->assertIsArray( $term_ids );
+		$this->assertCount( 2, $term_ids );
+		$this->assertContains( $category_1_id, $term_ids );
+		$this->assertContains( $category_2_id, $term_ids );
+	}
+
+	/**
+	 * Test get_or_create_term_ids with new terms.
+	 */
+	public function test_get_or_create_term_ids_new_terms() {
+		// Prepare terms data for new terms.
+		$terms = [
+			[
+				'name' => 'New Category 1',
+				'slug' => 'new-category-1',
+			],
+			[
+				'name' => 'New Category 2',
+				'slug' => 'new-category-2',
+			],
+		];
+
+		// Get term IDs (should create new terms).
+		$term_ids = Taxonomy_Terms::get_or_create_term_ids( $terms, 'category' );
+
+		// Assert that term IDs are returned.
+		$this->assertIsArray( $term_ids );
+		$this->assertCount( 2, $term_ids );
+
+		// Verify that the terms were actually created.
+		$term_1 = get_term_by( 'name', 'New Category 1', 'category' );
+		$term_2 = get_term_by( 'name', 'New Category 2', 'category' );
+
+		$this->assertNotFalse( $term_1 );
+		$this->assertNotFalse( $term_2 );
+		$this->assertContains( $term_1->term_id, $term_ids );
+		$this->assertContains( $term_2->term_id, $term_ids );
+	}
+
+	/**
+	 * Test get_or_create_term_ids with hierarchical terms.
+	 */
+	public function test_get_or_create_term_ids_hierarchical() {
+		// Prepare hierarchical terms data.
+		$terms = [
+			[
+				'name' => 'Parent Category' . Taxonomy_Terms::SEPARATOR . 'Child Category',
+				'slug' => 'child-category',
+			],
+		];
+
+		// Get term IDs (should create hierarchical terms).
+		$term_ids = Taxonomy_Terms::get_or_create_term_ids( $terms, 'category' );
+
+		// Assert that term ID is returned.
+		$this->assertIsArray( $term_ids );
+		$this->assertCount( 1, $term_ids );
+
+		// Verify that both parent and child terms were created.
+		$parent_term = get_term_by( 'name', 'Parent Category', 'category' );
+		$child_term = get_term_by( 'name', 'Child Category', 'category' );
+
+		$this->assertNotFalse( $parent_term );
+		$this->assertNotFalse( $child_term );
+		$this->assertSame( $parent_term->term_id, $child_term->parent );
+		$this->assertContains( $child_term->term_id, $term_ids );
+	}
+
+	/**
+	 * Test get_or_create_term_ids with existing terms only taxonomy.
+	 */
+	public function test_get_or_create_term_ids_existing_terms_only() {
+		// Register a custom taxonomy.
+		register_taxonomy( 'existing_only_tax', 'post', [ 'public' => true ] );
+
+		// Add the taxonomy to the existing terms only list.
+		add_filter(
+			'newspack_network_content_distribution_existing_terms_only_taxonomies',
+			function( $taxonomies ) {
+				$taxonomies[] = 'existing_only_tax';
+				return $taxonomies;
+			}
+		);
+
+		// Prepare terms data for non-existent terms.
+		$terms = [
+			[
+				'name' => 'Non-existent Term',
+				'slug' => 'non-existent-term',
+			],
+		];
+
+		// Get term IDs (should not create new terms).
+		$term_ids = Taxonomy_Terms::get_or_create_term_ids( $terms, 'existing_only_tax' );
+
+		// Assert that no term IDs are returned.
+		$this->assertIsArray( $term_ids );
+		$this->assertEmpty( $term_ids );
+
+		// Verify that the term was not created.
+		$term = get_term_by( 'name', 'Non-existent Term', 'existing_only_tax' );
+		$this->assertFalse( $term );
+	}
+
+	/**
+	 * Test recursively_get_and_create_term_id with single term.
+	 */
+	public function test_recursively_get_and_create_term_id_single() {
+		// Test with non-existent term.
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( 'New Single Term', 'category' );
+
+		// Assert that a term ID is returned.
+		$this->assertIsInt( $term_id );
+		$this->assertGreaterThan( 0, $term_id );
+
+		// Verify that the term was created.
+		$term = get_term( $term_id );
+		$this->assertSame( 'New Single Term', $term->name );
+		$this->assertSame( 'category', $term->taxonomy );
+		$this->assertSame( 0, $term->parent );
+	}
+
+	/**
+	 * Test recursively_get_and_create_term_id with existing term.
+	 */
+	public function test_recursively_get_and_create_term_id_existing() {
+		// Create an existing term.
+		$existing_term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Existing Term',
+				'slug'     => 'existing-term',
+			]
+		);
+
+		// Get the term ID.
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( 'Existing Term', 'category' );
+
+		// Assert that the existing term ID is returned.
+		$this->assertSame( $existing_term_id, $term_id );
+	}
+
+	/**
+	 * Test recursively_get_and_create_term_id with hierarchical terms.
+	 */
+	public function test_recursively_get_and_create_term_id_hierarchical() {
+		// Test with hierarchical term name.
+		$hierarchical_name = 'Parent Term' . Taxonomy_Terms::SEPARATOR . 'Child Term' . Taxonomy_Terms::SEPARATOR . 'Grandchild Term';
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( $hierarchical_name, 'category' );
+
+		// Assert that a term ID is returned.
+		$this->assertIsInt( $term_id );
+		$this->assertGreaterThan( 0, $term_id );
+
+		// Verify the hierarchy was created correctly.
+		$grandchild_term = get_term( $term_id );
+		$this->assertSame( 'Grandchild Term', $grandchild_term->name );
+
+		$child_term = get_term( $grandchild_term->parent );
+		$this->assertSame( 'Child Term', $child_term->name );
+
+		$parent_term = get_term( $child_term->parent );
+		$this->assertSame( 'Parent Term', $parent_term->name );
+		$this->assertSame( 0, $parent_term->parent );
+	}
+
+	/**
+	 * Test recursively_get_and_create_term_id with hierarchical terms.
+	 */
+	public function test_recursively_get_and_create_term_id_hierarchical_parent_exists() {
+		// Create an existing term.
+		$existing_term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Parent Term',
+				'slug'     => 'parent-term',
+			]
+		);
+
+		// Test with hierarchical term name.
+		$hierarchical_name = 'Parent Term' . Taxonomy_Terms::SEPARATOR . 'Child Term' . Taxonomy_Terms::SEPARATOR . 'Grandchild Term';
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( $hierarchical_name, 'category' );
+
+		// Assert that a term ID is returned.
+		$this->assertIsInt( $term_id );
+		$this->assertGreaterThan( 0, $term_id );
+
+		// Verify the hierarchy was created correctly.
+		$grandchild_term = get_term( $term_id );
+		$this->assertSame( 'Grandchild Term', $grandchild_term->name );
+
+		$child_term = get_term( $grandchild_term->parent );
+		$this->assertSame( 'Child Term', $child_term->name );
+
+		$parent_term = get_term( $child_term->parent );
+		$this->assertSame( 'Parent Term', $parent_term->name );
+		$this->assertSame( 0, $parent_term->parent );
+	}
+
+	/**
+	 * Test recursively_get_and_create_term_id with partially existing hierarchy.
+	 */
+	public function test_recursively_get_and_create_term_id_partial_hierarchy() {
+		// Create a parent term.
+		$parent_term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Existing Parent',
+				'slug'     => 'existing-parent',
+			]
+		);
+
+		// Test with hierarchical term name where parent exists.
+		$hierarchical_name = 'Existing Parent' . Taxonomy_Terms::SEPARATOR . 'New Child';
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( $hierarchical_name, 'category' );
+
+		// Assert that a term ID is returned.
+		$this->assertIsInt( $term_id );
+		$this->assertGreaterThan( 0, $term_id );
+
+		// Verify the child was created with correct parent.
+		$child_term = get_term( $term_id );
+		$this->assertSame( 'New Child', $child_term->name );
+		$this->assertSame( $parent_term_id, $child_term->parent );
+	}
+
+	/**
+	 * Test recursively_get_and_create_term_id with existing terms only taxonomy.
+	 */
+	public function test_recursively_get_and_create_term_id_existing_only() {
+		// Register a custom taxonomy.
+		register_taxonomy( 'existing_only_tax', 'post', [ 'public' => true ] );
+
+		// Add the taxonomy to the existing terms only list.
+		add_filter(
+			'newspack_network_content_distribution_existing_terms_only_taxonomies',
+			function( $taxonomies ) {
+				$taxonomies[] = 'existing_only_tax';
+				return $taxonomies;
+			}
+		);
+
+		// Test with non-existent term.
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( 'Non-existent Term', 'existing_only_tax' );
+
+		// Assert that false is returned.
+		$this->assertFalse( $term_id );
+
+		// Verify that the term was not created.
+		$term = get_term_by( 'name', 'Non-existent Term', 'existing_only_tax' );
+		$this->assertFalse( $term );
+	}
+
+	/**
+	 * Test recursively_get_and_create_term_id with existing terms only taxonomy and existing term.
+	 */
+	public function test_recursively_get_and_create_term_id_existing_only_with_existing_term() {
+		// Register a custom taxonomy.
+		register_taxonomy( 'existing_only_tax', 'post', [ 'public' => true ] );
+
+		// Add the taxonomy to the existing terms only list.
+		add_filter(
+			'newspack_network_content_distribution_existing_terms_only_taxonomies',
+			function( $taxonomies ) {
+				$taxonomies[] = 'existing_only_tax';
+				return $taxonomies;
+			}
+		);
+
+		// Create an existing term.
+		$existing_term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'existing_only_tax',
+				'name'     => 'Existing Term',
+				'slug'     => 'existing-term',
+			]
+		);
+
+		// Test with existing term.
+		$term_id = Taxonomy_Terms::recursively_get_and_create_term_id( 'Existing Term', 'existing_only_tax' );
+
+		// Assert that the existing term ID is returned.
+		$this->assertSame( $existing_term_id, $term_id );
+	}
+
+	/**
+	 * Test get_or_create_term_ids with mixed existing and new terms.
+	 */
+	public function test_get_or_create_term_ids_mixed() {
+		// Create one existing term.
+		$existing_term_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Existing Category',
+				'slug'     => 'existing-category',
+			]
+		);
+
+		// Prepare mixed terms data.
+		$terms = [
+			[
+				'name' => 'Existing Category',
+				'slug' => 'existing-category',
+			],
+			[
+				'name' => 'New Category',
+				'slug' => 'new-category',
+			],
+		];
+
+		// Get term IDs.
+		$term_ids = Taxonomy_Terms::get_or_create_term_ids( $terms, 'category' );
+
+		// Assert that both term IDs are returned.
+		$this->assertIsArray( $term_ids );
+		$this->assertCount( 2, $term_ids );
+		$this->assertContains( $existing_term_id, $term_ids );
+
+		// Verify that the new term was created.
+		$new_term = get_term_by( 'name', 'New Category', 'category' );
+		$this->assertNotFalse( $new_term );
+		$this->assertContains( $new_term->term_id, $term_ids );
+	}
+}

--- a/tests/unit-tests/content-distribution/test-yoast-primary-cat.php
+++ b/tests/unit-tests/content-distribution/test-yoast-primary-cat.php
@@ -21,7 +21,7 @@ class TestYoastPrimaryCat extends \WP_UnitTestCase {
 	/**
 	 * Test category slug used in the test. It's part of the sample payload.
 	 */
-	const TEST_CATEGORY_SLUG = 'category-2';
+	const TEST_CATEGORY_NAME = 'category-2';
 
 	/**
 	 * Test the outgoing post.
@@ -29,7 +29,7 @@ class TestYoastPrimaryCat extends \WP_UnitTestCase {
 	public function test_outgoing_post() {
 		$post_id = self::factory()->post->create();
 
-		$category_id = self::factory()->category->create( [ 'slug' => self::TEST_CATEGORY_SLUG ] );
+		$category_id = self::factory()->category->create( [ 'name' => self::TEST_CATEGORY_NAME ] );
 
 		$primary_term = new \WPSEO_Primary_Term( 'category', $post_id );
 		$primary_term->set_primary_term( $category_id );
@@ -38,10 +38,10 @@ class TestYoastPrimaryCat extends \WP_UnitTestCase {
 
 		$outgoing_meta = $outgoing_post->get_payload()['post_data']['post_meta'];
 
-		$meta_name = Yoast_Primary_Cat::PRIMARY_CAT_SLUG_META_NAME;
+		$meta_name = Yoast_Primary_Cat::PRIMARY_CAT_NAME_META_NAME;
 
 		$this->assertArrayHasKey( $meta_name, $outgoing_meta );
-		$this->assertEquals( self::TEST_CATEGORY_SLUG, $outgoing_meta[ $meta_name ][0], 'The primary category slug should be part of the outgoing post meta' );
+		$this->assertEquals( self::TEST_CATEGORY_NAME, $outgoing_meta[ $meta_name ][0], 'The primary category name should be part of the outgoing post meta' );
 	}
 
 	/**
@@ -54,9 +54,9 @@ class TestYoastPrimaryCat extends \WP_UnitTestCase {
 		update_option( 'siteurl', 'https://node2.test' );
 		update_option( 'home', 'https://node2.test' );
 
-		$meta_name = Yoast_Primary_Cat::PRIMARY_CAT_SLUG_META_NAME;
+		$meta_name = Yoast_Primary_Cat::PRIMARY_CAT_NAME_META_NAME;
 
-		$payload['post_data']['post_meta'][ $meta_name ] = [ self::TEST_CATEGORY_SLUG ];
+		$payload['post_data']['post_meta'][ $meta_name ] = [ self::TEST_CATEGORY_NAME ];
 
 		$incoming_post = new Incoming_Post( $payload );
 
@@ -67,6 +67,6 @@ class TestYoastPrimaryCat extends \WP_UnitTestCase {
 
 		$primary_term_category = get_term( $primary_term_id, 'category' );
 
-		$this->assertEquals( self::TEST_CATEGORY_SLUG, $primary_term_category->slug, 'The primary category should be correctly set in the created post' );
+		$this->assertEquals( self::TEST_CATEGORY_NAME, $primary_term_category->name, 'The primary category should be correctly set in the created post' );
 	}
 }


### PR DESCRIPTION
This PR makes Content Distribution account for taxonomy hierarchy

## Testing

* Test distributing posts and assigning categories nested under other categories
* Test it with both categories that exist and don't exist in the destination site
* The whole hierarchy should be recreated in the target site
* Also confirm that the Yoast's primary category is correctly assigned when hierarchy is involved