### PR TITLE
Network memberships integrity check

### DIFF
--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -39,6 +39,7 @@ class Initializer {
 			if ( Node\Settings::get_hub_url() ) {
 				Node\Webhook::init();
 				Node\Info_Endpoints::init();
+				Node\Integrity_Check_Endpoints::init();
 				Node\Pulling::init();
 				Rest_Authenticaton::init_node_filters();
 			}
@@ -56,6 +57,7 @@ class Initializer {
 		Synchronize_All::init();
 		Data_Backfill::init();
 		Membership_Dedupe::init();
+		CLI\Integrity_Check::init();
 
 		Woocommerce\Events::init();
 		Woocommerce_Subscriptions\My_Account::init();

--- a/includes/class-integrity-check-utils.php
+++ b/includes/class-integrity-check-utils.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Integrity Check utility functions.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network;
+
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+
+/**
+ * Shared utility functions for integrity check operations.
+ */
+class Integrity_Check_Utils {
+
+	/**
+	 * Get all membership data
+	 *
+	 * @param int|null $max_records Maximum number of records to return (for testing).
+	 * @return array Array of (email, status, network_id) data
+	 */
+	public static function get_membership_data( $max_records = null ) {
+		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$query = "
+			SELECT 
+				u.user_email,
+				p.post_status as status,
+				pm_network.meta_value as network_id
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
+			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
+			INNER JOIN (
+				SELECT 
+					p2.post_author,
+					pm2.meta_value,
+					MAX(p2.post_date) as max_date
+				FROM {$wpdb->posts} p2
+				INNER JOIN {$wpdb->postmeta} pm2 ON p2.post_parent = pm2.post_id AND pm2.meta_key = %s
+				WHERE p2.post_type = 'wc_user_membership'
+				AND pm2.meta_value IS NOT NULL
+				AND pm2.meta_value != ''
+				GROUP BY p2.post_author, pm2.meta_value
+			) latest ON p.post_author = latest.post_author 
+				AND pm_network.meta_value = latest.meta_value 
+				AND p.post_date = latest.max_date
+			WHERE p.post_type = 'wc_user_membership'
+			AND pm_network.meta_value IS NOT NULL
+			AND pm_network.meta_value != ''
+			ORDER BY LOWER(u.user_email) ASC
+		";
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		if ( $max_records ) {
+			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, Memberships_Admin::NETWORK_ID_META_KEY ) );
+
+		$membership_data = [];
+		foreach ( $results as $result ) {
+			$membership_data[] = [
+				'email'      => strtolower( $result->user_email ),
+				'status'     => $result->status,
+				'network_id' => $result->network_id,
+			];
+		}
+
+		return $membership_data;
+	}
+
+	/**
+	 * Get membership data within an email range
+	 *
+	 * Filters memberships by email address range rather than positional offset.
+	 * This enables range-based chunking that's resilient to data shifts when
+	 * memberships are added/removed from the beginning or middle of the dataset.
+	 *
+	 * @param string   $start_email The start email (inclusive).
+	 * @param string   $end_email The end email (inclusive).
+	 * @param int|null $max_records Maximum number of records to return (for testing).
+	 * @return array Array of (email, status, network_id) data
+	 */
+	public static function get_membership_data_range( $start_email, $end_email, $max_records = null ) {
+		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$query = "
+			SELECT 
+				u.user_email,
+				p.post_status as status,
+				pm_network.meta_value as network_id
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
+			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
+			INNER JOIN (
+				SELECT 
+					p2.post_author,
+					pm2.meta_value,
+					MAX(p2.post_date) as max_date
+				FROM {$wpdb->posts} p2
+				INNER JOIN {$wpdb->postmeta} pm2 ON p2.post_parent = pm2.post_id AND pm2.meta_key = %s
+				WHERE p2.post_type = 'wc_user_membership'
+				AND pm2.meta_value IS NOT NULL
+				AND pm2.meta_value != ''
+				GROUP BY p2.post_author, pm2.meta_value
+			) latest ON p.post_author = latest.post_author 
+				AND pm_network.meta_value = latest.meta_value 
+				AND p.post_date = latest.max_date
+			WHERE p.post_type = 'wc_user_membership'
+			AND pm_network.meta_value IS NOT NULL
+			AND pm_network.meta_value != ''
+			AND LOWER(u.user_email) >= %s
+			AND LOWER(u.user_email) <= %s
+			ORDER BY LOWER(u.user_email) ASC
+		";
+
+		if ( $max_records ) {
+			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, Memberships_Admin::NETWORK_ID_META_KEY, $start_email, $end_email ) );
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		$membership_data = [];
+		foreach ( $results as $result ) {
+			$membership_data[] = [
+				'email'      => strtolower( $result->user_email ),
+				'status'     => $result->status,
+				'network_id' => $result->network_id,
+			];
+		}
+
+		return $membership_data;
+	}
+
+	/**
+	 * Generate a hash from membership data
+	 *
+	 * @param array $data Array of (email, status, network_id) data.
+	 * @return string SHA-256 hash
+	 */
+	public static function generate_hash( $data ) {
+		if ( empty( $data ) ) {
+			return '';
+		}
+
+		// Create a string representation of the data for hashing.
+		$hash_string = '';
+		foreach ( $data as $item ) {
+			$hash_string .= $item['email'] . ':' . $item['status'] . ':' . $item['network_id'] . "\n";
+		}
+
+		return hash( 'sha256', $hash_string );
+	}
+
+	/**
+	 * Filter membership data by email range
+	 *
+	 * @param array  $data Membership data.
+	 * @param string $start_email Start email (inclusive).
+	 * @param string $end_email End email (inclusive).
+	 * @return array Filtered data
+	 */
+	public static function filter_data_by_range( $data, $start_email, $end_email ) {
+		$filtered = [];
+		$start_email = strtolower( $start_email );
+		$end_email = strtolower( $end_email );
+		
+		foreach ( $data as $item ) {
+			$email = strtolower( $item['email'] );
+			if ( $email >= $start_email && $email <= $end_email ) {
+				$filtered[] = $item;
+			}
+		}
+		return $filtered;
+	}
+}

--- a/includes/class-integrity-check-utils.php
+++ b/includes/class-integrity-check-utils.php
@@ -53,13 +53,13 @@ class Integrity_Check_Utils {
 
 		// Add range filtering if provided.
 		if ( $start_email !== null && $end_email !== null ) {
-			$query .= "
+			$query .= '
 			AND LOWER(u.user_email) >= %s
-			AND LOWER(u.user_email) <= %s";
+			AND LOWER(u.user_email) <= %s';
 		}
 
-		$query .= "
-			ORDER BY LOWER(u.user_email) ASC";
+		$query .= '
+			ORDER BY LOWER(u.user_email) ASC';
 		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 
 		return $query;

--- a/includes/class-integrity-check-utils.php
+++ b/includes/class-integrity-check-utils.php
@@ -15,16 +15,13 @@ use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
 class Integrity_Check_Utils {
 
 	/**
-	 * Get all membership data
+	 * Build the base membership query
 	 *
-	 * @param int|null $max_records Maximum number of records to return (for testing).
-	 * @return array Array of (email, status, network_id) data
+	 * @param string|null $start_email Optional start email for range filtering.
+	 * @param string|null $end_email Optional end email for range filtering.
+	 * @return string The SQL query string
 	 */
-	public static function get_membership_data( $max_records = null ) {
-		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
-			return [];
-		}
-
+	private static function build_membership_query( $start_email = null, $end_email = null ) {
 		global $wpdb;
 
 		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
@@ -52,17 +49,39 @@ class Integrity_Check_Utils {
 				AND p.post_date = latest.max_date
 			WHERE p.post_type = 'wc_user_membership'
 			AND pm_network.meta_value IS NOT NULL
-			AND pm_network.meta_value != ''
-			ORDER BY LOWER(u.user_email) ASC
-		";
+			AND pm_network.meta_value != ''";
+
+		// Add range filtering if provided.
+		if ( $start_email !== null && $end_email !== null ) {
+			$query .= "
+			AND LOWER(u.user_email) >= %s
+			AND LOWER(u.user_email) <= %s";
+		}
+
+		$query .= "
+			ORDER BY LOWER(u.user_email) ASC";
 		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		return $query;
+	}
+
+	/**
+	 * Execute membership query and format results
+	 *
+	 * @param string   $query The SQL query.
+	 * @param array    $prepare_args Arguments for wpdb->prepare.
+	 * @param int|null $max_records Maximum number of records to return.
+	 * @return array Array of (email, status, network_id) data
+	 */
+	private static function execute_membership_query( $query, $prepare_args, $max_records = null ) {
+		global $wpdb;
 
 		if ( $max_records ) {
 			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, Memberships_Admin::NETWORK_ID_META_KEY ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $wpdb->prepare( $query, ...$prepare_args ) );
 
 		$membership_data = [];
 		foreach ( $results as $result ) {
@@ -74,6 +93,26 @@ class Integrity_Check_Utils {
 		}
 
 		return $membership_data;
+	}
+
+	/**
+	 * Get all membership data
+	 *
+	 * @param int|null $max_records Maximum number of records to return (for testing).
+	 * @return array Array of (email, status, network_id) data
+	 */
+	public static function get_membership_data( $max_records = null ) {
+		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+			return [];
+		}
+
+		$query = self::build_membership_query();
+		$prepare_args = [
+			Memberships_Admin::NETWORK_ID_META_KEY,
+			Memberships_Admin::NETWORK_ID_META_KEY,
+		];
+
+		return self::execute_membership_query( $query, $prepare_args, $max_records );
 	}
 
 	/**
@@ -93,57 +132,15 @@ class Integrity_Check_Utils {
 			return [];
 		}
 
-		global $wpdb;
+		$query = self::build_membership_query( $start_email, $end_email );
+		$prepare_args = [
+			Memberships_Admin::NETWORK_ID_META_KEY,
+			Memberships_Admin::NETWORK_ID_META_KEY,
+			$start_email,
+			$end_email,
+		];
 
-		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-		$query = "
-			SELECT 
-				u.user_email,
-				p.post_status as status,
-				pm_network.meta_value as network_id
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
-			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
-			INNER JOIN (
-				SELECT 
-					p2.post_author,
-					pm2.meta_value,
-					MAX(p2.post_date) as max_date
-				FROM {$wpdb->posts} p2
-				INNER JOIN {$wpdb->postmeta} pm2 ON p2.post_parent = pm2.post_id AND pm2.meta_key = %s
-				WHERE p2.post_type = 'wc_user_membership'
-				AND pm2.meta_value IS NOT NULL
-				AND pm2.meta_value != ''
-				GROUP BY p2.post_author, pm2.meta_value
-			) latest ON p.post_author = latest.post_author 
-				AND pm_network.meta_value = latest.meta_value 
-				AND p.post_date = latest.max_date
-			WHERE p.post_type = 'wc_user_membership'
-			AND pm_network.meta_value IS NOT NULL
-			AND pm_network.meta_value != ''
-			AND LOWER(u.user_email) >= %s
-			AND LOWER(u.user_email) <= %s
-			ORDER BY LOWER(u.user_email) ASC
-		";
-
-		if ( $max_records ) {
-			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
-		}
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, Memberships_Admin::NETWORK_ID_META_KEY, $start_email, $end_email ) );
-		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-
-		$membership_data = [];
-		foreach ( $results as $result ) {
-			$membership_data[] = [
-				'email'      => strtolower( $result->user_email ),
-				'status'     => $result->status,
-				'network_id' => $result->network_id,
-			];
-		}
-
-		return $membership_data;
+		return self::execute_membership_query( $query, $prepare_args, $max_records );
 	}
 
 	/**

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -45,9 +45,6 @@ class Integrity_Check {
 	 * [--verbose]
 	 * : Output verbose information during the check.
 	 *
-	 * [--chunk-size=<size>]
-	 * : Maximum number of memberships to compare in each chunk (default: 1000).
-	 *
 	 * [--max=<count>]
 	 * : Maximum number of memberships to process (for testing only - do not use in production).
 	 *
@@ -55,7 +52,6 @@ class Integrity_Check {
 	 *
 	 *     wp newspack-network integrity-check
 	 *     wp newspack-network integrity-check --verbose
-	 *     wp newspack-network integrity-check --chunk-size=500
 	 *     wp newspack-network integrity-check --max=50 --verbose
 	 *
 	 * @param array $args The command arguments.
@@ -64,7 +60,6 @@ class Integrity_Check {
 	 */
 	public static function integrity_check( $args, $assoc_args ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
 		$verbose = isset( $assoc_args['verbose'] ) ? true : false;
-		$chunk_size = isset( $assoc_args['chunk-size'] ) ? intval( $assoc_args['chunk-size'] ) : 1000;
 		$max_records = isset( $assoc_args['max'] ) ? intval( $assoc_args['max'] ) : null;
 
 		if ( $max_records ) {
@@ -123,7 +118,7 @@ class Integrity_Check {
 			$node_name = str_replace( [ 'https://www.', 'https://', 'http://www.', 'http://' ], '', $node_url );
 			$node_columns[] = $node_name;
 
-			$specific_discrepancies = self::find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose, $max_records );
+			$specific_discrepancies = self::find_discrepancies_chunked( $hub_data, $node, $verbose, $max_records );
 
 			// Process discrepancies for this node.
 			foreach ( $specific_discrepancies as $discrepancy ) {
@@ -237,13 +232,13 @@ class Integrity_Check {
 	 *
 	 * @param array                       $hub_data Hub membership data.
 	 * @param \Newspack_Network\Node\Node $node The node to compare with.
-	 * @param int                         $chunk_size Maximum number of memberships per chunk.
 	 * @param bool                        $verbose Whether to output verbose information.
 	 * @param int|null                    $max_records Maximum number of records to process (for testing).
 	 * @return array Array of specific discrepancies
 	 */
-	private static function find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose = false, $max_records = null ) {
+	private static function find_discrepancies_chunked( $hub_data, $node, $verbose = false, $max_records = null ) {
 		$total_hub_memberships = count( $hub_data );
+		$chunk_size = 1000; // Target chunk size in number of emails.
 
 		// Create email ranges based on actual data distribution.
 		$email_ranges = self::create_email_ranges( $hub_data, $chunk_size );

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -32,7 +32,7 @@ class Integrity_Check {
 	 * @return void
 	 */
 	public static function register_commands() {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		if ( Site_Role::is_hub() && defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'newspack-network integrity-check', [ __CLASS__, 'integrity_check' ] );
 		}
 	}
@@ -70,10 +70,6 @@ class Integrity_Check {
 		$fix_discrepancies = isset( $assoc_args['fix-discrepancies'] ) ? true : false;
 		$chunk_size = isset( $assoc_args['chunk-size'] ) ? intval( $assoc_args['chunk-size'] ) : 1000;
 		$max_records = isset( $assoc_args['max'] ) ? intval( $assoc_args['max'] ) : null;
-
-		if ( ! Site_Role::is_hub() ) {
-			WP_CLI::error( 'This command can only be run on a Hub site.' );
-		}
 
 		if ( $max_records ) {
 			WP_CLI::warning( sprintf( 'Using --max=%d for testing. Do not use --max in production as it may produce false positives.', $max_records ) );
@@ -123,10 +119,10 @@ class Integrity_Check {
 		// Step 3: Collect discrepancies from all nodes into a consolidated table.
 		$all_discrepancies = [];
 		$node_columns = [ 'email', 'network_id', 'hub_status' ];
-		
+
 		foreach ( $discrepancies as $node ) {
 			WP_CLI::line( sprintf( 'Analyzing discrepancies for node: %s', $node->get_url() ) );
-			
+
 			$node_url = $node->get_url();
 			$node_name = str_replace( [ 'https://www.', 'https://', 'http://www.', 'http://' ], '', $node_url );
 			$node_columns[] = $node_name;
@@ -136,7 +132,7 @@ class Integrity_Check {
 			// Process discrepancies for this node.
 			foreach ( $specific_discrepancies as $discrepancy ) {
 				$key = $discrepancy['email'] . '::' . $discrepancy['network_id'];
-				
+
 				if ( ! isset( $all_discrepancies[ $key ] ) ) {
 					$all_discrepancies[ $key ] = [
 						'email'      => $discrepancy['email'],
@@ -144,7 +140,7 @@ class Integrity_Check {
 						'hub_status' => $discrepancy['hub_status'],
 					];
 				}
-				
+
 				$all_discrepancies[ $key ][ $node_name ] = $discrepancy['node_status'];
 			}
 		}
@@ -417,10 +413,10 @@ class Integrity_Check {
 		foreach ( $all_keys as $key ) {
 			$hub_item = $hub_lookup[ $key ] ?? null;
 			$node_item = $node_lookup[ $key ] ?? null;
-			
+
 			$hub_status = $hub_item ? $hub_item['status'] : 'NOT_FOUND';
 			$node_status = $node_item ? $node_item['status'] : 'NOT_FOUND';
-			
+
 			// Extract email and network_id for display.
 			$parts = explode( '::', $key );
 			$email = $parts[0];
@@ -487,56 +483,56 @@ class Integrity_Check {
 		// Calculate target ranges based on data size and target chunk size.
 		$total_emails = count( $hub_data );
 		$target_ranges = max( 1, ceil( $total_emails / $target_chunk_size ) );
-		
+
 		// If we need fewer ranges, combine adjacent ranges.
 		if ( $target_ranges < count( $fixed_ranges ) ) {
 			$consolidated_ranges = [];
 			$ranges_per_group = ceil( count( $fixed_ranges ) / $target_ranges );
-			
+
 			$current_idx = 0;
 			$fixed_ranges_count = count( $fixed_ranges );
 			while ( $current_idx < $fixed_ranges_count ) {
 				$start_idx = $current_idx;
 				$end_idx = min( $current_idx + $ranges_per_group - 1, $fixed_ranges_count - 1 );
-				
+
 				$consolidated_ranges[] = [
 					'start' => $fixed_ranges[ $start_idx ]['start'],
 					'end'   => $fixed_ranges[ $end_idx ]['end'],
 				];
-				
+
 				$current_idx += $ranges_per_group;
 			}
-			
+
 			return $consolidated_ranges;
 		}
-		
+
 		// If we need more ranges, subdivide the alphabet further.
 		if ( $target_ranges > count( $fixed_ranges ) ) {
 			$alphabet = 'abcdefghijklmnopqrstuvwxyz';
 			$ranges = [];
 			$chars_per_range = max( 1, floor( 26 / $target_ranges ) );
-			
+
 			// Ensure we don't exceed available alphabet characters.
 			$actual_target_ranges = min( $target_ranges, 26 );
-			
+
 			for ( $i = 0; $i < $actual_target_ranges; $i++ ) {
 				$start_char_idx = $i * $chars_per_range;
 				$end_char_idx = min( $start_char_idx + $chars_per_range - 1, 25 );
-				
+
 				// Validate array bounds.
 				if ( $start_char_idx >= 26 ) {
 					break;
 				}
-				
+
 				$start_char = $alphabet[ $start_char_idx ];
 				$end_char = ( $i === $actual_target_ranges - 1 ) ? 'zzzzz' : $alphabet[ $end_char_idx ];
-				
+
 				$ranges[] = [
 					'start' => $start_char,
 					'end'   => $end_char,
 				];
 			}
-			
+
 			return $ranges;
 		}
 
@@ -556,13 +552,13 @@ class Integrity_Check {
 	 */
 	private static function get_node_range_hash( $node, $start_email, $end_email, $max_records = null ) {
 		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-hash', $node->get_url() );
-		
+
 		$query_args = [
 			'start' => strtolower( $start_email ),
 			'end'   => strtolower( $end_email ),
 			'_t'    => time(), // Cache-busting parameter.
 		];
-		
+
 		if ( $max_records ) {
 			$query_args['max'] = $max_records;
 		}
@@ -597,13 +593,13 @@ class Integrity_Check {
 	 */
 	private static function get_node_range_data( $node, $start_email, $end_email, $max_records = null ) {
 		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-data', $node->get_url() );
-		
+
 		$query_args = [
 			'start' => strtolower( $start_email ),
 			'end'   => strtolower( $end_email ),
 			'_t'    => time(), // Cache-busting parameter.
 		];
-		
+
 		if ( $max_records ) {
 			$query_args['max'] = $max_records;
 		}

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -357,11 +357,7 @@ class Integrity_Check {
 	}
 
 	/**
-	 * Create fixed email ranges for consistent chunking
-	 *
-	 * Creates fixed alphabetical ranges that are consistent across hub and nodes
-	 * regardless of data distribution differences. This prevents boundary mismatches
-	 * that occur when hub and nodes have different membership counts.
+	 * Create fixed email ranges for consistent chunking.
 	 *
 	 * @param array $hub_data Hub membership data (sorted by email).
 	 * @param int   $target_chunk_size Target number of emails per chunk.
@@ -372,93 +368,66 @@ class Integrity_Check {
 			return [];
 		}
 
-		// Use fixed alphabetical ranges instead of data-dependent ranges.
-		// This ensures consistent boundaries regardless of data distribution.
-		$fixed_ranges = [
-			[
-				'start' => '0',
-				'end'   => 'c',
-			],
-			[
-				'start' => 'd',
-				'end'   => 'g',
-			],
-			[
-				'start' => 'h',
-				'end'   => 'k',
-			],
-			[
-				'start' => 'l',
-				'end'   => 'o',
-			],
-			[
-				'start' => 'p',
-				'end'   => 's',
-			],
-			[
-				'start' => 't',
-				'end'   => 'zzzzz',
-			],
-		];
-
-		// Calculate target ranges based on data size and target chunk size.
 		$total_emails = count( $hub_data );
-		$target_ranges = max( 1, ceil( $total_emails / $target_chunk_size ) );
+		$num_ranges = max( 1, ceil( $total_emails / $target_chunk_size ) );
+		$ranges = [];
 
-		// If we need fewer ranges, combine adjacent ranges.
-		if ( $target_ranges < count( $fixed_ranges ) ) {
-			$consolidated_ranges = [];
-			$ranges_per_group = ceil( count( $fixed_ranges ) / $target_ranges );
+		// Sort data by email to ensure consistent ordering.
+		usort(
+			$hub_data,
+			function( $a, $b ) {
+				return strcasecmp( $a['email'], $b['email'] );
+			}
+		);
 
-			$current_idx = 0;
-			$fixed_ranges_count = count( $fixed_ranges );
-			while ( $current_idx < $fixed_ranges_count ) {
-				$start_idx = $current_idx;
-				$end_idx = min( $current_idx + $ranges_per_group - 1, $fixed_ranges_count - 1 );
+		// Create ranges based on actual data distribution.
+		$emails_per_range = ceil( $total_emails / $num_ranges );
 
-				$consolidated_ranges[] = [
-					'start' => $fixed_ranges[ $start_idx ]['start'],
-					'end'   => $fixed_ranges[ $end_idx ]['end'],
-				];
+		for ( $i = 0; $i < $num_ranges; $i++ ) {
+			$start_idx = $i * $emails_per_range;
+			$end_idx = min( ( $i + 1 ) * $emails_per_range - 1, $total_emails - 1 );
 
-				$current_idx += $ranges_per_group;
+			if ( $start_idx >= $total_emails ) {
+				break;
 			}
 
-			return $consolidated_ranges;
-		}
+			// Use actual email addresses as boundaries.
+			$start_email = $hub_data[ $start_idx ]['email'];
 
-		// If we need more ranges, subdivide the alphabet further.
-		if ( $target_ranges > count( $fixed_ranges ) ) {
-			$alphabet = 'abcdefghijklmnopqrstuvwxyz';
-			$ranges = [];
-			$chars_per_range = max( 1, floor( 26 / $target_ranges ) );
-
-			// Ensure we don't exceed available alphabet characters.
-			$actual_target_ranges = min( $target_ranges, 26 );
-
-			for ( $i = 0; $i < $actual_target_ranges; $i++ ) {
-				$start_char_idx = $i * $chars_per_range;
-				$end_char_idx = min( $start_char_idx + $chars_per_range - 1, 25 );
-
-				// Validate array bounds.
-				if ( $start_char_idx >= 26 ) {
-					break;
+			// For the last range, use 'zzzzz' as the end to catch everything.
+			if ( $i === $num_ranges - 1 ) {
+				$end_email = 'zzzzz';
+			} else {
+				// Use the email just before the next range starts as the upper bound.
+				// This ensures no gaps between ranges.
+				$next_start_idx = min( ( $i + 1 ) * $emails_per_range, $total_emails - 1 );
+				if ( $next_start_idx > 0 ) {
+					// Get the character just before the next range's first email.
+					$next_email = $hub_data[ $next_start_idx ]['email'];
+					// Create an end boundary that includes everything up to (but not including) the next email.
+					// We'll use the next email with a character decremented.
+					$end_email = $next_email;
+					// Adjust to create a proper boundary.
+					$last_char = substr( $end_email, -1 );
+					if ( ord( $last_char ) > ord( 'a' ) ) {
+						$end_email = substr( $end_email, 0, -1 ) . chr( ord( $last_char ) - 1 ) . 'zzz';
+					} else {
+						// If we can't decrement, just use the email as-is.
+						// The range comparison should handle this correctly.
+						$end_email = $next_email;
+					}
+				} else {
+					$end_email = 'zzzzz';
 				}
-
-				$start_char = $alphabet[ $start_char_idx ];
-				$end_char = ( $i === $actual_target_ranges - 1 ) ? 'zzzzz' : $alphabet[ $end_char_idx ];
-
-				$ranges[] = [
-					'start' => $start_char,
-					'end'   => $end_char,
-				];
 			}
 
-			return $ranges;
+			$ranges[] = [
+				'start' => strtolower( $start_email ),
+				'end'   => strtolower( $end_email ),
+			];
 		}
 
-		// Default to fixed ranges.
-		return $fixed_ranges;
+		return $ranges;
 	}
 
 

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -9,7 +9,7 @@ namespace Newspack_Network\CLI;
 
 use Newspack_Network\Site_Role;
 use Newspack_Network\Hub\Nodes;
-use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+use Newspack_Network\Integrity_Check_Utils;
 use WP_CLI;
 
 /**
@@ -83,8 +83,8 @@ class Integrity_Check {
 		WP_CLI::line( '' );
 
 		// Step 1: Get hub's membership data and generate hash.
-		$hub_data = self::get_hub_membership_data( $max_records );
-		$hub_hash = self::generate_hash( $hub_data );
+		$hub_data = Integrity_Check_Utils::get_membership_data( $max_records );
+		$hub_hash = Integrity_Check_Utils::generate_hash( $hub_data );
 
 		if ( $verbose ) {
 			WP_CLI::line( sprintf( '%d memberships found on the hub', count( $hub_data ) ) );
@@ -176,53 +176,6 @@ class Integrity_Check {
 		}
 	}
 
-	/**
-	 * Get all membership data from the hub
-	 *
-	 * @param int|null $max_records Maximum number of records to return (for testing).
-	 * @return array Array of (email, status) pairs
-	 */
-	private static function get_hub_membership_data( $max_records = null ) {
-		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
-			WP_CLI::error( 'WooCommerce Memberships plugin is not active.' );
-		}
-
-		global $wpdb;
-
-		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-		$query = "
-			SELECT DISTINCT
-				u.user_email,
-				p.post_status as status,
-				pm_network.meta_value as network_id
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
-			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
-			WHERE p.post_type = 'wc_user_membership'
-			AND pm_network.meta_value IS NOT NULL
-			AND pm_network.meta_value != ''
-			ORDER BY LOWER(u.user_email) ASC
-		";
-		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-
-		if ( $max_records ) {
-			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
-		}
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY ) );
-
-		$membership_data = [];
-		foreach ( $results as $result ) {
-			$membership_data[] = [
-				'email'      => strtolower( $result->user_email ),
-				'status'     => $result->status,
-				'network_id' => $result->network_id,
-			];
-		}
-
-		return $membership_data;
-	}
 
 	/**
 	 * Get membership data from a node via REST API
@@ -232,6 +185,7 @@ class Integrity_Check {
 	 */
 	private static function get_node_membership_data( $node ) {
 		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/memberships', $node->get_url() );
+		$endpoint = add_query_arg( [ '_t' => time() ], $endpoint ); // Cache-busting parameter.
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		$response = wp_remote_get(
 			$endpoint,
@@ -261,9 +215,11 @@ class Integrity_Check {
 	private static function get_node_hash( $node, $max_records = null ) {
 		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/hash', $node->get_url() );
 
+		$query_args = [ '_t' => time() ]; // Cache-busting parameter.
 		if ( $max_records ) {
-			$endpoint = add_query_arg( [ 'max' => $max_records ], $endpoint );
+			$query_args['max'] = $max_records;
 		}
+		$endpoint = add_query_arg( $query_args, $endpoint );
 
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		$response = wp_remote_get(
@@ -354,25 +310,6 @@ class Integrity_Check {
 		return $data['memberships'] ?? [];
 	}
 
-	/**
-	 * Generate a hash from membership data
-	 *
-	 * @param array $data Array of (email, status) pairs.
-	 * @return string SHA-256 hash
-	 */
-	private static function generate_hash( $data ) {
-		if ( empty( $data ) ) {
-			return '';
-		}
-
-		// Create a string representation of the data for hashing.
-		$hash_string = '';
-		foreach ( $data as $item ) {
-			$hash_string .= $item['email'] . ':' . $item['status'] . ':' . $item['network_id'] . "\n";
-		}
-
-		return hash( 'sha256', $hash_string );
-	}
 
 	/**
 	 * Find specific discrepancies between hub and node data using range-based chunked approach
@@ -402,10 +339,10 @@ class Integrity_Check {
 
 		foreach ( $email_ranges as $chunk_index => $range ) {
 			// Get hub chunk data for this range.
-			$hub_chunk = self::filter_data_by_range( $hub_data, $range['start'], $range['end'] );
+			$hub_chunk = Integrity_Check_Utils::filter_data_by_range( $hub_data, $range['start'], $range['end'] );
 
 			// Generate hash for this chunk from hub data.
-			$hub_chunk_hash = self::generate_hash( $hub_chunk );
+			$hub_chunk_hash = Integrity_Check_Utils::generate_hash( $hub_chunk );
 
 			// Get corresponding chunk hash from node using range.
 			$node_chunk_hash = self::get_node_range_hash( $node, $range['start'], $range['end'], $max_records );
@@ -528,10 +465,14 @@ class Integrity_Check {
 			$end_index = min( ( $i + 1 ) * $actual_chunk_size - 1, $total_emails - 1 );
 
 			$start_email = $hub_data[ $start_index ]['email'];
-			$end_email = $hub_data[ $end_index ]['email'];
-
+			
 			// For the last chunk, extend to ensure we capture everything beyond the last email.
-			$end_email_boundary = ( $i === $num_chunks - 1 ) ? 'zzzzz' : $end_email;
+			if ( $i === $num_chunks - 1 ) {
+				$end_email_boundary = 'zzzzz';
+			} else {
+				// Use the last email of this chunk as the end boundary.
+				$end_email_boundary = $hub_data[ $end_index ]['email'];
+			}
 
 			$ranges[] = [
 				'start' => $start_email,
@@ -542,27 +483,6 @@ class Integrity_Check {
 		return $ranges;
 	}
 
-	/**
-	 * Filter membership data by email range
-	 *
-	 * @param array  $data Membership data.
-	 * @param string $start_email Start email (inclusive).
-	 * @param string $end_email End email (inclusive).
-	 * @return array Filtered data
-	 */
-	private static function filter_data_by_range( $data, $start_email, $end_email ) {
-		$filtered = [];
-		$start_email = strtolower( $start_email );
-		$end_email = strtolower( $end_email );
-		
-		foreach ( $data as $item ) {
-			$email = strtolower( $item['email'] );
-			if ( $email >= $start_email && $email <= $end_email ) {
-				$filtered[] = $item;
-			}
-		}
-		return $filtered;
-	}
 
 	/**
 	 * Get range hash from a node via REST API
@@ -579,6 +499,7 @@ class Integrity_Check {
 		$query_args = [
 			'start' => strtolower( $start_email ),
 			'end'   => strtolower( $end_email ),
+			'_t'    => time(), // Cache-busting parameter.
 		];
 		
 		if ( $max_records ) {
@@ -619,6 +540,7 @@ class Integrity_Check {
 		$query_args = [
 			'start' => strtolower( $start_email ),
 			'end'   => strtolower( $end_email ),
+			'_t'    => time(), // Cache-busting parameter.
 		];
 		
 		if ( $max_records ) {

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -127,15 +127,15 @@ class Integrity_Check {
 			$specific_discrepancies = self::find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose, $max_records );
 
 			if ( ! empty( $specific_discrepancies ) ) {
-				// Deduplicate discrepancies by email address to prevent duplicate entries
+				// Deduplicate discrepancies by (email, network_id) pair to prevent duplicate entries
 				$deduplicated_discrepancies = [];
-				$seen_emails = [];
+				$seen_keys = [];
 				
 				foreach ( $specific_discrepancies as $discrepancy ) {
-					$email = $discrepancy['email'];
-					if ( ! isset( $seen_emails[ $email ] ) ) {
+					$key = $discrepancy['email'] . '::' . $discrepancy['network_id'];
+					if ( ! isset( $seen_keys[ $key ] ) ) {
 						$deduplicated_discrepancies[] = $discrepancy;
-						$seen_emails[ $email ] = true;
+						$seen_keys[ $key ] = true;
 					}
 				}
 				
@@ -147,13 +147,14 @@ class Integrity_Check {
 				foreach ( $deduplicated_discrepancies as $discrepancy ) {
 					$table_data[] = [
 						'email'       => $discrepancy['email'],
+						'network_id'  => $discrepancy['network_id'],
 						'hub_status'  => $discrepancy['hub_status'],
 						'node_status' => $discrepancy['node_status'],
 					];
 				}
 
 				// Display as table using WP-CLI's table formatter.
-				WP_CLI\Utils\format_items( 'table', $table_data, [ 'email', 'hub_status', 'node_status' ] );
+				WP_CLI\Utils\format_items( 'table', $table_data, [ 'email', 'network_id', 'hub_status', 'node_status' ] );
 			}
 
 			WP_CLI::line( '' );
@@ -181,7 +182,8 @@ class Integrity_Check {
 		$query = "
 			SELECT DISTINCT
 				u.user_email,
-				p.post_status as status
+				p.post_status as status,
+				pm_network.meta_value as network_id
 			FROM {$wpdb->posts} p
 			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
 			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
@@ -202,8 +204,9 @@ class Integrity_Check {
 		$membership_data = [];
 		foreach ( $results as $result ) {
 			$membership_data[] = [
-				'email'  => strtolower( $result->user_email ),
-				'status' => $result->status,
+				'email'      => strtolower( $result->user_email ),
+				'status'     => $result->status,
+				'network_id' => $result->network_id,
 			];
 		}
 
@@ -354,7 +357,7 @@ class Integrity_Check {
 		// Create a string representation of the data for hashing.
 		$hash_string = '';
 		foreach ( $data as $item ) {
-			$hash_string .= $item['email'] . ':' . $item['status'] . "\n";
+			$hash_string .= $item['email'] . ':' . $item['status'] . ':' . $item['network_id'] . "\n";
 		}
 
 		return hash( 'sha256', $hash_string );
@@ -446,28 +449,39 @@ class Integrity_Check {
 	private static function compare_chunk_data( $hub_chunk, $node_chunk ) {
 		$discrepancies = [];
 
-		// Create lookup arrays for faster comparison.
+		// Create lookup arrays for faster comparison using (email, network_id) as key.
 		$hub_lookup = [];
 		foreach ( $hub_chunk as $item ) {
-			$hub_lookup[ $item['email'] ] = $item['status'];
+			$key = $item['email'] . '::' . $item['network_id'];
+			$hub_lookup[ $key ] = $item;
 		}
 
 		$node_lookup = [];
 		foreach ( $node_chunk as $item ) {
-			$node_lookup[ $item['email'] ] = $item['status'];
+			$key = $item['email'] . '::' . $item['network_id'];
+			$node_lookup[ $key ] = $item;
 		}
 
 		// Find discrepancies within this chunk.
-		$all_emails = array_unique( array_merge( array_keys( $hub_lookup ), array_keys( $node_lookup ) ) );
-		sort( $all_emails );
+		$all_keys = array_unique( array_merge( array_keys( $hub_lookup ), array_keys( $node_lookup ) ) );
+		sort( $all_keys );
 
-		foreach ( $all_emails as $email ) {
-			$hub_status = $hub_lookup[ $email ] ?? 'NOT_FOUND';
-			$node_status = $node_lookup[ $email ] ?? 'NOT_FOUND';
+		foreach ( $all_keys as $key ) {
+			$hub_item = $hub_lookup[ $key ] ?? null;
+			$node_item = $node_lookup[ $key ] ?? null;
+			
+			$hub_status = $hub_item ? $hub_item['status'] : 'NOT_FOUND';
+			$node_status = $node_item ? $node_item['status'] : 'NOT_FOUND';
+			
+			// Extract email and network_id for display
+			$parts = explode( '::', $key );
+			$email = $parts[0];
+			$network_id = $parts[1];
 
 			if ( $hub_status !== $node_status ) {
 				$discrepancies[] = [
 					'email'       => $email,
+					'network_id'  => $network_id,
 					'hub_status'  => $hub_status,
 					'node_status' => $node_status,
 				];

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -120,44 +120,55 @@ class Integrity_Check {
 
 		WP_CLI::warning( sprintf( 'Found %d nodes with discrepancies', count( $discrepancies ) ) );
 
-		// Step 3: For each discrepant node, perform chunked verification.
+		// Step 3: Collect discrepancies from all nodes into a consolidated table.
+		$all_discrepancies = [];
+		$node_columns = [ 'email', 'network_id', 'hub_status' ];
+		
 		foreach ( $discrepancies as $node ) {
 			WP_CLI::line( sprintf( 'Analyzing discrepancies for node: %s', $node->get_url() ) );
+			
+			$node_url = $node->get_url();
+			$node_name = str_replace( [ 'https://www.', 'https://', 'http://www.', 'http://' ], '', $node_url );
+			$node_columns[] = $node_name;
 
 			$specific_discrepancies = self::find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose, $max_records );
 
-			if ( ! empty( $specific_discrepancies ) ) {
-				// Deduplicate discrepancies by (email, network_id) pair to prevent duplicate entries
-				$deduplicated_discrepancies = [];
-				$seen_keys = [];
+			// Process discrepancies for this node
+			foreach ( $specific_discrepancies as $discrepancy ) {
+				$key = $discrepancy['email'] . '::' . $discrepancy['network_id'];
 				
-				foreach ( $specific_discrepancies as $discrepancy ) {
-					$key = $discrepancy['email'] . '::' . $discrepancy['network_id'];
-					if ( ! isset( $seen_keys[ $key ] ) ) {
-						$deduplicated_discrepancies[] = $discrepancy;
-						$seen_keys[ $key ] = true;
-					}
-				}
-				
-				WP_CLI::line( sprintf( 'Found %d specific discrepancies:', count( $deduplicated_discrepancies ) ) );
-				WP_CLI::line( '' );
-
-				// Prepare table data for WP-CLI table.
-				$table_data = [];
-				foreach ( $deduplicated_discrepancies as $discrepancy ) {
-					$table_data[] = [
-						'email'       => $discrepancy['email'],
-						'network_id'  => $discrepancy['network_id'],
-						'hub_status'  => $discrepancy['hub_status'],
-						'node_status' => $discrepancy['node_status'],
+				if ( ! isset( $all_discrepancies[ $key ] ) ) {
+					$all_discrepancies[ $key ] = [
+						'email'      => $discrepancy['email'],
+						'network_id' => $discrepancy['network_id'],
+						'hub_status' => $discrepancy['hub_status'],
 					];
 				}
+				
+				$all_discrepancies[ $key ][ $node_name ] = $discrepancy['node_status'];
+			}
+		}
 
-				// Display as table using WP-CLI's table formatter.
-				WP_CLI\Utils\format_items( 'table', $table_data, [ 'email', 'network_id', 'hub_status', 'node_status' ] );
+		// Display consolidated table if there are any discrepancies
+		if ( ! empty( $all_discrepancies ) ) {
+			WP_CLI::line( '' );
+			WP_CLI::line( sprintf( 'Found %d total discrepancies:', count( $all_discrepancies ) ) );
+			WP_CLI::line( '' );
+
+			// Prepare table data with node columns
+			$table_data = [];
+			foreach ( $all_discrepancies as $discrepancy ) {
+				// Fill in missing node statuses with empty string
+				foreach ( $node_columns as $column ) {
+					if ( ! isset( $discrepancy[ $column ] ) && ! in_array( $column, [ 'email', 'network_id', 'hub_status' ] ) ) {
+						$discrepancy[ $column ] = '';
+					}
+				}
+				$table_data[] = $discrepancy;
 			}
 
-			WP_CLI::line( '' );
+			// Display as table using WP-CLI's table formatter
+			WP_CLI\Utils\format_items( 'table', $table_data, $node_columns );
 		}
 
 		if ( $fix_discrepancies ) {

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -52,7 +52,7 @@ class Integrity_Check {
 	 * : Maximum number of memberships to compare in each chunk (default: 1000).
 	 *
 	 * [--max=<count>]
-	 * : Maximum number of memberships to process (for testing).
+	 * : Maximum number of memberships to process (for testing only - do not use in production).
 	 *
 	 * ## EXAMPLES
 	 *
@@ -73,6 +73,10 @@ class Integrity_Check {
 
 		if ( ! Site_Role::is_hub() ) {
 			WP_CLI::error( 'This command can only be run on a Hub site.' );
+		}
+
+		if ( $max_records ) {
+			WP_CLI::warning( sprintf( 'Using --max=%d for testing. Do not use --max in production as it may produce false positives.', $max_records ) );
 		}
 
 		WP_CLI::line( 'Starting integrity check for network membership data...' );
@@ -123,12 +127,24 @@ class Integrity_Check {
 			$specific_discrepancies = self::find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose, $max_records );
 
 			if ( ! empty( $specific_discrepancies ) ) {
-				WP_CLI::line( sprintf( 'Found %d specific discrepancies:', count( $specific_discrepancies ) ) );
+				// Deduplicate discrepancies by email address to prevent duplicate entries
+				$deduplicated_discrepancies = [];
+				$seen_emails = [];
+				
+				foreach ( $specific_discrepancies as $discrepancy ) {
+					$email = $discrepancy['email'];
+					if ( ! isset( $seen_emails[ $email ] ) ) {
+						$deduplicated_discrepancies[] = $discrepancy;
+						$seen_emails[ $email ] = true;
+					}
+				}
+				
+				WP_CLI::line( sprintf( 'Found %d specific discrepancies:', count( $deduplicated_discrepancies ) ) );
 				WP_CLI::line( '' );
 
 				// Prepare table data for WP-CLI table.
 				$table_data = [];
-				foreach ( $specific_discrepancies as $discrepancy ) {
+				foreach ( $deduplicated_discrepancies as $discrepancy ) {
 					$table_data[] = [
 						'email'       => $discrepancy['email'],
 						'hub_status'  => $discrepancy['hub_status'],

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -1,0 +1,592 @@
+<?php
+/**
+ * Integrity Check CLI command.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\CLI;
+
+use Newspack_Network\Site_Role;
+use Newspack_Network\Hub\Nodes;
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+use WP_CLI;
+
+/**
+ * Integrity Check CLI command class.
+ */
+class Integrity_Check {
+
+	/**
+	 * Initialize this class and register hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_commands' ] );
+	}
+
+	/**
+	 * Register the WP-CLI commands
+	 *
+	 * @return void
+	 */
+	public static function register_commands() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'newspack-network integrity-check', [ __CLASS__, 'integrity_check' ] );
+		}
+	}
+
+	/**
+	 * Performs an integrity check on network membership data.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--verbose]
+	 * : Output verbose information during the check.
+	 *
+	 * [--fix-discrepancies]
+	 * : Attempt to fix discrepancies found during the check.
+	 *
+	 * [--chunk-size=<size>]
+	 * : Maximum number of memberships to compare in each chunk (default: 1000).
+	 *
+	 * [--max=<count>]
+	 * : Maximum number of memberships to process (for testing).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack-network integrity-check
+	 *     wp newspack-network integrity-check --verbose
+	 *     wp newspack-network integrity-check --chunk-size=500
+	 *     wp newspack-network integrity-check --max=50 --verbose
+	 *
+	 * @param array $args The command arguments.
+	 * @param array $assoc_args The command options.
+	 * @return void
+	 */
+	public static function integrity_check( $args, $assoc_args ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
+		$verbose = isset( $assoc_args['verbose'] ) ? true : false;
+		$fix_discrepancies = isset( $assoc_args['fix-discrepancies'] ) ? true : false;
+		$chunk_size = isset( $assoc_args['chunk-size'] ) ? intval( $assoc_args['chunk-size'] ) : 1000;
+		$max_records = isset( $assoc_args['max'] ) ? intval( $assoc_args['max'] ) : null;
+
+		if ( ! Site_Role::is_hub() ) {
+			WP_CLI::error( 'This command can only be run on a Hub site.' );
+		}
+
+		WP_CLI::line( 'Starting integrity check for network membership data...' );
+		WP_CLI::line( '' );
+
+		// Step 1: Get hub's membership data and generate hash.
+		$hub_data = self::get_hub_membership_data( $max_records );
+		$hub_hash = self::generate_hash( $hub_data );
+
+		if ( $verbose ) {
+			WP_CLI::line( sprintf( '%d memberships found on the hub', count( $hub_data ) ) );
+			WP_CLI::line( sprintf( 'Hub hash: %s', $hub_hash ) );
+			WP_CLI::line( '' );
+		}
+
+		// Step 2: Get node data and compare hashes.
+		$nodes = Nodes::get_all_nodes();
+		$discrepancies = [];
+
+		foreach ( $nodes as $node ) {
+			$node_hash = self::get_node_hash( $node, $max_records );
+
+			if ( $verbose ) {
+				WP_CLI::line( sprintf( 'Node %s hash: %s', $node->get_url(), $node_hash ) );
+			}
+
+			if ( $hub_hash !== $node_hash ) {
+				$discrepancies[] = $node;
+				WP_CLI::warning( sprintf( 'Hash mismatch detected for node: %s', $node->get_url() ) );
+			} else {
+				WP_CLI::success( sprintf( 'Hash match for node: %s', $node->get_url() ) );
+			}
+		}
+
+		WP_CLI::line( '' );
+
+		if ( empty( $discrepancies ) ) {
+			WP_CLI::success( 'All nodes are in sync with the hub!' );
+			return;
+		}
+
+		WP_CLI::warning( sprintf( 'Found %d nodes with discrepancies', count( $discrepancies ) ) );
+
+		// Step 3: For each discrepant node, perform chunked verification.
+		foreach ( $discrepancies as $node ) {
+			WP_CLI::line( sprintf( 'Analyzing discrepancies for node: %s', $node->get_url() ) );
+
+			$specific_discrepancies = self::find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose, $max_records );
+
+			if ( ! empty( $specific_discrepancies ) ) {
+				WP_CLI::line( sprintf( 'Found %d specific discrepancies:', count( $specific_discrepancies ) ) );
+				WP_CLI::line( '' );
+
+				// Prepare table data for WP-CLI table.
+				$table_data = [];
+				foreach ( $specific_discrepancies as $discrepancy ) {
+					$table_data[] = [
+						'email'       => $discrepancy['email'],
+						'hub_status'  => $discrepancy['hub_status'],
+						'node_status' => $discrepancy['node_status'],
+					];
+				}
+
+				// Display as table using WP-CLI's table formatter.
+				WP_CLI\Utils\format_items( 'table', $table_data, [ 'email', 'hub_status', 'node_status' ] );
+			}
+
+			WP_CLI::line( '' );
+		}
+
+		if ( $fix_discrepancies ) {
+			WP_CLI::line( 'Fix discrepancies functionality would be implemented here.' );
+		}
+	}
+
+	/**
+	 * Get all membership data from the hub
+	 *
+	 * @param int|null $max_records Maximum number of records to return (for testing).
+	 * @return array Array of (email, status) pairs
+	 */
+	private static function get_hub_membership_data( $max_records = null ) {
+		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+			WP_CLI::error( 'WooCommerce Memberships plugin is not active.' );
+		}
+
+		global $wpdb;
+
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$query = "
+			SELECT DISTINCT
+				u.user_email,
+				p.post_status as status
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
+			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
+			WHERE p.post_type = 'wc_user_membership'
+			AND pm_network.meta_value IS NOT NULL
+			AND pm_network.meta_value != ''
+			ORDER BY u.user_email ASC
+		";
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		if ( $max_records ) {
+			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY ) );
+
+		$membership_data = [];
+		foreach ( $results as $result ) {
+			$membership_data[] = [
+				'email'  => $result->user_email,
+				'status' => $result->status,
+			];
+		}
+
+		return $membership_data;
+	}
+
+	/**
+	 * Get membership data from a node via REST API
+	 *
+	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @return array Array of (email, status) pairs
+	 */
+	private static function get_node_membership_data( $node ) {
+		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/memberships', $node->get_url() );
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$response = wp_remote_get(
+			$endpoint,
+			[
+				'headers' => $node->get_authorization_headers( 'integrity-check' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			WP_CLI::error( sprintf( 'Failed to get membership data from node: %s', $node->get_url() ) );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		return $data['memberships'] ?? [];
+	}
+
+	/**
+	 * Get hash from a node via REST API
+	 *
+	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @param int|null                    $max_records Maximum number of records to include in hash.
+	 * @return string The hash from the node
+	 */
+	private static function get_node_hash( $node, $max_records = null ) {
+		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/hash', $node->get_url() );
+
+		if ( $max_records ) {
+			$endpoint = add_query_arg( [ 'max' => $max_records ], $endpoint );
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$response = wp_remote_get(
+			$endpoint,
+			[
+				'headers' => $node->get_authorization_headers( 'integrity-check' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			WP_CLI::error( sprintf( 'Failed to get hash from node: %s', $node->get_url() ) );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		return $data['hash'] ?? '';
+	}
+
+	/**
+	 * Get chunk hash from a node via REST API
+	 *
+	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @param int                         $offset The offset for the chunk.
+	 * @param int                         $limit The limit for the chunk.
+	 * @return string The chunk hash from the node
+	 */
+	private static function get_node_chunk_hash( $node, $offset, $limit ) {
+		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/chunk-hash', $node->get_url() );
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$response = wp_remote_get(
+			add_query_arg(
+				[
+					'offset' => $offset,
+					'limit'  => $limit,
+				],
+				$endpoint
+			),
+			[
+				'headers' => $node->get_authorization_headers( 'integrity-check' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			WP_CLI::error( sprintf( 'Failed to get chunk hash from node: %s', $node->get_url() ) );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		return $data['hash'] ?? '';
+	}
+
+	/**
+	 * Get chunk data from a node via REST API
+	 *
+	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @param int                         $offset The offset for the chunk.
+	 * @param int                         $limit The limit for the chunk.
+	 * @return array The chunk data from the node
+	 */
+	private static function get_node_chunk_data( $node, $offset, $limit ) {
+		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/chunk-data', $node->get_url() );
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$response = wp_remote_get(
+			add_query_arg(
+				[
+					'offset' => $offset,
+					'limit'  => $limit,
+				],
+				$endpoint
+			),
+			[
+				'headers' => $node->get_authorization_headers( 'integrity-check' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			WP_CLI::error( sprintf( 'Failed to get chunk data from node: %s', $node->get_url() ) );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		return $data['memberships'] ?? [];
+	}
+
+	/**
+	 * Generate a hash from membership data
+	 *
+	 * @param array $data Array of (email, status) pairs.
+	 * @return string SHA-256 hash
+	 */
+	private static function generate_hash( $data ) {
+		if ( empty( $data ) ) {
+			return '';
+		}
+
+		// Create a string representation of the data for hashing.
+		$hash_string = '';
+		foreach ( $data as $item ) {
+			$hash_string .= $item['email'] . ':' . $item['status'] . "\n";
+		}
+
+		return hash( 'sha256', $hash_string );
+	}
+
+	/**
+	 * Find specific discrepancies between hub and node data using range-based chunked approach
+	 *
+	 * Uses email address ranges instead of positional offsets to avoid the "shifting problem":
+	 * If hub has [A,B,C,D] and node has [B,C,D,E] (A missing), positional chunks would ALL
+	 * mismatch due to shifting. Range-based chunks (A-B, C-D) only show mismatch in affected range.
+	 *
+	 * @param array                       $hub_data Hub membership data.
+	 * @param \Newspack_Network\Node\Node $node The node to compare with.
+	 * @param int                         $chunk_size Maximum number of memberships per chunk.
+	 * @param bool                        $verbose Whether to output verbose information.
+	 * @param int|null                    $max_records Maximum number of records to process (for testing).
+	 * @return array Array of specific discrepancies
+	 */
+	private static function find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose = false, $max_records = null ) {
+		$total_hub_memberships = count( $hub_data );
+
+		// Create email ranges based on actual data distribution.
+		$email_ranges = self::create_email_ranges( $hub_data, $chunk_size );
+		$num_chunks = count( $email_ranges );
+		$all_discrepancies = [];
+
+		if ( $verbose ) {
+			WP_CLI::line( sprintf( 'Checking %d memberships in %d range-based chunks (target size: %d)', $total_hub_memberships, $num_chunks, $chunk_size ) );
+		}
+
+		foreach ( $email_ranges as $chunk_index => $range ) {
+			// Get hub chunk data for this range.
+			$hub_chunk = self::filter_data_by_range( $hub_data, $range['start'], $range['end'] );
+
+			// Generate hash for this chunk from hub data.
+			$hub_chunk_hash = self::generate_hash( $hub_chunk );
+
+			// Get corresponding chunk hash from node using range.
+			$node_chunk_hash = self::get_node_range_hash( $node, $range['start'], $range['end'] );
+
+			if ( $verbose ) {
+				WP_CLI::line(
+					sprintf(
+						'  Chunk %d (%s to %s): Hub=%s, Node=%s (%d emails)',
+						$chunk_index + 1,
+						$range['start'],
+						$range['end'],
+						substr( $hub_chunk_hash, 0, 8 ),
+						substr( $node_chunk_hash, 0, 8 ),
+						count( $hub_chunk )
+					)
+				);
+			}
+
+			// If chunk hashes match, skip this chunk.
+			if ( $hub_chunk_hash === $node_chunk_hash ) {
+				if ( $verbose ) {
+					WP_CLI::line( sprintf( '    ✓ Chunk %d matches', $chunk_index + 1 ) );
+				}
+				continue;
+			}
+
+			// Chunk hashes don't match - get detailed data for this range.
+			if ( $verbose ) {
+				WP_CLI::line( sprintf( '    ✗ Chunk %d mismatch - fetching detailed data', $chunk_index + 1 ) );
+			}
+
+			$node_chunk_data = self::get_node_range_data( $node, $range['start'], $range['end'] );
+			$chunk_discrepancies = self::compare_chunk_data( $hub_chunk, $node_chunk_data );
+
+			$all_discrepancies = array_merge( $all_discrepancies, $chunk_discrepancies );
+
+			if ( $verbose ) {
+				WP_CLI::line( sprintf( '    Found %d discrepancies in chunk %d', count( $chunk_discrepancies ), $chunk_index + 1 ) );
+			}
+		}
+
+		return $all_discrepancies;
+	}
+
+	/**
+	 * Compare two chunks of membership data and find discrepancies
+	 *
+	 * @param array $hub_chunk Hub chunk data.
+	 * @param array $node_chunk Node chunk data.
+	 * @return array Array of discrepancies
+	 */
+	private static function compare_chunk_data( $hub_chunk, $node_chunk ) {
+		$discrepancies = [];
+
+		// Create lookup arrays for faster comparison.
+		$hub_lookup = [];
+		foreach ( $hub_chunk as $item ) {
+			$hub_lookup[ $item['email'] ] = $item['status'];
+		}
+
+		$node_lookup = [];
+		foreach ( $node_chunk as $item ) {
+			$node_lookup[ $item['email'] ] = $item['status'];
+		}
+
+		// Find discrepancies within this chunk.
+		$all_emails = array_unique( array_merge( array_keys( $hub_lookup ), array_keys( $node_lookup ) ) );
+		sort( $all_emails );
+
+		foreach ( $all_emails as $email ) {
+			$hub_status = $hub_lookup[ $email ] ?? 'NOT_FOUND';
+			$node_status = $node_lookup[ $email ] ?? 'NOT_FOUND';
+
+			if ( $hub_status !== $node_status ) {
+				$discrepancies[] = [
+					'email'       => $email,
+					'hub_status'  => $hub_status,
+					'node_status' => $node_status,
+				];
+			}
+		}
+
+		return $discrepancies;
+	}
+
+	/**
+	 * Create email ranges based on actual data distribution
+	 *
+	 * Creates content-based ranges instead of positional chunks to solve the shifting problem.
+	 * Each range covers a specific email address span (e.g., 'a@domain.com' to 'm@domain.com').
+	 * When emails are added/removed, only the affected range needs re-checking, not all chunks.
+	 *
+	 * @param array $hub_data Hub membership data (sorted by email).
+	 * @param int   $target_chunk_size Target number of emails per chunk.
+	 * @return array Array of ranges with start and end email addresses
+	 */
+	private static function create_email_ranges( $hub_data, $target_chunk_size ) {
+		if ( empty( $hub_data ) ) {
+			return [];
+		}
+
+		$total_emails = count( $hub_data );
+		$num_chunks = max( 1, ceil( $total_emails / $target_chunk_size ) );
+		$actual_chunk_size = ceil( $total_emails / $num_chunks );
+
+		$ranges = [];
+		for ( $i = 0; $i < $num_chunks; $i++ ) {
+			$start_index = $i * $actual_chunk_size;
+			$end_index = min( ( $i + 1 ) * $actual_chunk_size - 1, $total_emails - 1 );
+
+			$start_email = $hub_data[ $start_index ]['email'];
+			$end_email = $hub_data[ $end_index ]['email'];
+
+			// For the last chunk, extend to ensure we capture everything beyond the last email.
+			$end_email_boundary = ( $i === $num_chunks - 1 ) ? 'zzzzz' : $end_email;
+
+			$ranges[] = [
+				'start' => $start_email,
+				'end'   => $end_email_boundary,
+			];
+		}
+
+		return $ranges;
+	}
+
+	/**
+	 * Filter membership data by email range
+	 *
+	 * @param array  $data Membership data.
+	 * @param string $start_email Start email (inclusive).
+	 * @param string $end_email End email (inclusive).
+	 * @return array Filtered data
+	 */
+	private static function filter_data_by_range( $data, $start_email, $end_email ) {
+		$filtered = [];
+		foreach ( $data as $item ) {
+			$email = $item['email'];
+			if ( $email >= $start_email && $email <= $end_email ) {
+				$filtered[] = $item;
+			}
+		}
+		return $filtered;
+	}
+
+	/**
+	 * Get range hash from a node via REST API
+	 *
+	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @param string                      $start_email Start email for the range.
+	 * @param string                      $end_email End email for the range.
+	 * @return string The range hash from the node
+	 */
+	private static function get_node_range_hash( $node, $start_email, $end_email ) {
+		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-hash', $node->get_url() );
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$response = wp_remote_get(
+			add_query_arg(
+				[
+					'start' => $start_email,
+					'end'   => $end_email,
+				],
+				$endpoint
+			),
+			[
+				'headers' => $node->get_authorization_headers( 'integrity-check' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			WP_CLI::error( sprintf( 'Failed to get range hash from node: %s', $node->get_url() ) );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		return $data['hash'] ?? '';
+	}
+
+	/**
+	 * Get range data from a node via REST API
+	 *
+	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @param string                      $start_email Start email for the range.
+	 * @param string                      $end_email End email for the range.
+	 * @return array The range data from the node
+	 */
+	private static function get_node_range_data( $node, $start_email, $end_email ) {
+		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-data', $node->get_url() );
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$response = wp_remote_get(
+			add_query_arg(
+				[
+					'start' => $start_email,
+					'end'   => $end_email,
+				],
+				$endpoint
+			),
+			[
+				'headers' => $node->get_authorization_headers( 'integrity-check' ),
+				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			WP_CLI::error( sprintf( 'Failed to get range data from node: %s', $node->get_url() ) );
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		return $data['memberships'] ?? [];
+	}
+}

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -133,7 +133,7 @@ class Integrity_Check {
 
 			$specific_discrepancies = self::find_discrepancies_chunked( $hub_data, $node, $chunk_size, $verbose, $max_records );
 
-			// Process discrepancies for this node
+			// Process discrepancies for this node.
 			foreach ( $specific_discrepancies as $discrepancy ) {
 				$key = $discrepancy['email'] . '::' . $discrepancy['network_id'];
 				
@@ -149,16 +149,16 @@ class Integrity_Check {
 			}
 		}
 
-		// Display consolidated table if there are any discrepancies
+		// Display consolidated table if there are any discrepancies.
 		if ( ! empty( $all_discrepancies ) ) {
 			WP_CLI::line( '' );
 			WP_CLI::line( sprintf( 'Found %d total discrepancies:', count( $all_discrepancies ) ) );
 			WP_CLI::line( '' );
 
-			// Prepare table data with node columns
+			// Prepare table data with node columns.
 			$table_data = [];
 			foreach ( $all_discrepancies as $discrepancy ) {
-				// Fill in missing node statuses with empty string
+				// Fill in missing node statuses with empty string.
 				foreach ( $node_columns as $column ) {
 					if ( ! isset( $discrepancy[ $column ] ) && ! in_array( $column, [ 'email', 'network_id', 'hub_status' ] ) ) {
 						$discrepancy[ $column ] = '';
@@ -167,7 +167,7 @@ class Integrity_Check {
 				$table_data[] = $discrepancy;
 			}
 
-			// Display as table using WP-CLI's table formatter
+			// Display as table using WP-CLI's table formatter.
 			WP_CLI\Utils\format_items( 'table', $table_data, $node_columns );
 		}
 
@@ -484,7 +484,7 @@ class Integrity_Check {
 			$hub_status = $hub_item ? $hub_item['status'] : 'NOT_FOUND';
 			$node_status = $node_item ? $node_item['status'] : 'NOT_FOUND';
 			
-			// Extract email and network_id for display
+			// Extract email and network_id for display.
 			$parts = explode( '::', $key );
 			$email = $parts[0];
 			$network_id = $parts[1];

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -45,9 +45,6 @@ class Integrity_Check {
 	 * [--verbose]
 	 * : Output verbose information during the check.
 	 *
-	 * [--fix-discrepancies]
-	 * : Attempt to fix discrepancies found during the check.
-	 *
 	 * [--chunk-size=<size>]
 	 * : Maximum number of memberships to compare in each chunk (default: 1000).
 	 *
@@ -67,7 +64,6 @@ class Integrity_Check {
 	 */
 	public static function integrity_check( $args, $assoc_args ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
 		$verbose = isset( $assoc_args['verbose'] ) ? true : false;
-		$fix_discrepancies = isset( $assoc_args['fix-discrepancies'] ) ? true : false;
 		$chunk_size = isset( $assoc_args['chunk-size'] ) ? intval( $assoc_args['chunk-size'] ) : 1000;
 		$max_records = isset( $assoc_args['max'] ) ? intval( $assoc_args['max'] ) : null;
 
@@ -165,10 +161,6 @@ class Integrity_Check {
 
 			// Display as table using WP-CLI's table formatter.
 			WP_CLI\Utils\format_items( 'table', $table_data, $node_columns );
-		}
-
-		if ( $fix_discrepancies ) {
-			WP_CLI::line( 'Fix discrepancies functionality would be implemented here.' );
 		}
 	}
 

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -229,77 +229,6 @@ class Integrity_Check {
 	}
 
 	/**
-	 * Get chunk hash from a node via REST API
-	 *
-	 * @param \Newspack_Network\Node\Node $node The node to query.
-	 * @param int                         $offset The offset for the chunk.
-	 * @param int                         $limit The limit for the chunk.
-	 * @return string The chunk hash from the node
-	 */
-	private static function get_node_chunk_hash( $node, $offset, $limit ) {
-		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/chunk-hash', $node->get_url() );
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
-		$response = wp_remote_get(
-			add_query_arg(
-				[
-					'offset' => $offset,
-					'limit'  => $limit,
-				],
-				$endpoint
-			),
-			[
-				'headers' => $node->get_authorization_headers( 'integrity-check' ),
-				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
-			]
-		);
-
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			WP_CLI::error( sprintf( 'Failed to get chunk hash from node: %s', $node->get_url() ) );
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-
-		return $data['hash'] ?? '';
-	}
-
-	/**
-	 * Get chunk data from a node via REST API
-	 *
-	 * @param \Newspack_Network\Node\Node $node The node to query.
-	 * @param int                         $offset The offset for the chunk.
-	 * @param int                         $limit The limit for the chunk.
-	 * @return array The chunk data from the node
-	 */
-	private static function get_node_chunk_data( $node, $offset, $limit ) {
-		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/chunk-data', $node->get_url() );
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
-		$response = wp_remote_get(
-			add_query_arg(
-				[
-					'offset' => $offset,
-					'limit'  => $limit,
-				],
-				$endpoint
-			),
-			[
-				'headers' => $node->get_authorization_headers( 'integrity-check' ),
-				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
-			]
-		);
-
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			WP_CLI::error( sprintf( 'Failed to get chunk data from node: %s', $node->get_url() ) );
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-
-		return $data['memberships'] ?? [];
-	}
-
-
-	/**
 	 * Find specific discrepancies between hub and node data using range-based chunked approach
 	 *
 	 * Uses email address ranges instead of positional offsets to avoid the "shifting problem":
@@ -534,16 +463,17 @@ class Integrity_Check {
 
 
 	/**
-	 * Get range hash from a node via REST API
+	 * Get range data from a node via REST API (common implementation)
 	 *
 	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @param string                      $endpoint_type The endpoint type ('range-hash' or 'range-data').
 	 * @param string                      $start_email Start email for the range.
 	 * @param string                      $end_email End email for the range.
-	 * @param int|null                    $max_records Maximum number of records to include in hash (for testing).
-	 * @return string The range hash from the node
+	 * @param int|null                    $max_records Maximum number of records (for testing).
+	 * @return mixed The response data from the node
 	 */
-	private static function get_node_range_hash( $node, $start_email, $end_email, $max_records = null ) {
-		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-hash', $node->get_url() );
+	private static function get_node_range_request( $node, $endpoint_type, $start_email, $end_email, $max_records = null ) {
+		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/%s', $node->get_url(), $endpoint_type );
 
 		$query_args = [
 			'start' => strtolower( $start_email ),
@@ -565,12 +495,25 @@ class Integrity_Check {
 		);
 
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			WP_CLI::error( sprintf( 'Failed to get range hash from node: %s', $node->get_url() ) );
+			$error_type = str_replace( '-', ' ', $endpoint_type );
+			WP_CLI::error( sprintf( 'Failed to get %s from node: %s', $error_type, $node->get_url() ) );
 		}
 
 		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
+		return json_decode( $body, true );
+	}
 
+	/**
+	 * Get range hash from a node via REST API
+	 *
+	 * @param \Newspack_Network\Node\Node $node The node to query.
+	 * @param string                      $start_email Start email for the range.
+	 * @param string                      $end_email End email for the range.
+	 * @param int|null                    $max_records Maximum number of records to include in hash (for testing).
+	 * @return string The range hash from the node
+	 */
+	private static function get_node_range_hash( $node, $start_email, $end_email, $max_records = null ) {
+		$data = self::get_node_range_request( $node, 'range-hash', $start_email, $end_email, $max_records );
 		return $data['hash'] ?? '';
 	}
 
@@ -584,34 +527,7 @@ class Integrity_Check {
 	 * @return array The range data from the node
 	 */
 	private static function get_node_range_data( $node, $start_email, $end_email, $max_records = null ) {
-		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-data', $node->get_url() );
-
-		$query_args = [
-			'start' => strtolower( $start_email ),
-			'end'   => strtolower( $end_email ),
-			'_t'    => time(), // Cache-busting parameter.
-		];
-
-		if ( $max_records ) {
-			$query_args['max'] = $max_records;
-		}
-
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
-		$response = wp_remote_get(
-			add_query_arg( $query_args, $endpoint ),
-			[
-				'headers' => $node->get_authorization_headers( 'integrity-check' ),
-				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
-			]
-		);
-
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			WP_CLI::error( sprintf( 'Failed to get range data from node: %s', $node->get_url() ) );
-		}
-
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-
+		$data = self::get_node_range_request( $node, 'range-data', $start_email, $end_email, $max_records );
 		return $data['memberships'] ?? [];
 	}
 }

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -172,7 +172,7 @@ class Integrity_Check {
 			WHERE p.post_type = 'wc_user_membership'
 			AND pm_network.meta_value IS NOT NULL
 			AND pm_network.meta_value != ''
-			ORDER BY u.user_email ASC
+			ORDER BY LOWER(u.user_email) ASC
 		";
 		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 
@@ -186,7 +186,7 @@ class Integrity_Check {
 		$membership_data = [];
 		foreach ( $results as $result ) {
 			$membership_data[] = [
-				'email'  => $result->user_email,
+				'email'  => strtolower( $result->user_email ),
 				'status' => $result->status,
 			];
 		}
@@ -378,7 +378,7 @@ class Integrity_Check {
 			$hub_chunk_hash = self::generate_hash( $hub_chunk );
 
 			// Get corresponding chunk hash from node using range.
-			$node_chunk_hash = self::get_node_range_hash( $node, $range['start'], $range['end'] );
+			$node_chunk_hash = self::get_node_range_hash( $node, $range['start'], $range['end'], $max_records );
 
 			if ( $verbose ) {
 				WP_CLI::line(
@@ -407,7 +407,7 @@ class Integrity_Check {
 				WP_CLI::line( sprintf( '    ✗ Chunk %d mismatch - fetching detailed data', $chunk_index + 1 ) );
 			}
 
-			$node_chunk_data = self::get_node_range_data( $node, $range['start'], $range['end'] );
+			$node_chunk_data = self::get_node_range_data( $node, $range['start'], $range['end'], $max_records );
 			$chunk_discrepancies = self::compare_chunk_data( $hub_chunk, $node_chunk_data );
 
 			$all_discrepancies = array_merge( $all_discrepancies, $chunk_discrepancies );
@@ -511,8 +511,11 @@ class Integrity_Check {
 	 */
 	private static function filter_data_by_range( $data, $start_email, $end_email ) {
 		$filtered = [];
+		$start_email = strtolower( $start_email );
+		$end_email = strtolower( $end_email );
+		
 		foreach ( $data as $item ) {
-			$email = $item['email'];
+			$email = strtolower( $item['email'] );
 			if ( $email >= $start_email && $email <= $end_email ) {
 				$filtered[] = $item;
 			}
@@ -526,19 +529,24 @@ class Integrity_Check {
 	 * @param \Newspack_Network\Node\Node $node The node to query.
 	 * @param string                      $start_email Start email for the range.
 	 * @param string                      $end_email End email for the range.
+	 * @param int|null                    $max_records Maximum number of records to include in hash (for testing).
 	 * @return string The range hash from the node
 	 */
-	private static function get_node_range_hash( $node, $start_email, $end_email ) {
+	private static function get_node_range_hash( $node, $start_email, $end_email, $max_records = null ) {
 		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-hash', $node->get_url() );
+		
+		$query_args = [
+			'start' => strtolower( $start_email ),
+			'end'   => strtolower( $end_email ),
+		];
+		
+		if ( $max_records ) {
+			$query_args['max'] = $max_records;
+		}
+
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		$response = wp_remote_get(
-			add_query_arg(
-				[
-					'start' => $start_email,
-					'end'   => $end_email,
-				],
-				$endpoint
-			),
+			add_query_arg( $query_args, $endpoint ),
 			[
 				'headers' => $node->get_authorization_headers( 'integrity-check' ),
 				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
@@ -561,19 +569,24 @@ class Integrity_Check {
 	 * @param \Newspack_Network\Node\Node $node The node to query.
 	 * @param string                      $start_email Start email for the range.
 	 * @param string                      $end_email End email for the range.
+	 * @param int|null                    $max_records Maximum number of records to return (for testing).
 	 * @return array The range data from the node
 	 */
-	private static function get_node_range_data( $node, $start_email, $end_email ) {
+	private static function get_node_range_data( $node, $start_email, $end_email, $max_records = null ) {
 		$endpoint = sprintf( '%s/wp-json/newspack-network/v1/integrity-check/range-data', $node->get_url() );
+		
+		$query_args = [
+			'start' => strtolower( $start_email ),
+			'end'   => strtolower( $end_email ),
+		];
+		
+		if ( $max_records ) {
+			$query_args['max'] = $max_records;
+		}
+
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 		$response = wp_remote_get(
-			add_query_arg(
-				[
-					'start' => $start_email,
-					'end'   => $end_email,
-				],
-				$endpoint
-			),
+			add_query_arg( $query_args, $endpoint ),
 			[
 				'headers' => $node->get_authorization_headers( 'integrity-check' ),
 				'timeout' => 60, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout

--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -440,11 +440,11 @@ class Integrity_Check {
 	}
 
 	/**
-	 * Create email ranges based on actual data distribution
+	 * Create fixed email ranges for consistent chunking
 	 *
-	 * Creates content-based ranges instead of positional chunks to solve the shifting problem.
-	 * Each range covers a specific email address span (e.g., 'a@domain.com' to 'm@domain.com').
-	 * When emails are added/removed, only the affected range needs re-checking, not all chunks.
+	 * Creates fixed alphabetical ranges that are consistent across hub and nodes
+	 * regardless of data distribution differences. This prevents boundary mismatches
+	 * that occur when hub and nodes have different membership counts.
 	 *
 	 * @param array $hub_data Hub membership data (sorted by email).
 	 * @param int   $target_chunk_size Target number of emails per chunk.
@@ -455,32 +455,93 @@ class Integrity_Check {
 			return [];
 		}
 
+		// Use fixed alphabetical ranges instead of data-dependent ranges.
+		// This ensures consistent boundaries regardless of data distribution.
+		$fixed_ranges = [
+			[
+				'start' => '0',
+				'end'   => 'c',
+			],
+			[
+				'start' => 'd',
+				'end'   => 'g',
+			],
+			[
+				'start' => 'h',
+				'end'   => 'k',
+			],
+			[
+				'start' => 'l',
+				'end'   => 'o',
+			],
+			[
+				'start' => 'p',
+				'end'   => 's',
+			],
+			[
+				'start' => 't',
+				'end'   => 'zzzzz',
+			],
+		];
+
+		// Calculate target ranges based on data size and target chunk size.
 		$total_emails = count( $hub_data );
-		$num_chunks = max( 1, ceil( $total_emails / $target_chunk_size ) );
-		$actual_chunk_size = ceil( $total_emails / $num_chunks );
-
-		$ranges = [];
-		for ( $i = 0; $i < $num_chunks; $i++ ) {
-			$start_index = $i * $actual_chunk_size;
-			$end_index = min( ( $i + 1 ) * $actual_chunk_size - 1, $total_emails - 1 );
-
-			$start_email = $hub_data[ $start_index ]['email'];
+		$target_ranges = max( 1, ceil( $total_emails / $target_chunk_size ) );
+		
+		// If we need fewer ranges, combine adjacent ranges.
+		if ( $target_ranges < count( $fixed_ranges ) ) {
+			$consolidated_ranges = [];
+			$ranges_per_group = ceil( count( $fixed_ranges ) / $target_ranges );
 			
-			// For the last chunk, extend to ensure we capture everything beyond the last email.
-			if ( $i === $num_chunks - 1 ) {
-				$end_email_boundary = 'zzzzz';
-			} else {
-				// Use the last email of this chunk as the end boundary.
-				$end_email_boundary = $hub_data[ $end_index ]['email'];
+			$current_idx = 0;
+			$fixed_ranges_count = count( $fixed_ranges );
+			while ( $current_idx < $fixed_ranges_count ) {
+				$start_idx = $current_idx;
+				$end_idx = min( $current_idx + $ranges_per_group - 1, $fixed_ranges_count - 1 );
+				
+				$consolidated_ranges[] = [
+					'start' => $fixed_ranges[ $start_idx ]['start'],
+					'end'   => $fixed_ranges[ $end_idx ]['end'],
+				];
+				
+				$current_idx += $ranges_per_group;
 			}
-
-			$ranges[] = [
-				'start' => $start_email,
-				'end'   => $end_email_boundary,
-			];
+			
+			return $consolidated_ranges;
+		}
+		
+		// If we need more ranges, subdivide the alphabet further.
+		if ( $target_ranges > count( $fixed_ranges ) ) {
+			$alphabet = 'abcdefghijklmnopqrstuvwxyz';
+			$ranges = [];
+			$chars_per_range = max( 1, floor( 26 / $target_ranges ) );
+			
+			// Ensure we don't exceed available alphabet characters.
+			$actual_target_ranges = min( $target_ranges, 26 );
+			
+			for ( $i = 0; $i < $actual_target_ranges; $i++ ) {
+				$start_char_idx = $i * $chars_per_range;
+				$end_char_idx = min( $start_char_idx + $chars_per_range - 1, 25 );
+				
+				// Validate array bounds.
+				if ( $start_char_idx >= 26 ) {
+					break;
+				}
+				
+				$start_char = $alphabet[ $start_char_idx ];
+				$end_char = ( $i === $actual_target_ranges - 1 ) ? 'zzzzz' : $alphabet[ $end_char_idx ];
+				
+				$ranges[] = [
+					'start' => $start_char,
+					'end'   => $end_char,
+				];
+			}
+			
+			return $ranges;
 		}
 
-		return $ranges;
+		// Default to fixed ranges.
+		return $fixed_ranges;
 	}
 
 

--- a/includes/node/class-integrity-check-endpoints.php
+++ b/includes/node/class-integrity-check-endpoints.php
@@ -1,0 +1,444 @@
+<?php
+/**
+ * Newspack Network Node integrity check endpoints.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Node;
+
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+
+/**
+ * Class that registers the integrity check endpoints for nodes
+ */
+class Integrity_Check_Endpoints {
+	/**
+	 * Runs the initialization.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+	}
+
+	/**
+	 * Register the routes for the integrity check endpoints.
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			'newspack-network/v1',
+			'/integrity-check/hash',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_hash_request' ],
+					'permission_callback' => function( $request ) {
+						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
+					},
+				],
+			]
+		);
+
+		register_rest_route(
+			'newspack-network/v1',
+			'/integrity-check/memberships',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_memberships_request' ],
+					'permission_callback' => function( $request ) {
+						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
+					},
+				],
+			]
+		);
+
+		register_rest_route(
+			'newspack-network/v1',
+			'/integrity-check/chunk-hash',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_chunk_hash_request' ],
+					'permission_callback' => function( $request ) {
+						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
+					},
+					'args'                => [
+						'offset' => [
+							'required' => true,
+							'type'     => 'integer',
+							'minimum'  => 0,
+						],
+						'limit'  => [
+							'required' => true,
+							'type'     => 'integer',
+							'minimum'  => 1,
+							'maximum'  => 5000,
+						],
+					],
+				],
+			]
+		);
+
+		register_rest_route(
+			'newspack-network/v1',
+			'/integrity-check/chunk-data',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_chunk_data_request' ],
+					'permission_callback' => function( $request ) {
+						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
+					},
+					'args'                => [
+						'offset' => [
+							'required' => true,
+							'type'     => 'integer',
+							'minimum'  => 0,
+						],
+						'limit'  => [
+							'required' => true,
+							'type'     => 'integer',
+							'minimum'  => 1,
+							'maximum'  => 5000,
+						],
+					],
+				],
+			]
+		);
+
+		register_rest_route(
+			'newspack-network/v1',
+			'/integrity-check/range-hash',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_range_hash_request' ],
+					'permission_callback' => function( $request ) {
+						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
+					},
+					'args'                => [
+						'start' => [
+							'required' => true,
+							'type'     => 'string',
+						],
+						'end'   => [
+							'required' => true,
+							'type'     => 'string',
+						],
+					],
+				],
+			]
+		);
+
+		register_rest_route(
+			'newspack-network/v1',
+			'/integrity-check/range-data',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'handle_range_data_request' ],
+					'permission_callback' => function( $request ) {
+						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
+					},
+					'args'                => [
+						'start' => [
+							'required' => true,
+							'type'     => 'string',
+						],
+						'end'   => [
+							'required' => true,
+							'type'     => 'string',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Handles the hash request.
+	 *
+	 * Returns hash for memberships within a specific email range, enabling range-based
+	 * chunking that avoids the shifting problem of positional chunks.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 */
+	public static function handle_hash_request( $request ) {
+		$max_records = $request->get_param( 'max' );
+		$membership_data = self::get_node_membership_data( $max_records );
+		$hash = self::generate_hash( $membership_data );
+
+		return rest_ensure_response(
+			[
+				'hash'  => $hash,
+				'count' => count( $membership_data ),
+			]
+		);
+	}
+
+	/**
+	 * Handles the memberships request.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 */
+	public static function handle_memberships_request( $request ) {
+		$membership_data = self::get_node_membership_data();
+
+		return rest_ensure_response(
+			[
+				'memberships' => $membership_data,
+				'count'       => count( $membership_data ),
+			]
+		);
+	}
+
+	/**
+	 * Handles the chunk hash request.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 */
+	public static function handle_chunk_hash_request( $request ) {
+		$offset = intval( $request->get_param( 'offset' ) );
+		$limit = intval( $request->get_param( 'limit' ) );
+
+		$chunk_data = self::get_node_membership_data_chunk( $offset, $limit );
+		$hash = self::generate_hash( $chunk_data );
+
+		return rest_ensure_response(
+			[
+				'hash'   => $hash,
+				'offset' => $offset,
+				'limit'  => $limit,
+				'count'  => count( $chunk_data ),
+			]
+		);
+	}
+
+	/**
+	 * Handles the chunk data request.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 */
+	public static function handle_chunk_data_request( $request ) {
+		$offset = intval( $request->get_param( 'offset' ) );
+		$limit = intval( $request->get_param( 'limit' ) );
+
+		$chunk_data = self::get_node_membership_data_chunk( $offset, $limit );
+
+		return rest_ensure_response(
+			[
+				'memberships' => $chunk_data,
+				'offset'      => $offset,
+				'limit'       => $limit,
+				'count'       => count( $chunk_data ),
+			]
+		);
+	}
+
+	/**
+	 * Handles the range hash request.
+	 *
+	 * Returns hash for memberships within a specific email range, enabling range-based
+	 * chunking that avoids the shifting problem of positional chunks.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 */
+	public static function handle_range_hash_request( $request ) {
+		$start_email = $request->get_param( 'start' );
+		$end_email = $request->get_param( 'end' );
+
+		$range_data = self::get_node_membership_data_range( $start_email, $end_email );
+		$hash = self::generate_hash( $range_data );
+
+		return rest_ensure_response(
+			[
+				'hash'  => $hash,
+				'start' => $start_email,
+				'end'   => $end_email,
+				'count' => count( $range_data ),
+			]
+		);
+	}
+
+	/**
+	 * Handles the range data request.
+	 *
+	 * @param \WP_REST_Request $request The REST request object.
+	 */
+	public static function handle_range_data_request( $request ) {
+		$start_email = $request->get_param( 'start' );
+		$end_email = $request->get_param( 'end' );
+
+		$range_data = self::get_node_membership_data_range( $start_email, $end_email );
+
+		return rest_ensure_response(
+			[
+				'memberships' => $range_data,
+				'start'       => $start_email,
+				'end'         => $end_email,
+				'count'       => count( $range_data ),
+			]
+		);
+	}
+
+	/**
+	 * Get all membership data from the node
+	 *
+	 * @param int|null $max_records Maximum number of records to return (for testing).
+	 * @return array Array of (email, status) pairs
+	 */
+	private static function get_node_membership_data( $max_records = null ) {
+		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$query = "
+			SELECT DISTINCT
+				u.user_email,
+				p.post_status as status
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
+			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
+			WHERE p.post_type = 'wc_user_membership'
+			AND pm_network.meta_value IS NOT NULL
+			AND pm_network.meta_value != ''
+			ORDER BY u.user_email ASC
+		";
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		if ( $max_records ) {
+			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY ) );
+
+		$membership_data = [];
+		foreach ( $results as $result ) {
+			$membership_data[] = [
+				'email'  => $result->user_email,
+				'status' => $result->status,
+			];
+		}
+
+		return $membership_data;
+	}
+
+	/**
+	 * Get a chunk of membership data from the node
+	 *
+	 * @param int $offset The offset to start from.
+	 * @param int $limit The number of records to return.
+	 * @return array Array of (email, status) pairs
+	 */
+	private static function get_node_membership_data_chunk( $offset, $limit ) {
+		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$query = "
+			SELECT DISTINCT
+				u.user_email,
+				p.post_status as status
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
+			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
+			WHERE p.post_type = 'wc_user_membership'
+			AND pm_network.meta_value IS NOT NULL
+			AND pm_network.meta_value != ''
+			ORDER BY u.user_email ASC
+			LIMIT %d, %d
+		";
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, $offset, $limit ) );
+
+		$membership_data = [];
+		foreach ( $results as $result ) {
+			$membership_data[] = [
+				'email'  => $result->user_email,
+				'status' => $result->status,
+			];
+		}
+
+		return $membership_data;
+	}
+
+	/**
+	 * Get membership data from the node within an email range
+	 *
+	 * Filters memberships by email address range rather than positional offset.
+	 * This enables range-based chunking that's resilient to data shifts when
+	 * memberships are added/removed from the beginning or middle of the dataset.
+	 *
+	 * @param string $start_email The start email (inclusive).
+	 * @param string $end_email The end email (inclusive).
+	 * @return array Array of (email, status) pairs
+	 */
+	private static function get_node_membership_data_range( $start_email, $end_email ) {
+		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
+			return [];
+		}
+
+		global $wpdb;
+
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$query = "
+			SELECT DISTINCT
+				u.user_email,
+				p.post_status as status
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
+			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
+			WHERE p.post_type = 'wc_user_membership'
+			AND pm_network.meta_value IS NOT NULL
+			AND pm_network.meta_value != ''
+			AND u.user_email >= %s
+			AND u.user_email <= %s
+			ORDER BY u.user_email ASC
+		";
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, $start_email, $end_email ) );
+
+		$membership_data = [];
+		foreach ( $results as $result ) {
+			$membership_data[] = [
+				'email'  => $result->user_email,
+				'status' => $result->status,
+			];
+		}
+
+		return $membership_data;
+	}
+
+	/**
+	 * Generate a hash from membership data
+	 *
+	 * @param array $data Array of (email, status) pairs.
+	 * @return string SHA-256 hash
+	 */
+	private static function generate_hash( $data ) {
+		if ( empty( $data ) ) {
+			return '';
+		}
+
+		// Create a string representation of the data for hashing.
+		$hash_string = '';
+		foreach ( $data as $item ) {
+			$hash_string .= $item['email'] . ':' . $item['status'] . "\n";
+		}
+
+		return hash( 'sha256', $hash_string );
+	}
+}

--- a/includes/node/class-integrity-check-endpoints.php
+++ b/includes/node/class-integrity-check-endpoints.php
@@ -212,7 +212,8 @@ class Integrity_Check_Endpoints {
 		$query = "
 			SELECT DISTINCT 
 				u.user_email,
-				p.post_status as status
+				p.post_status as status,
+				pm_network.meta_value as network_id
 			FROM {$wpdb->posts} p
 			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
 			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
@@ -232,8 +233,9 @@ class Integrity_Check_Endpoints {
 		$membership_data = [];
 		foreach ( $results as $result ) {
 			$membership_data[] = [
-				'email'  => strtolower( $result->user_email ),
-				'status' => $result->status,
+				'email'      => strtolower( $result->user_email ),
+				'status'     => $result->status,
+				'network_id' => $result->network_id,
 			];
 		}
 
@@ -262,7 +264,8 @@ class Integrity_Check_Endpoints {
 		$query = "
 			SELECT DISTINCT 
 				u.user_email,
-				p.post_status as status
+				p.post_status as status,
+				pm_network.meta_value as network_id
 			FROM {$wpdb->posts} p
 			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
 			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
@@ -284,8 +287,9 @@ class Integrity_Check_Endpoints {
 		$membership_data = [];
 		foreach ( $results as $result ) {
 			$membership_data[] = [
-				'email'  => strtolower( $result->user_email ),
-				'status' => $result->status,
+				'email'      => strtolower( $result->user_email ),
+				'status'     => $result->status,
+				'network_id' => $result->network_id,
 			];
 		}
 
@@ -306,7 +310,7 @@ class Integrity_Check_Endpoints {
 		// Create a string representation of the data for hashing.
 		$hash_string = '';
 		foreach ( $data as $item ) {
-			$hash_string .= $item['email'] . ':' . $item['status'] . "\n";
+			$hash_string .= $item['email'] . ':' . $item['status'] . ':' . $item['network_id'] . "\n";
 		}
 
 		return hash( 'sha256', $hash_string );

--- a/includes/node/class-integrity-check-endpoints.php
+++ b/includes/node/class-integrity-check-endpoints.php
@@ -209,6 +209,7 @@ class Integrity_Check_Endpoints {
 
 		global $wpdb;
 
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 		$query = "
 			SELECT DISTINCT 
 				u.user_email,
@@ -227,8 +228,9 @@ class Integrity_Check_Endpoints {
 			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY ) );
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 
 		$membership_data = [];
 		foreach ( $results as $result ) {
@@ -261,6 +263,7 @@ class Integrity_Check_Endpoints {
 
 		global $wpdb;
 
+		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 		$query = "
 			SELECT DISTINCT 
 				u.user_email,
@@ -281,8 +284,9 @@ class Integrity_Check_Endpoints {
 			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, $start_email, $end_email ) );
+		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 
 		$membership_data = [];
 		foreach ( $results as $result ) {

--- a/includes/node/class-integrity-check-endpoints.php
+++ b/includes/node/class-integrity-check-endpoints.php
@@ -7,7 +7,7 @@
 
 namespace Newspack_Network\Node;
 
-use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+use Newspack_Network\Integrity_Check_Utils;
 
 /**
  * Class that registers the integrity check endpoints for nodes
@@ -121,8 +121,8 @@ class Integrity_Check_Endpoints {
 	 */
 	public static function handle_hash_request( $request ) {
 		$max_records = $request->get_param( 'max' );
-		$membership_data = self::get_node_membership_data( $max_records );
-		$hash = self::generate_hash( $membership_data );
+		$membership_data = Integrity_Check_Utils::get_membership_data( $max_records );
+		$hash = Integrity_Check_Utils::generate_hash( $membership_data );
 
 		return rest_ensure_response(
 			[
@@ -138,7 +138,7 @@ class Integrity_Check_Endpoints {
 	 * @param \WP_REST_Request $request The REST request object.
 	 */
 	public static function handle_memberships_request( $request ) {
-		$membership_data = self::get_node_membership_data();
+		$membership_data = Integrity_Check_Utils::get_membership_data();
 
 		return rest_ensure_response(
 			[
@@ -161,8 +161,8 @@ class Integrity_Check_Endpoints {
 		$end_email = strtolower( $request->get_param( 'end' ) );
 		$max_records = $request->get_param( 'max' );
 
-		$range_data = self::get_node_membership_data_range( $start_email, $end_email, $max_records );
-		$hash = self::generate_hash( $range_data );
+		$range_data = Integrity_Check_Utils::get_membership_data_range( $start_email, $end_email, $max_records );
+		$hash = Integrity_Check_Utils::generate_hash( $range_data );
 
 		return rest_ensure_response(
 			[
@@ -184,7 +184,7 @@ class Integrity_Check_Endpoints {
 		$end_email = strtolower( $request->get_param( 'end' ) );
 		$max_records = $request->get_param( 'max' );
 
-		$range_data = self::get_node_membership_data_range( $start_email, $end_email, $max_records );
+		$range_data = Integrity_Check_Utils::get_membership_data_range( $start_email, $end_email, $max_records );
 
 		return rest_ensure_response(
 			[
@@ -194,129 +194,5 @@ class Integrity_Check_Endpoints {
 				'count'       => count( $range_data ),
 			]
 		);
-	}
-
-	/**
-	 * Get all membership data from the node
-	 *
-	 * @param int|null $max_records Maximum number of records to return (for testing).
-	 * @return array Array of (email, status) pairs
-	 */
-	private static function get_node_membership_data( $max_records = null ) {
-		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
-			return [];
-		}
-
-		global $wpdb;
-
-		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-		$query = "
-			SELECT DISTINCT 
-				u.user_email,
-				p.post_status as status,
-				pm_network.meta_value as network_id
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
-			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
-			WHERE p.post_type = 'wc_user_membership'
-			AND pm_network.meta_value IS NOT NULL
-			AND pm_network.meta_value != ''
-			ORDER BY LOWER(u.user_email) ASC
-		";
-
-		if ( $max_records ) {
-			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
-		}
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY ) );
-		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-
-		$membership_data = [];
-		foreach ( $results as $result ) {
-			$membership_data[] = [
-				'email'      => strtolower( $result->user_email ),
-				'status'     => $result->status,
-				'network_id' => $result->network_id,
-			];
-		}
-
-		return $membership_data;
-	}
-
-	/**
-	 * Get membership data from the node within an email range
-	 *
-	 * Filters memberships by email address range rather than positional offset.
-	 * This enables range-based chunking that's resilient to data shifts when
-	 * memberships are added/removed from the beginning or middle of the dataset.
-	 *
-	 * @param string   $start_email The start email (inclusive).
-	 * @param string   $end_email The end email (inclusive).
-	 * @param int|null $max_records Maximum number of records to return (for testing).
-	 * @return array Array of (email, status) pairs
-	 */
-	private static function get_node_membership_data_range( $start_email, $end_email, $max_records = null ) {
-		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
-			return [];
-		}
-
-		global $wpdb;
-
-		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-		$query = "
-			SELECT DISTINCT 
-				u.user_email,
-				p.post_status as status,
-				pm_network.meta_value as network_id
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
-			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
-			WHERE p.post_type = 'wc_user_membership'
-			AND pm_network.meta_value IS NOT NULL
-			AND pm_network.meta_value != ''
-			AND LOWER(u.user_email) >= %s
-			AND LOWER(u.user_email) <= %s
-			ORDER BY LOWER(u.user_email) ASC
-		";
-
-		if ( $max_records ) {
-			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
-		}
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, $start_email, $end_email ) );
-		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-
-		$membership_data = [];
-		foreach ( $results as $result ) {
-			$membership_data[] = [
-				'email'      => strtolower( $result->user_email ),
-				'status'     => $result->status,
-				'network_id' => $result->network_id,
-			];
-		}
-
-		return $membership_data;
-	}
-
-	/**
-	 * Generate a hash from membership data
-	 *
-	 * @param array $data Array of (email, status) pairs.
-	 * @return string SHA-256 hash
-	 */
-	private static function generate_hash( $data ) {
-		if ( empty( $data ) ) {
-			return '';
-		}
-
-		// Create a string representation of the data for hashing.
-		$hash_string = '';
-		foreach ( $data as $item ) {
-			$hash_string .= $item['email'] . ':' . $item['status'] . ':' . $item['network_id'] . "\n";
-		}
-
-		return hash( 'sha256', $hash_string );
 	}
 }

--- a/includes/node/class-integrity-check-endpoints.php
+++ b/includes/node/class-integrity-check-endpoints.php
@@ -56,60 +56,6 @@ class Integrity_Check_Endpoints {
 
 		register_rest_route(
 			'newspack-network/v1',
-			'/integrity-check/chunk-hash',
-			[
-				[
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_chunk_hash_request' ],
-					'permission_callback' => function( $request ) {
-						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
-					},
-					'args'                => [
-						'offset' => [
-							'required' => true,
-							'type'     => 'integer',
-							'minimum'  => 0,
-						],
-						'limit'  => [
-							'required' => true,
-							'type'     => 'integer',
-							'minimum'  => 1,
-							'maximum'  => 5000,
-						],
-					],
-				],
-			]
-		);
-
-		register_rest_route(
-			'newspack-network/v1',
-			'/integrity-check/chunk-data',
-			[
-				[
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_chunk_data_request' ],
-					'permission_callback' => function( $request ) {
-						return \Newspack_Network\Rest_Authenticaton::verify_signature( $request, 'integrity-check', Settings::get_secret_key() );
-					},
-					'args'                => [
-						'offset' => [
-							'required' => true,
-							'type'     => 'integer',
-							'minimum'  => 0,
-						],
-						'limit'  => [
-							'required' => true,
-							'type'     => 'integer',
-							'minimum'  => 1,
-							'maximum'  => 5000,
-						],
-					],
-				],
-			]
-		);
-
-		register_rest_route(
-			'newspack-network/v1',
 			'/integrity-check/range-hash',
 			[
 				[
@@ -126,6 +72,10 @@ class Integrity_Check_Endpoints {
 						'end'   => [
 							'required' => true,
 							'type'     => 'string',
+						],
+						'max'   => [
+							'required' => false,
+							'type'     => 'integer',
 						],
 					],
 				],
@@ -151,6 +101,10 @@ class Integrity_Check_Endpoints {
 							'required' => true,
 							'type'     => 'string',
 						],
+						'max'   => [
+							'required' => false,
+							'type'     => 'integer',
+						],
 					],
 				],
 			]
@@ -159,7 +113,7 @@ class Integrity_Check_Endpoints {
 
 	/**
 	 * Handles the hash request.
-	 *
+	 * 
 	 * Returns hash for memberships within a specific email range, enabling range-based
 	 * chunking that avoids the shifting problem of positional chunks.
 	 *
@@ -195,61 +149,19 @@ class Integrity_Check_Endpoints {
 	}
 
 	/**
-	 * Handles the chunk hash request.
-	 *
-	 * @param \WP_REST_Request $request The REST request object.
-	 */
-	public static function handle_chunk_hash_request( $request ) {
-		$offset = intval( $request->get_param( 'offset' ) );
-		$limit = intval( $request->get_param( 'limit' ) );
-
-		$chunk_data = self::get_node_membership_data_chunk( $offset, $limit );
-		$hash = self::generate_hash( $chunk_data );
-
-		return rest_ensure_response(
-			[
-				'hash'   => $hash,
-				'offset' => $offset,
-				'limit'  => $limit,
-				'count'  => count( $chunk_data ),
-			]
-		);
-	}
-
-	/**
-	 * Handles the chunk data request.
-	 *
-	 * @param \WP_REST_Request $request The REST request object.
-	 */
-	public static function handle_chunk_data_request( $request ) {
-		$offset = intval( $request->get_param( 'offset' ) );
-		$limit = intval( $request->get_param( 'limit' ) );
-
-		$chunk_data = self::get_node_membership_data_chunk( $offset, $limit );
-
-		return rest_ensure_response(
-			[
-				'memberships' => $chunk_data,
-				'offset'      => $offset,
-				'limit'       => $limit,
-				'count'       => count( $chunk_data ),
-			]
-		);
-	}
-
-	/**
 	 * Handles the range hash request.
-	 *
+	 * 
 	 * Returns hash for memberships within a specific email range, enabling range-based
 	 * chunking that avoids the shifting problem of positional chunks.
 	 *
 	 * @param \WP_REST_Request $request The REST request object.
 	 */
 	public static function handle_range_hash_request( $request ) {
-		$start_email = $request->get_param( 'start' );
-		$end_email = $request->get_param( 'end' );
+		$start_email = strtolower( $request->get_param( 'start' ) );
+		$end_email = strtolower( $request->get_param( 'end' ) );
+		$max_records = $request->get_param( 'max' );
 
-		$range_data = self::get_node_membership_data_range( $start_email, $end_email );
+		$range_data = self::get_node_membership_data_range( $start_email, $end_email, $max_records );
 		$hash = self::generate_hash( $range_data );
 
 		return rest_ensure_response(
@@ -268,10 +180,11 @@ class Integrity_Check_Endpoints {
 	 * @param \WP_REST_Request $request The REST request object.
 	 */
 	public static function handle_range_data_request( $request ) {
-		$start_email = $request->get_param( 'start' );
-		$end_email = $request->get_param( 'end' );
+		$start_email = strtolower( $request->get_param( 'start' ) );
+		$end_email = strtolower( $request->get_param( 'end' ) );
+		$max_records = $request->get_param( 'max' );
 
-		$range_data = self::get_node_membership_data_range( $start_email, $end_email );
+		$range_data = self::get_node_membership_data_range( $start_email, $end_email, $max_records );
 
 		return rest_ensure_response(
 			[
@@ -296,9 +209,8 @@ class Integrity_Check_Endpoints {
 
 		global $wpdb;
 
-		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 		$query = "
-			SELECT DISTINCT
+			SELECT DISTINCT 
 				u.user_email,
 				p.post_status as status
 			FROM {$wpdb->posts} p
@@ -307,9 +219,8 @@ class Integrity_Check_Endpoints {
 			WHERE p.post_type = 'wc_user_membership'
 			AND pm_network.meta_value IS NOT NULL
 			AND pm_network.meta_value != ''
-			ORDER BY u.user_email ASC
+			ORDER BY LOWER(u.user_email) ASC
 		";
-		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 
 		if ( $max_records ) {
 			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
@@ -321,51 +232,7 @@ class Integrity_Check_Endpoints {
 		$membership_data = [];
 		foreach ( $results as $result ) {
 			$membership_data[] = [
-				'email'  => $result->user_email,
-				'status' => $result->status,
-			];
-		}
-
-		return $membership_data;
-	}
-
-	/**
-	 * Get a chunk of membership data from the node
-	 *
-	 * @param int $offset The offset to start from.
-	 * @param int $limit The number of records to return.
-	 * @return array Array of (email, status) pairs
-	 */
-	private static function get_node_membership_data_chunk( $offset, $limit ) {
-		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
-			return [];
-		}
-
-		global $wpdb;
-
-		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-		$query = "
-			SELECT DISTINCT
-				u.user_email,
-				p.post_status as status
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->users} u ON p.post_author = u.ID
-			INNER JOIN {$wpdb->postmeta} pm_network ON p.post_parent = pm_network.post_id AND pm_network.meta_key = %s
-			WHERE p.post_type = 'wc_user_membership'
-			AND pm_network.meta_value IS NOT NULL
-			AND pm_network.meta_value != ''
-			ORDER BY u.user_email ASC
-			LIMIT %d, %d
-		";
-		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
-		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, $offset, $limit ) );
-
-		$membership_data = [];
-		foreach ( $results as $result ) {
-			$membership_data[] = [
-				'email'  => $result->user_email,
+				'email'  => strtolower( $result->user_email ),
 				'status' => $result->status,
 			];
 		}
@@ -380,20 +247,20 @@ class Integrity_Check_Endpoints {
 	 * This enables range-based chunking that's resilient to data shifts when
 	 * memberships are added/removed from the beginning or middle of the dataset.
 	 *
-	 * @param string $start_email The start email (inclusive).
-	 * @param string $end_email The end email (inclusive).
+	 * @param string   $start_email The start email (inclusive).
+	 * @param string   $end_email The end email (inclusive).
+	 * @param int|null $max_records Maximum number of records to return (for testing).
 	 * @return array Array of (email, status) pairs
 	 */
-	private static function get_node_membership_data_range( $start_email, $end_email ) {
+	private static function get_node_membership_data_range( $start_email, $end_email, $max_records = null ) {
 		if ( ! class_exists( 'WC_Memberships_User_Membership' ) ) {
 			return [];
 		}
 
 		global $wpdb;
 
-		// phpcs:disable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 		$query = "
-			SELECT DISTINCT
+			SELECT DISTINCT 
 				u.user_email,
 				p.post_status as status
 			FROM {$wpdb->posts} p
@@ -402,11 +269,14 @@ class Integrity_Check_Endpoints {
 			WHERE p.post_type = 'wc_user_membership'
 			AND pm_network.meta_value IS NOT NULL
 			AND pm_network.meta_value != ''
-			AND u.user_email >= %s
-			AND u.user_email <= %s
-			ORDER BY u.user_email ASC
+			AND LOWER(u.user_email) >= %s
+			AND LOWER(u.user_email) <= %s
+			ORDER BY LOWER(u.user_email) ASC
 		";
-		// phpcs:enable WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+
+		if ( $max_records ) {
+			$query .= $wpdb->prepare( ' LIMIT %d', $max_records );
+		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $wpdb->prepare( $query, Memberships_Admin::NETWORK_ID_META_KEY, $start_email, $end_email ) );
@@ -414,7 +284,7 @@ class Integrity_Check_Endpoints {
 		$membership_data = [];
 		foreach ( $results as $result ) {
 			$membership_data[] = [
-				'email'  => $result->user_email,
+				'email'  => strtolower( $result->user_email ),
 				'status' => $result->status,
 			];
 		}

--- a/tests/unit-tests/test-integrity-check-cli.php
+++ b/tests/unit-tests/test-integrity-check-cli.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Class TestIntegrityCheckCLI
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\CLI\Integrity_Check;
+
+/**
+ * Test the Integrity Check CLI class.
+ */
+class TestIntegrityCheckCLI extends WP_UnitTestCase {
+
+	/**
+	 * Test hash generation for different scenarios
+	 */
+	public function test_generate_hash() {
+		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
+		$generate_hash_method = $integrity_check_reflection->getMethod( 'generate_hash' );
+		$generate_hash_method->setAccessible( true );
+
+		// Empty data should return empty string.
+		$empty_data_hash = $generate_hash_method->invoke( null, [] );
+		$this->assertEquals( '', $empty_data_hash );
+
+		// Single item hash.
+		$single_membership_data = [
+			[
+				'email'      => 'test@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'test-plan',
+			],
+		];
+		$single_item_hash = $generate_hash_method->invoke( null, $single_membership_data );
+		$expected_single_hash = hash( 'sha256', "test@example.com:wcm-active:test-plan\n" );
+		$this->assertEquals( $expected_single_hash, $single_item_hash );
+
+		// Multiple items hash.
+		$multiple_memberships_data = [
+			[
+				'email'      => 'test1@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan-a',
+			],
+			[
+				'email'      => 'test2@example.com',
+				'status'     => 'wcm-cancelled',
+				'network_id' => 'plan-b',
+			],
+		];
+		$multiple_items_hash = $generate_hash_method->invoke( null, $multiple_memberships_data );
+		$expected_multiple_string = "test1@example.com:wcm-active:plan-a\ntest2@example.com:wcm-cancelled:plan-b\n";
+		$expected_multiple_hash = hash( 'sha256', $expected_multiple_string );
+		$this->assertEquals( $expected_multiple_hash, $multiple_items_hash );
+
+		// Hash consistency - same data should produce same hash.
+		$first_consistency_hash = $generate_hash_method->invoke( null, $multiple_memberships_data );
+		$second_consistency_hash = $generate_hash_method->invoke( null, $multiple_memberships_data );
+		$this->assertEquals( $first_consistency_hash, $second_consistency_hash );
+	}
+
+	/**
+	 * Test email range filtering
+	 */
+	public function test_filter_data_by_range() {
+		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
+		$filter_data_by_range_method = $integrity_check_reflection->getMethod( 'filter_data_by_range' );
+		$filter_data_by_range_method->setAccessible( true );
+
+		$membership_test_data = [
+			[
+				'email'      => 'alice@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+			[
+				'email'      => 'bob@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+			[
+				'email'      => 'charlie@example.com',
+				'status'     => 'wcm-cancelled',
+				'network_id' => 'plan2',
+			],
+			[
+				'email'      => 'david@example.com',
+				'status'     => 'wcm-expired',
+				'network_id' => 'plan1',
+			],
+		];
+
+		// Test filtering by range (alice to david should include all).
+		$all_filtered_results = $filter_data_by_range_method->invoke( null, $membership_test_data, 'alice@example.com', 'david@example.com' );
+		$this->assertCount( 4, $all_filtered_results );
+		
+		// Test filtering by range (b to d should include bob, charlie).
+		$partial_filtered_results = $filter_data_by_range_method->invoke( null, $membership_test_data, 'b', 'd' );
+		$this->assertCount( 2, $partial_filtered_results );
+		$this->assertEquals( 'bob@example.com', $partial_filtered_results[0]['email'] );
+		$this->assertEquals( 'charlie@example.com', $partial_filtered_results[1]['email'] );
+
+		// Test case insensitive filtering.
+		$case_insensitive_test_data = [
+			[
+				'email'      => 'Alice@Example.com',
+				'status'     => 'wcm-active', 
+				'network_id' => 'plan1',
+			],
+			[
+				'email'      => 'BOB@EXAMPLE.COM',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+		];
+		$case_insensitive_results = $filter_data_by_range_method->invoke( null, $case_insensitive_test_data, 'a', 'z' );
+		$this->assertCount( 2, $case_insensitive_results );
+	}
+
+	/**
+	 * Test email range creation
+	 */
+	public function test_create_email_ranges() {
+		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
+		$create_email_ranges_method = $integrity_check_reflection->getMethod( 'create_email_ranges' );
+		$create_email_ranges_method->setAccessible( true );
+
+		$email_range_test_data = [
+			[ 'email' => 'a@test.com' ],
+			[ 'email' => 'b@test.com' ],
+			[ 'email' => 'c@test.com' ],
+			[ 'email' => 'd@test.com' ],
+		];
+
+		$created_ranges = $create_email_ranges_method->invoke( null, $email_range_test_data, 2 );
+		$this->assertCount( 2, $created_ranges );
+		
+		// First range.
+		$this->assertEquals( 'a@test.com', $created_ranges[0]['start'] );
+		$this->assertEquals( 'b@test.com', $created_ranges[0]['end'] );
+		
+		// Second range.
+		$this->assertEquals( 'c@test.com', $created_ranges[1]['start'] );
+		// The end boundary depends on whether this is the last chunk.
+		$this->assertTrue( $created_ranges[1]['end'] === 'd@test.com' || $created_ranges[1]['end'] === 'zzzzz' );
+	}
+
+
+	/**
+	 * Test chunk comparison with no discrepancies
+	 */
+	public function test_compare_chunk_data_no_discrepancies() {
+		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
+		$compare_chunk_data_method = $integrity_check_reflection->getMethod( 'compare_chunk_data' );
+		$compare_chunk_data_method->setAccessible( true );
+
+		$matching_hub_chunk = [
+			[
+				'email'      => 'test@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+			[
+				'email'      => 'user@example.com',
+				'status'     => 'wcm-cancelled',
+				'network_id' => 'plan2',
+			],
+		];
+
+		$matching_node_chunk = [
+			[
+				'email'      => 'test@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+			[
+				'email'      => 'user@example.com',
+				'status'     => 'wcm-cancelled',
+				'network_id' => 'plan2',
+			],
+		];
+
+		$no_discrepancy_results = $compare_chunk_data_method->invoke( null, $matching_hub_chunk, $matching_node_chunk );
+		$this->assertEmpty( $no_discrepancy_results );
+	}
+
+	/**
+	 * Test chunk comparison with status discrepancies
+	 */
+	public function test_compare_chunk_data_status_discrepancy() {
+		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
+		$compare_chunk_data_method = $integrity_check_reflection->getMethod( 'compare_chunk_data' );
+		$compare_chunk_data_method->setAccessible( true );
+
+		$hub_chunk_with_active_status = [
+			[
+				'email'      => 'test@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+		];
+
+		$node_chunk_with_cancelled_status = [
+			[
+				'email'      => 'test@example.com',
+				'status'     => 'wcm-cancelled',
+				'network_id' => 'plan1',
+			],
+		];
+
+		$status_discrepancy_results = $compare_chunk_data_method->invoke( null, $hub_chunk_with_active_status, $node_chunk_with_cancelled_status );
+		$this->assertCount( 1, $status_discrepancy_results );
+		$this->assertEquals( 'test@example.com', $status_discrepancy_results[0]['email'] );
+		$this->assertEquals( 'plan1', $status_discrepancy_results[0]['network_id'] );
+		$this->assertEquals( 'wcm-active', $status_discrepancy_results[0]['hub_status'] );
+		$this->assertEquals( 'wcm-cancelled', $status_discrepancy_results[0]['node_status'] );
+	}
+
+	/**
+	 * Test chunk comparison with missing memberships
+	 */
+	public function test_compare_chunk_data_missing_membership() {
+		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
+		$compare_chunk_data_method = $integrity_check_reflection->getMethod( 'compare_chunk_data' );
+		$compare_chunk_data_method->setAccessible( true );
+
+		$hub_chunk_with_test_email = [
+			[
+				'email'      => 'test@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+		];
+
+		$node_chunk_with_different_email = [
+			[
+				'email'      => 'different@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+		];
+
+		$missing_membership_discrepancies = $compare_chunk_data_method->invoke( null, $hub_chunk_with_test_email, $node_chunk_with_different_email );
+		$this->assertCount( 2, $missing_membership_discrepancies );
+		
+		// Check for both NOT_FOUND cases.
+		$discrepancy_emails = array_column( $missing_membership_discrepancies, 'email' );
+		$this->assertContains( 'test@example.com', $discrepancy_emails );
+		$this->assertContains( 'different@example.com', $discrepancy_emails );
+	}
+
+	/**
+	 * Test unique key generation for same email with different network IDs
+	 */
+	public function test_compare_chunk_data_same_email_different_network_id() {
+		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
+		$compare_chunk_data_method = $integrity_check_reflection->getMethod( 'compare_chunk_data' );
+		$compare_chunk_data_method->setAccessible( true );
+
+		$hub_chunk_multiple_plans = [
+			[
+				'email'      => 'user@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+			[
+				'email'      => 'user@example.com',
+				'status'     => 'wcm-cancelled',
+				'network_id' => 'plan2',
+			],
+		];
+
+		$node_chunk_multiple_plans = [
+			[
+				'email'      => 'user@example.com',
+				'status'     => 'wcm-active',
+				'network_id' => 'plan1',
+			],
+			[
+				'email'      => 'user@example.com',
+				'status'     => 'wcm-cancelled',
+				'network_id' => 'plan2',
+			],
+		];
+
+		$multiple_plans_discrepancies = $compare_chunk_data_method->invoke( null, $hub_chunk_multiple_plans, $node_chunk_multiple_plans );
+		$this->assertEmpty( $multiple_plans_discrepancies );
+	}
+}

--- a/tests/unit-tests/test-integrity-check-cli.php
+++ b/tests/unit-tests/test-integrity-check-cli.php
@@ -6,6 +6,7 @@
  */
 
 use Newspack_Network\CLI\Integrity_Check;
+use Newspack_Network\Integrity_Check_Utils;
 
 /**
  * Test the Integrity Check CLI class.
@@ -16,12 +17,9 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 	 * Test hash generation for different scenarios
 	 */
 	public function test_generate_hash() {
-		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
-		$generate_hash_method = $integrity_check_reflection->getMethod( 'generate_hash' );
-		$generate_hash_method->setAccessible( true );
 
 		// Empty data should return empty string.
-		$empty_data_hash = $generate_hash_method->invoke( null, [] );
+		$empty_data_hash = Integrity_Check_Utils::generate_hash( [] );
 		$this->assertEquals( '', $empty_data_hash );
 
 		// Single item hash.
@@ -32,7 +30,7 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 				'network_id' => 'test-plan',
 			],
 		];
-		$single_item_hash = $generate_hash_method->invoke( null, $single_membership_data );
+		$single_item_hash = Integrity_Check_Utils::generate_hash( $single_membership_data );
 		$expected_single_hash = hash( 'sha256', "test@example.com:wcm-active:test-plan\n" );
 		$this->assertEquals( $expected_single_hash, $single_item_hash );
 
@@ -49,14 +47,14 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 				'network_id' => 'plan-b',
 			],
 		];
-		$multiple_items_hash = $generate_hash_method->invoke( null, $multiple_memberships_data );
+		$multiple_items_hash = Integrity_Check_Utils::generate_hash( $multiple_memberships_data );
 		$expected_multiple_string = "test1@example.com:wcm-active:plan-a\ntest2@example.com:wcm-cancelled:plan-b\n";
 		$expected_multiple_hash = hash( 'sha256', $expected_multiple_string );
 		$this->assertEquals( $expected_multiple_hash, $multiple_items_hash );
 
 		// Hash consistency - same data should produce same hash.
-		$first_consistency_hash = $generate_hash_method->invoke( null, $multiple_memberships_data );
-		$second_consistency_hash = $generate_hash_method->invoke( null, $multiple_memberships_data );
+		$first_consistency_hash = Integrity_Check_Utils::generate_hash( $multiple_memberships_data );
+		$second_consistency_hash = Integrity_Check_Utils::generate_hash( $multiple_memberships_data );
 		$this->assertEquals( $first_consistency_hash, $second_consistency_hash );
 	}
 
@@ -64,9 +62,6 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 	 * Test email range filtering
 	 */
 	public function test_filter_data_by_range() {
-		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
-		$filter_data_by_range_method = $integrity_check_reflection->getMethod( 'filter_data_by_range' );
-		$filter_data_by_range_method->setAccessible( true );
 
 		$membership_test_data = [
 			[
@@ -92,11 +87,11 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 		];
 
 		// Test filtering by range (alice to david should include all).
-		$all_filtered_results = $filter_data_by_range_method->invoke( null, $membership_test_data, 'alice@example.com', 'david@example.com' );
+		$all_filtered_results = Integrity_Check_Utils::filter_data_by_range( $membership_test_data, 'alice@example.com', 'david@example.com' );
 		$this->assertCount( 4, $all_filtered_results );
 		
 		// Test filtering by range (b to d should include bob, charlie).
-		$partial_filtered_results = $filter_data_by_range_method->invoke( null, $membership_test_data, 'b', 'd' );
+		$partial_filtered_results = Integrity_Check_Utils::filter_data_by_range( $membership_test_data, 'b', 'd' );
 		$this->assertCount( 2, $partial_filtered_results );
 		$this->assertEquals( 'bob@example.com', $partial_filtered_results[0]['email'] );
 		$this->assertEquals( 'charlie@example.com', $partial_filtered_results[1]['email'] );
@@ -114,7 +109,7 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 				'network_id' => 'plan1',
 			],
 		];
-		$case_insensitive_results = $filter_data_by_range_method->invoke( null, $case_insensitive_test_data, 'a', 'z' );
+		$case_insensitive_results = Integrity_Check_Utils::filter_data_by_range( $case_insensitive_test_data, 'a', 'z' );
 		$this->assertCount( 2, $case_insensitive_results );
 	}
 

--- a/tests/unit-tests/test-integrity-check-cli.php
+++ b/tests/unit-tests/test-integrity-check-cli.php
@@ -89,7 +89,7 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 		// Test filtering by range (alice to david should include all).
 		$all_filtered_results = Integrity_Check_Utils::filter_data_by_range( $membership_test_data, 'alice@example.com', 'david@example.com' );
 		$this->assertCount( 4, $all_filtered_results );
-		
+
 		// Test filtering by range (b to d should include bob, charlie).
 		$partial_filtered_results = Integrity_Check_Utils::filter_data_by_range( $membership_test_data, 'b', 'd' );
 		$this->assertCount( 2, $partial_filtered_results );
@@ -100,7 +100,7 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 		$case_insensitive_test_data = [
 			[
 				'email'      => 'Alice@Example.com',
-				'status'     => 'wcm-active', 
+				'status'     => 'wcm-active',
 				'network_id' => 'plan1',
 			],
 			[
@@ -112,40 +112,6 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 		$case_insensitive_results = Integrity_Check_Utils::filter_data_by_range( $case_insensitive_test_data, 'a', 'z' );
 		$this->assertCount( 2, $case_insensitive_results );
 	}
-
-	/**
-	 * Test email range creation with fixed alphabetical ranges
-	 */
-	public function test_create_email_ranges() {
-		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
-		$create_email_ranges_method = $integrity_check_reflection->getMethod( 'create_email_ranges' );
-		$create_email_ranges_method->setAccessible( true );
-
-		$email_range_test_data = [
-			[ 'email' => 'a@test.com' ],
-			[ 'email' => 'b@test.com' ],
-			[ 'email' => 'c@test.com' ],
-			[ 'email' => 'd@test.com' ],
-		];
-
-		// Test with target chunk size of 2 - should consolidate ranges.
-		$created_ranges = $create_email_ranges_method->invoke( null, $email_range_test_data, 2 );
-		$this->assertCount( 2, $created_ranges );
-		
-		// Fixed ranges are consolidated when fewer chunks are needed.
-		$this->assertEquals( '0', $created_ranges[0]['start'] );
-		$this->assertEquals( 'k', $created_ranges[0]['end'] );
-		
-		$this->assertEquals( 'l', $created_ranges[1]['start'] );
-		$this->assertEquals( 'zzzzz', $created_ranges[1]['end'] );
-		
-		// Test with larger chunk size - should use default fixed ranges.
-		$large_ranges = $create_email_ranges_method->invoke( null, $email_range_test_data, 1000 );
-		$this->assertCount( 1, $large_ranges );
-		$this->assertEquals( '0', $large_ranges[0]['start'] );
-		$this->assertEquals( 'zzzzz', $large_ranges[0]['end'] );
-	}
-
 
 	/**
 	 * Test chunk comparison with no discrepancies
@@ -243,7 +209,7 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 
 		$missing_membership_discrepancies = $compare_chunk_data_method->invoke( null, $hub_chunk_with_test_email, $node_chunk_with_different_email );
 		$this->assertCount( 2, $missing_membership_discrepancies );
-		
+
 		// Check for both NOT_FOUND cases.
 		$discrepancy_emails = array_column( $missing_membership_discrepancies, 'email' );
 		$this->assertContains( 'test@example.com', $discrepancy_emails );

--- a/tests/unit-tests/test-integrity-check-cli.php
+++ b/tests/unit-tests/test-integrity-check-cli.php
@@ -114,7 +114,7 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test email range creation
+	 * Test email range creation with fixed alphabetical ranges
 	 */
 	public function test_create_email_ranges() {
 		$integrity_check_reflection = new ReflectionClass( Integrity_Check::class );
@@ -128,17 +128,22 @@ class TestIntegrityCheckCLI extends WP_UnitTestCase {
 			[ 'email' => 'd@test.com' ],
 		];
 
+		// Test with target chunk size of 2 - should consolidate ranges.
 		$created_ranges = $create_email_ranges_method->invoke( null, $email_range_test_data, 2 );
 		$this->assertCount( 2, $created_ranges );
 		
-		// First range.
-		$this->assertEquals( 'a@test.com', $created_ranges[0]['start'] );
-		$this->assertEquals( 'b@test.com', $created_ranges[0]['end'] );
+		// Fixed ranges are consolidated when fewer chunks are needed.
+		$this->assertEquals( '0', $created_ranges[0]['start'] );
+		$this->assertEquals( 'k', $created_ranges[0]['end'] );
 		
-		// Second range.
-		$this->assertEquals( 'c@test.com', $created_ranges[1]['start'] );
-		// The end boundary depends on whether this is the last chunk.
-		$this->assertTrue( $created_ranges[1]['end'] === 'd@test.com' || $created_ranges[1]['end'] === 'zzzzz' );
+		$this->assertEquals( 'l', $created_ranges[1]['start'] );
+		$this->assertEquals( 'zzzzz', $created_ranges[1]['end'] );
+		
+		// Test with larger chunk size - should use default fixed ranges.
+		$large_ranges = $create_email_ranges_method->invoke( null, $email_range_test_data, 1000 );
+		$this->assertCount( 1, $large_ranges );
+		$this->assertEquals( '0', $large_ranges[0]['start'] );
+		$this->assertEquals( 'zzzzz', $large_ranges[0]['end'] );
 	}
 
 

--- a/tests/unit-tests/test-integrity-check-endpoints.php
+++ b/tests/unit-tests/test-integrity-check-endpoints.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Class TestIntegrityCheckEndpoints
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Node\Integrity_Check_Endpoints;
+
+/**
+ * Test the Integrity Check Endpoints class.
+ */
+class TestIntegrityCheckEndpoints extends WP_UnitTestCase {
+
+	/**
+	 * Test route registration
+	 */
+	public function test_register_routes() {
+		// Clear any existing routes.
+		$GLOBALS['wp_rest_server'] = null;
+		rest_get_server();
+
+		// Register our routes.
+		Integrity_Check_Endpoints::register_routes();
+
+		$registered_routes = rest_get_server()->get_routes();
+
+		// Check that our routes are registered.
+		$this->assertArrayHasKey( '/newspack-network/v1/integrity-check/hash', $registered_routes );
+		$this->assertArrayHasKey( '/newspack-network/v1/integrity-check/memberships', $registered_routes );
+		$this->assertArrayHasKey( '/newspack-network/v1/integrity-check/range-hash', $registered_routes );
+		$this->assertArrayHasKey( '/newspack-network/v1/integrity-check/range-data', $registered_routes );
+	}
+
+	/**
+	 * Test route arguments for range endpoints
+	 */
+	public function test_range_route_arguments() {
+		// Clear any existing routes.
+		$GLOBALS['wp_rest_server'] = null;
+		rest_get_server();
+
+		// Register our routes.
+		Integrity_Check_Endpoints::register_routes();
+
+		$registered_routes = rest_get_server()->get_routes();
+
+		// Check range-hash route arguments.
+		$range_hash_route_config = $registered_routes['/newspack-network/v1/integrity-check/range-hash'][0];
+		$this->assertArrayHasKey( 'args', $range_hash_route_config );
+		$this->assertArrayHasKey( 'start', $range_hash_route_config['args'] );
+		$this->assertArrayHasKey( 'end', $range_hash_route_config['args'] );
+		$this->assertArrayHasKey( 'max', $range_hash_route_config['args'] );
+
+		// Check that start and end are required.
+		$this->assertTrue( $range_hash_route_config['args']['start']['required'] );
+		$this->assertTrue( $range_hash_route_config['args']['end']['required'] );
+		$this->assertFalse( $range_hash_route_config['args']['max']['required'] );
+
+		// Check range-data route arguments.
+		$range_data_route_config = $registered_routes['/newspack-network/v1/integrity-check/range-data'][0];
+		$this->assertArrayHasKey( 'args', $range_data_route_config );
+		$this->assertArrayHasKey( 'start', $range_data_route_config['args'] );
+		$this->assertArrayHasKey( 'end', $range_data_route_config['args'] );
+		$this->assertArrayHasKey( 'max', $range_data_route_config['args'] );
+	}
+
+	/**
+	 * Test basic request handling
+	 */
+	public function test_handle_requests() {
+		// Test hash request.
+		$hash_request = new WP_REST_Request( 'GET', '/newspack-network/v1/integrity-check/hash' );
+		$hash_response = Integrity_Check_Endpoints::handle_hash_request( $hash_request );
+		$hash_response_data = $hash_response->get_data();
+		$this->assertArrayHasKey( 'hash', $hash_response_data );
+		$this->assertArrayHasKey( 'count', $hash_response_data );
+
+		// Test memberships request.
+		$memberships_request = new WP_REST_Request( 'GET', '/newspack-network/v1/integrity-check/memberships' );
+		$memberships_response = Integrity_Check_Endpoints::handle_memberships_request( $memberships_request );
+		$memberships_response_data = $memberships_response->get_data();
+		$this->assertArrayHasKey( 'memberships', $memberships_response_data );
+		$this->assertArrayHasKey( 'count', $memberships_response_data );
+		$this->assertIsArray( $memberships_response_data['memberships'] );
+	}
+
+	/**
+	 * Test range request handling
+	 */
+	public function test_handle_range_requests() {
+		// Test range hash request.
+		$range_hash_request = new WP_REST_Request( 'GET', '/newspack-network/v1/integrity-check/range-hash' );
+		$range_hash_request->set_param( 'start', 'a@example.com' );
+		$range_hash_request->set_param( 'end', 'z@example.com' );
+		$range_hash_response = Integrity_Check_Endpoints::handle_range_hash_request( $range_hash_request );
+		$range_hash_response_data = $range_hash_response->get_data();
+		$this->assertArrayHasKey( 'hash', $range_hash_response_data );
+		$this->assertArrayHasKey( 'start', $range_hash_response_data );
+		$this->assertArrayHasKey( 'end', $range_hash_response_data );
+		$this->assertArrayHasKey( 'count', $range_hash_response_data );
+		$this->assertEquals( 'a@example.com', $range_hash_response_data['start'] );
+		$this->assertEquals( 'z@example.com', $range_hash_response_data['end'] );
+
+		// Test range data request.
+		$range_data_request = new WP_REST_Request( 'GET', '/newspack-network/v1/integrity-check/range-data' );
+		$range_data_request->set_param( 'start', 'b@example.com' );
+		$range_data_request->set_param( 'end', 'y@example.com' );
+		$range_data_response = Integrity_Check_Endpoints::handle_range_data_request( $range_data_request );
+		$range_data_response_data = $range_data_response->get_data();
+		$this->assertArrayHasKey( 'memberships', $range_data_response_data );
+		$this->assertArrayHasKey( 'start', $range_data_response_data );
+		$this->assertArrayHasKey( 'end', $range_data_response_data );
+		$this->assertArrayHasKey( 'count', $range_data_response_data );
+		$this->assertEquals( 'b@example.com', $range_data_response_data['start'] );
+		$this->assertEquals( 'y@example.com', $range_data_response_data['end'] );
+		$this->assertIsArray( $range_data_response_data['memberships'] );
+
+		// Test case insensitive email handling.
+		$case_insensitive_request = new WP_REST_Request( 'GET', '/newspack-network/v1/integrity-check/range-hash' );
+		$case_insensitive_request->set_param( 'start', 'A@EXAMPLE.COM' );
+		$case_insensitive_request->set_param( 'end', 'Z@EXAMPLE.COM' );
+		$case_insensitive_response = Integrity_Check_Endpoints::handle_range_hash_request( $case_insensitive_request );
+		$case_insensitive_response_data = $case_insensitive_response->get_data();
+		$this->assertEquals( 'a@example.com', $case_insensitive_response_data['start'] );
+		$this->assertEquals( 'z@example.com', $case_insensitive_response_data['end'] );
+
+		// Test max parameter handling.
+		$max_parameter_request = new WP_REST_Request( 'GET', '/newspack-network/v1/integrity-check/range-data' );
+		$max_parameter_request->set_param( 'start', 'a@example.com' );
+		$max_parameter_request->set_param( 'end', 'z@example.com' );
+		$max_parameter_request->set_param( 'max', 50 );
+		$max_parameter_response = Integrity_Check_Endpoints::handle_range_data_request( $max_parameter_request );
+		$max_parameter_response_data = $max_parameter_response->get_data();
+		$this->assertArrayHasKey( 'memberships', $max_parameter_response_data );
+		$this->assertArrayHasKey( 'count', $max_parameter_response_data );
+		$this->assertLessThanOrEqual( 50, $max_parameter_response_data['count'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a WP CLI command to verify the network memberships integrity.

NPPM-386

### How to test the changes in this Pull Request:

1. Introduce some discrepancies by e.g. changing the status of a network-synced membership directly in the DB (this way it won't be picked up as an event)
2. Run `wp newspack-network integrity-check --verbose` and observe the discrepancies are listed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->