### PR TITLE
feat(story-budget): manage field syncing and props

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -53,6 +53,7 @@ class Content_Distribution {
 		add_filter( 'newspack_webhooks_request_priority', [ __CLASS__, 'webhooks_request_priority' ], 10, 2 );
 		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_short_circuit_distributed_meta' ], 10, 4 );
 		add_action( 'wp_after_insert_post', [ __CLASS__, 'handle_post_updated' ] );
+		add_action( 'set_object_terms', [ __CLASS__, 'handle_post_updated' ] );
 		add_action( 'updated_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'added_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );
 		add_action( 'deleted_post_meta', [ __CLASS__, 'handle_postmeta_update' ], 10, 3 );

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -324,7 +324,7 @@ class Story_Budget {
 		}
 
 		// Disable editing of network sites if the post is incoming.
-		$fields_props[ self::SITES_FIELD_SLUG ]['can_edit'] = false;
+		$fields_props[ self::SITES_FIELD_SLUG ]['is_editable'] = false;
 
 		return $fields_props;
 	}
@@ -356,7 +356,7 @@ class Story_Budget {
 			if ( ! isset( $fields_props[ $field_slug ] ) ) {
 				$fields_props[ $field_slug ] = [];
 			}
-			$fields_props[ $field_slug ]['can_edit'] = false;
+			$fields_props[ $field_slug ]['is_editable'] = false;
 		}
 
 		return $fields_props;

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -48,35 +48,6 @@ class Story_Budget {
 	}
 
 	/**
-	 * Filter the ignored post meta keys.
-	 *
-	 * @param array $ignored_keys The ignored post meta keys.
-	 *
-	 * @return array The ignored post meta keys.
-	 */
-	public static function filter_ignored_post_meta_keys( $ignored_keys ) {
-		// Bail if Newspack Story Budget is not active.
-		if ( ! class_exists( 'Newspack_Story_Budget\Fields' ) ) {
-			return $ignored_keys;
-		}
-
-		$fields = Fields::get_all_fields();
-		$ignored_fields = array_map(
-			function( $field ) {
-				$slug = $field->get_slug();
-				if ( ! in_array( $slug, self::$synced_fields, true ) ) {
-					return $field->get_post_meta_name();
-				}
-				return null;
-			},
-			$fields
-		);
-		$ignored_fields = array_filter( $ignored_fields );
-
-		return array_merge( $ignored_keys, $ignored_fields );
-	}
-
-	/**
 	 * Enqueue assets.
 	 */
 	public static function enqueue_assets() {
@@ -115,6 +86,36 @@ class Story_Budget {
 	public static function add_cors_headers( $headers ) {
 		$headers[] = 'X-Network-Site-Url';
 		return $headers;
+	}
+
+	/**
+	 * Filter the ignored post meta keys to include Story Budget fields that are
+	 * not intentionally synced.
+	 *
+	 * @param array $ignored_keys The ignored post meta keys.
+	 *
+	 * @return array The ignored post meta keys.
+	 */
+	public static function filter_ignored_post_meta_keys( $ignored_keys ) {
+		// Bail if Newspack Story Budget is not active.
+		if ( ! class_exists( 'Newspack_Story_Budget\Fields' ) ) {
+			return $ignored_keys;
+		}
+
+		$fields = Fields::get_all_fields();
+		$ignored_fields = array_map(
+			function( $field ) {
+				$slug = $field->get_slug();
+				if ( ! in_array( $slug, self::$synced_fields, true ) ) {
+					return $field->get_post_meta_name();
+				}
+				return null;
+			},
+			$fields
+		);
+		$ignored_fields = array_filter( $ignored_fields );
+
+		return array_merge( $ignored_keys, $ignored_fields );
 	}
 
 	/**

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -77,22 +77,6 @@ class Story_Budget {
 	}
 
 	/**
-	 * Filter whether the user can edit a field.
-	 *
-	 * @param bool           $user_can_edit Whether the user can edit the field.
-	 * @param Editable_Field $field         The field.
-	 * @param int            $user_id       The user ID.
-	 *
-	 * @return bool Whether the user can edit the field.
-	 */
-	public static function filter_user_can_edit_field( $user_can_edit, $field, $user_id ) {
-		if ( in_array( $field->get_slug(), self::$synced_fields, true ) ) {
-			return false;
-		}
-		return $user_can_edit;
-	}
-
-	/**
 	 * Enqueue assets.
 	 */
 	public static function enqueue_assets() {

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -40,7 +40,7 @@ class Story_Budget {
 		add_filter( 'rest_allowed_cors_headers', [ __CLASS__, 'add_cors_headers' ] );
 		add_filter( 'newspack_network_content_distribution_ignored_post_meta_keys', [ __CLASS__, 'filter_ignored_post_meta_keys' ] );
 
-		add_filter( 'newspack_story_budget_fields', [ __CLASS__, 'add_fields' ] );
+		add_filter( 'newspack_story_budget_fields', [ __CLASS__, 'add_sites_field' ] );
 		add_filter( 'newspack_story_budget_story_metadata', [ __CLASS__, 'add_story_remote_metadata' ], 10, 2 );
 		add_filter( 'newspack_story_budget_fields_props', [ __CLASS__, 'add_outgoing_post_network_sites_props' ], 10, 2 );
 		add_filter( 'newspack_story_budget_fields_props', [ __CLASS__, 'add_incoming_post_network_sites_props' ], 10, 2 );
@@ -119,12 +119,12 @@ class Story_Budget {
 	}
 
 	/**
-	 * Add fields to the Newspack Story Budget.
+	 * Add the sites field to Story Budget.
 	 *
 	 * @param array $fields The fields to add.
 	 * @return array The fields to add.
 	 */
-	public static function add_fields( $fields ) {
+	public static function add_sites_field( $fields ) {
 		$sites_list = self::get_sites_list();
 		if ( empty( $sites_list ) ) {
 			return $fields;

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -12,20 +12,84 @@ use Newspack_Network\Hub\Nodes;
 use Newspack_Network\Node\Settings as Node_Settings;
 use Newspack_Network\Content_Distribution;
 use Newspack_Network\Content_Distribution\Outgoing_Post;
+use Newspack_Network\Content_Distribution\Incoming_Post;
+
+use Newspack_Story_Budget\Fields;
+use Newspack_Story_Budget\Fields\Editable_Field;
 
 /**
  * Story Budget Integration Class.
  */
 class Story_Budget {
+	const SITES_FIELD_SLUG = 'network_sites';
+
+	/**
+	 * Story Budget fields that are synced on distribution.
+	 *
+	 * @var array
+	 */
+	private static $synced_fields = [
+		'status',
+	];
+
 	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 9 );
 		add_filter( 'rest_allowed_cors_headers', [ __CLASS__, 'add_cors_headers' ] );
+		add_filter( 'newspack_network_content_distribution_ignored_post_meta_keys', [ __CLASS__, 'filter_ignored_post_meta_keys' ] );
+
 		add_filter( 'newspack_story_budget_fields', [ __CLASS__, 'add_fields' ] );
 		add_filter( 'newspack_story_budget_story_metadata', [ __CLASS__, 'add_story_remote_metadata' ], 10, 2 );
-		add_filter( 'newspack_story_budget_fields_props', [ __CLASS__, 'add_fields_props' ], 10, 2 );
+		add_filter( 'newspack_story_budget_fields_props', [ __CLASS__, 'add_outgoing_post_network_sites_props' ], 10, 2 );
+		add_filter( 'newspack_story_budget_fields_props', [ __CLASS__, 'add_incoming_post_network_sites_props' ], 10, 2 );
+		add_filter( 'newspack_story_budget_fields_props', [ __CLASS__, 'add_synced_fields_props' ], 10, 2 );
+	}
+
+	/**
+	 * Filter the ignored post meta keys.
+	 *
+	 * @param array $ignored_keys The ignored post meta keys.
+	 *
+	 * @return array The ignored post meta keys.
+	 */
+	public static function filter_ignored_post_meta_keys( $ignored_keys ) {
+		// Bail if Newspack Story Budget is not active.
+		if ( ! class_exists( 'Newspack_Story_Budget\Fields' ) ) {
+			return $ignored_keys;
+		}
+
+		$fields = Fields::get_all_fields();
+		$ignored_fields = array_map(
+			function( $field ) {
+				$slug = $field->get_slug();
+				if ( ! in_array( $slug, self::$synced_fields, true ) ) {
+					return $field->get_post_meta_name();
+				}
+				return null;
+			},
+			$fields
+		);
+		$ignored_fields = array_filter( $ignored_fields );
+
+		return array_merge( $ignored_keys, $ignored_fields );
+	}
+
+	/**
+	 * Filter whether the user can edit a field.
+	 *
+	 * @param bool           $user_can_edit Whether the user can edit the field.
+	 * @param Editable_Field $field         The field.
+	 * @param int            $user_id       The user ID.
+	 *
+	 * @return bool Whether the user can edit the field.
+	 */
+	public static function filter_user_can_edit_field( $user_can_edit, $field, $user_id ) {
+		if ( in_array( $field->get_slug(), self::$synced_fields, true ) ) {
+			return false;
+		}
+		return $user_can_edit;
 	}
 
 	/**
@@ -89,7 +153,7 @@ class Story_Budget {
 			'is_filterable'      => 'always',
 			'name'               => __( 'Sites', 'newspack-story-budget' ),
 			'show_in_table'      => true,
-			'slug'               => 'network_sites',
+			'slug'               => self::SITES_FIELD_SLUG,
 			'type'               => 'text',
 			'options'            => $sites_list,
 			'default_order'      => 18,
@@ -113,7 +177,31 @@ class Story_Budget {
 			return $distributed_post->get_distribution();
 		}
 
-		$field = \Newspack_Story_Budget\Fields::get_field( 'network_sites' );
+		// If the post is incoming, read the value from the payload.
+		if ( Content_Distribution::is_post_incoming( $post_id ) ) {
+			try {
+				$incoming_post = new Incoming_Post( $post_id );
+				$original_site_url = $incoming_post->get_original_site_url();
+				$payload = $incoming_post->get_post_payload();
+				$sites = array_filter(
+					$payload['sites'],
+					function( $url ) {
+						return $url !== get_site_url();
+					}
+				);
+				return array_unique(
+					array_merge(
+						[ $original_site_url ],
+						$sites
+					)
+				);
+			} catch ( \Exception $e ) {
+				return [];
+			}
+		}
+
+		// Otherwise, read the value from the post meta.
+		$field = \Newspack_Story_Budget\Fields::get_field( self::SITES_FIELD_SLUG );
 		return \get_post_meta( $post_id, $field->get_post_meta_name(), false );
 	}
 
@@ -188,14 +276,14 @@ class Story_Budget {
 	}
 
 	/**
-	 * Add fields props to the Newspack Story Budget.
+	 * Add network sites field props to the Newspack Story Budget for outgoing posts.
 	 *
 	 * @param array $fields_props The fields props to add.
 	 * @param int   $story_id     The story ID.
 	 *
 	 * @return array The fields props to add.
 	 */
-	public static function add_fields_props( $fields_props, $story_id ) {
+	public static function add_outgoing_post_network_sites_props( $fields_props, $story_id ) {
 		$outgoing_post = Content_Distribution::get_distributed_post( $story_id );
 		if ( ! $outgoing_post ) {
 			return $fields_props;
@@ -211,9 +299,65 @@ class Story_Budget {
 			}
 		}
 
-		$fields_props['network_sites'] = [
-			'options' => $options,
-		];
+		if ( ! isset( $fields_props[ self::SITES_FIELD_SLUG ] ) ) {
+			$fields_props[ self::SITES_FIELD_SLUG ] = [];
+		}
+		$fields_props[ self::SITES_FIELD_SLUG ]['options'] = $options;
+
+		return $fields_props;
+	}
+
+	/**
+	 * Add network sites field props to the Newspack Story Budget for incoming posts.
+	 *
+	 * @param array $fields_props The fields props to add.
+	 * @param int   $story_id     The story ID.
+	 *
+	 * @return array The fields props to add.
+	 */
+	public static function add_incoming_post_network_sites_props( $fields_props, $story_id ) {
+		if ( ! Content_Distribution::is_post_incoming( $story_id ) ) {
+			return $fields_props;
+		}
+		if ( ! isset( $fields_props[ self::SITES_FIELD_SLUG ] ) ) {
+			$fields_props[ self::SITES_FIELD_SLUG ] = [];
+		}
+
+		// Disable editing of network sites if the post is incoming.
+		$fields_props[ self::SITES_FIELD_SLUG ]['can_edit'] = false;
+
+		return $fields_props;
+	}
+
+	/**
+	 * Add synced fields props to the Newspack Story Budget.
+	 *
+	 * @param array $fields_props The fields props to add.
+	 * @param int   $story_id     The story ID.
+	 *
+	 * @return array The fields props to add.
+	 */
+	public static function add_synced_fields_props( $fields_props, $story_id ) {
+		if ( ! Content_Distribution::is_post_incoming( $story_id ) ) {
+			return $fields_props;
+		}
+
+		try {
+			$incoming_post = new Incoming_Post( $story_id );
+		} catch ( \Exception $e ) {
+			return $fields_props;
+		}
+		if ( ! $incoming_post->is_linked() ) {
+			return $fields_props;
+		}
+
+		// Disable editing of synced fields.
+		foreach ( self::$synced_fields as $field_slug ) {
+			if ( ! isset( $fields_props[ $field_slug ] ) ) {
+				$fields_props[ $field_slug ] = [];
+			}
+			$fields_props[ $field_slug ]['can_edit'] = false;
+		}
 
 		return $fields_props;
 	}

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -276,7 +276,7 @@ class Story_Budget {
 	}
 
 	/**
-	 * Add network sites field props to the Newspack Story Budget for outgoing posts.
+	 * Add field props to the sites field for outgoing posts.
 	 *
 	 * @param array $fields_props The fields props to add.
 	 * @param int   $story_id     The story ID.
@@ -308,7 +308,7 @@ class Story_Budget {
 	}
 
 	/**
-	 * Add network sites field props to the Newspack Story Budget for incoming posts.
+	 * Add field props to the sites field for incoming posts.
 	 *
 	 * @param array $fields_props The fields props to add.
 	 * @param int   $story_id     The story ID.
@@ -330,7 +330,7 @@ class Story_Budget {
 	}
 
 	/**
-	 * Add synced fields props to the Newspack Story Budget.
+	 * Add fields props for synced fields.
 	 *
 	 * @param array $fields_props The fields props to add.
 	 * @param int   $story_id     The story ID.

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -142,20 +142,24 @@ class Story_Budget {
 			'type'               => 'text',
 			'options'            => $sites_list,
 			'default_order'      => 18,
-			'get_value_callback' => [ __CLASS__, 'get_field_value' ],
+			'get_value_callback' => [ __CLASS__, 'get_sites_field_value' ],
 		];
 
 		return $fields;
 	}
 
 	/**
-	 * Get the value of the field. If the post has been distributed, read the value from the distributed post, otherwise read it from the post meta.
+	 * Get the value of the sites field.
+	 *
+	 * If the post has been distributed, read the value from the distributed post,
+	 * if the post is incoming, read the value from the payload, otherwise read it
+	 * from the post meta.
 	 *
 	 * @param int $post_id The post ID.
 	 *
 	 * @return array The value of the field.
 	 */
-	public static function get_field_value( $post_id ) {
+	public static function get_sites_field_value( $post_id ) {
 		// If the post has been distributed, read the value from the distributed post.
 		$distributed_post = Content_Distribution::get_distributed_post( $post_id );
 		if ( $distributed_post ) {

--- a/includes/class-story-budget.php
+++ b/includes/class-story-budget.php
@@ -29,7 +29,8 @@ class Story_Budget {
 	 * @var array
 	 */
 	private static $synced_fields = [
-		'status',
+		'name',   // Story name.
+		'status', // Story status.
 	];
 
 	/**
@@ -39,6 +40,7 @@ class Story_Budget {
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 9 );
 		add_filter( 'rest_allowed_cors_headers', [ __CLASS__, 'add_cors_headers' ] );
 		add_filter( 'newspack_network_content_distribution_ignored_post_meta_keys', [ __CLASS__, 'filter_ignored_post_meta_keys' ] );
+		add_filter( 'newspack_network_content_distribution_always_distributed_taxonomies', [ __CLASS__, 'filter_always_distributed_taxonomies' ] );
 
 		add_filter( 'newspack_story_budget_fields', [ __CLASS__, 'add_sites_field' ] );
 		add_filter( 'newspack_story_budget_story_metadata', [ __CLASS__, 'add_story_remote_metadata' ], 10, 2 );
@@ -115,7 +117,21 @@ class Story_Budget {
 		);
 		$ignored_fields = array_filter( $ignored_fields );
 
+		$ignored_fields[] = '_np_story_budget__modified';
+
 		return array_merge( $ignored_keys, $ignored_fields );
+	}
+
+	/**
+	 * Filter the always distributed taxonomies to include Story Budget taxonomies.
+	 *
+	 * @param array $always_distributed_taxonomies The always distributed taxonomies.
+	 *
+	 * @return array The always distributed taxonomies.
+	 */
+	public static function filter_always_distributed_taxonomies( $always_distributed_taxonomies ) {
+		$always_distributed_taxonomies[] = 'newspack_story_status';
+		return $always_distributed_taxonomies;
 	}
 
 	/**

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -481,7 +481,10 @@ class Incoming_Post {
 				continue;
 			}
 			if ( $term_ids ) {
-				wp_set_object_terms( $this->ID, $term_ids, $taxonomy );
+				$result = wp_set_object_terms( $this->ID, $term_ids, $taxonomy );
+				if ( is_wp_error( $result ) ) {
+					self::log( 'Failed to set terms for taxonomy ' . $taxonomy . ' with message: ' . $result->get_error_message() );
+				}
 			}
 		}
 	}

--- a/includes/content-distribution/class-taxonomy-terms.php
+++ b/includes/content-distribution/class-taxonomy-terms.php
@@ -35,6 +35,25 @@ class Taxonomy_Terms {
 	}
 
 	/**
+	 * Get taxonomies that should always be distributed.
+	 *
+	 * @return string[] The always distributed taxonomies.
+	 */
+	public static function get_always_distributed_taxonomies() {
+		$always_distributed_taxonomies = [
+			'category', // WordPress core 'category' taxonomy.
+			'post_tag', // WordPress core 'post_tag' taxonomy.
+		];
+
+		/**
+		 * Filters the taxonomies that should always be distributed.
+		 *
+		 * @param string[] $always_distributed_taxonomies The always distributed taxonomies.
+		 */
+		return apply_filters( 'newspack_network_content_distribution_always_distributed_taxonomies', $always_distributed_taxonomies );
+	}
+
+	/**
 	 * Returns a list of taxonomies that should be distributed only if the terms already exist
 	 * in the destination site. Terms from these taxonomies will not be created if they don't exist.
 	 *
@@ -66,7 +85,7 @@ class Taxonomy_Terms {
 			if ( in_array( $taxonomy->name, $ignored_taxonomies, true ) ) {
 				continue;
 			}
-			if ( ! $taxonomy->public ) {
+			if ( ! $taxonomy->public && ! in_array( $taxonomy->name, self::get_always_distributed_taxonomies(), true ) ) {
 				continue;
 			}
 			$terms = get_the_terms( $post->ID, $taxonomy->name );

--- a/src/story-budget/components/local-budgets-control.js
+++ b/src/story-budget/components/local-budgets-control.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+
+export default function LocalBudgetsControl( {
+	value,
+	onChange,
+	disabled,
+	...props
+} ) {
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ localBudgets, setLocalBudgets ] = useState( [] );
+
+	useEffect( () => {
+		const fetchLocalBudgets = async () => {
+			setIsLoading( true );
+			const res = await apiFetch( {
+				path: 'newspack-story-budget/v1/budgets?include_archived=false',
+			} );
+			setLocalBudgets( res.budgets );
+			setIsLoading( false );
+		};
+		fetchLocalBudgets();
+	}, [] );
+
+	return (
+		<SelectControl
+			{ ...props }
+			disabled={ isLoading || disabled }
+			label={ __( 'Budget', 'newspack-network' ) }
+			value={ value }
+			onChange={ onChange }
+			options={ [
+				{
+					label: __( 'Select a budget', 'newspack-network' ),
+					value: '',
+				},
+				...localBudgets.map( budget => ( {
+					label: budget.name,
+					value: budget.id,
+				} ) ),
+			] }
+		/>
+	);
+}

--- a/src/story-budget/components/pull-story.js
+++ b/src/story-budget/components/pull-story.js
@@ -1,6 +1,6 @@
 /* eslint @wordpress/no-unsafe-wp-apis: 0 */
 /**
- * External dependencies.
+ * WordPress dependencies.
  */
 import {
 	__experimentalHStack as HStack,
@@ -11,14 +11,14 @@ import {
 	Button,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, useRef } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies.
  */
-import { useEffect } from 'react';
+import LocalBudgetsControl from './local-budgets-control';
 
 export default function PullStory( { items, closeModal, onActionPerformed } ) {
 	const isBulk = items.length > 1;
@@ -26,6 +26,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 	const [ statusOnPublish, setStatusOnPublish ] = useState( 'draft' );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ errors, setErrors ] = useState( [] );
+	const [ budget, setBudget ] = useState( '' );
 
 	const { fetchStory } = useDispatch( 'newspack-story-budget' );
 
@@ -40,21 +41,27 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 		}
 	}, [ errors ] );
 
-	const pullStory = async ( storyId ) => {
+	const pullStory = async storyId => {
 		const payload = await apiFetch( {
 			isStoryBudget: true,
 			fullPath: `newspack-network/v1/content-distribution/pull/${ storyId }`,
 			method: 'POST',
 			data: { status_on_create: statusOnPublish },
 		} );
-		await apiFetch( {
+		const res = await apiFetch( {
 			path: 'newspack-network/v1/content-distribution/insert',
 			method: 'POST',
 			data: { payload },
 		} );
+		// Set the budget for the story.
+		await apiFetch( {
+			path: `newspack-story-budget/v1/stories/${ res.post_id }/budgets`,
+			method: 'POST',
+			data: { value: [ budget ] },
+		} );
 		// Refetch story so distribution side-effects are reflected in the UI.
 		fetchStory( storyId );
-	}
+	};
 
 	const handleSubmit = ev => {
 		ev.preventDefault();
@@ -68,13 +75,13 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 			.then( () => {
 				closeModal();
 				onActionPerformed?.( items );
-			})
+			} )
 			.catch( error => {
 				setErrors( [ ...errors, error.message ] );
-			})
+			} )
 			.finally( () => {
 				setIsLoading( false );
-			});
+			} );
 	};
 
 	const statusOnPublishOptions = [
@@ -102,7 +109,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 								// translators: %s is the story title.
 								__( 'Pull “%s”', 'newspack-network' ),
 								items[ 0 ].name
-							) }
+						  ) }
 				</Heading>
 
 				{ errors.length > 0 && (
@@ -127,11 +134,20 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 					</div>
 				) }
 
+				<LocalBudgetsControl
+					value={ budget }
+					onChange={ setBudget }
+					disabled={ isLoading }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+
 				<SelectControl
 					label={ __( 'Status on publish', 'newspack-network' ) }
 					value={ statusOnPublish }
 					options={ statusOnPublishOptions }
 					onChange={ setStatusOnPublish }
+					disabled={ isLoading }
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
@@ -139,7 +155,7 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 				<HStack expanded direction="row-reverse" justify="end">
 					<Button
 						variant="primary"
-						disabled={ isLoading }
+						disabled={ isLoading || ! budget }
 						isBusy={ isLoading }
 						type="submit"
 					>
@@ -147,12 +163,9 @@ export default function PullStory( { items, closeModal, onActionPerformed } ) {
 							? __( 'Pull story', 'newspack-network' )
 							: sprintf(
 									// translators: %d is the number of stories.
-									__(
-										'Pull %d stories',
-										'newspack-network'
-									),
+									__( 'Pull %d stories', 'newspack-network' ),
 									items.length
-								) }
+							  ) }
 					</Button>
 					<Button
 						variant="tertiary"


### PR DESCRIPTION
Manage synced and unsynced fields for distributed posts and additional field props control:

 - For incoming posts, synced fields and the `network_sites` field should not be editable
 - All the other fields (unsynced) should be ignored on distribution

### Testing

1. Checkout this branch and https://github.com/Automattic/newspack-story-budget/pull/98
2. Edit a few story fields on a site and distribute that story to multiple sites
3. Visit the Story Budget app in the, edit the "Sites" field and confirm the options are disabled (can't undistribute)
4. Go to one of the destination sites and set a budget for the incoming post
5. View the linked story in the Story Budget app and enable "Edit mode"
6. Confirm the "Status" and "Sites" fields are not editable
7. Confirm that the "Sites" fields render the origin and other destinations (not the current site)
8. Confirm that the field values did not sync
9. Back to the origin site, edit the "Status" field, and wait for distribution
10. Go to the destination site and confirm that the "Status" field updated