### PR TITLE
fix: dont show user acitvity link when misconfigured

### DIFF
--- a/includes/class-users.php
+++ b/includes/class-users.php
@@ -88,7 +88,7 @@ class Users {
 					$event_log_url,
 					__( 'View all', 'newspack-network' )
 				);
-			} else {
+			} elseif ( Site_Role::is_node() ) {
 				$event_log_url = add_query_arg(
 					[
 						'page'  => EVENT_LOG_PAGE_SLUG,


### PR DESCRIPTION
Don't show a broken link to users activity if Network is not configured.

* Activate network plugin
* Dont configure it (leave Site role empty)
* Go to Admin > Users
* Confirm there is no link under the "Network activity" column