### PR TITLE
fix(content-distribution): Distributor migration tweaks

### DIFF
--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -424,6 +424,7 @@ class Content_Distribution {
 				Incoming_Post::UNLINKED_META,
 				Incoming_Post::ATTACHMENT_META,
 				Incoming_Post::STATUS_ON_PUBLISH_META,
+				Distributor_Migrator::MIGRATION_DATA_META,
 			]
 		);
 	}

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -354,7 +354,17 @@ class Content_Distribution {
 		 *
 		 * @param array $post_types Array of post types.
 		 */
-		return apply_filters( 'newspack_network_distributed_post_types', [ 'post', 'page' ] );
+		return apply_filters(
+			'newspack_network_distributed_post_types',
+			[
+				'post',
+				'page',
+				'newspack_lst_event',
+				'newspack_lst_generic',
+				'newspack_lst_mktplce',
+				'newspack_lst_place',
+			]
+		);
 	}
 
 	/**

--- a/includes/class-content-distribution.php
+++ b/includes/class-content-distribution.php
@@ -386,6 +386,23 @@ class Content_Distribution {
 		 */
 		$ignored_keys = apply_filters( 'newspack_network_content_distribution_ignored_post_meta_keys', $ignored_keys );
 
+		// Always ignore Distributor meta.
+		$distributor_meta = [
+			'dt_full_connection',
+			'dt_original_post_id',
+			'dt_original_post_url',
+			'dt_original_site_name',
+			'dt_original_site_url',
+			'dt_original_source_id',
+			'dt_subscription_signature',
+			'dt_syndicate_time',
+			'dt_unlinked',
+			'dt_subscriptions',
+			'dt_subscription_update',
+			'dt_connection_map',
+		];
+		$ignored_keys = array_merge( $ignored_keys, $distributor_meta );
+
 		// Always ignore content distribution post meta.
 		return array_merge(
 			$ignored_keys,

--- a/includes/content-distribution/class-cli.php
+++ b/includes/content-distribution/class-cli.php
@@ -188,57 +188,57 @@ class CLI {
 		if ( isset( $assoc_args['all'] ) ) {
 			$strict = isset( $assoc_args['strict'] );
 
-			$post_ids = Distributor_Migrator::get_posts_with_distributor_subscriptions();
+			$subscription_ids = Distributor_Migrator::get_distributor_subscriptions();
 
-			if ( empty( $post_ids ) ) {
-				WP_CLI::success( 'No distributed posts found.' );
+			if ( empty( $subscription_ids ) ) {
+				WP_CLI::success( 'No subscriptions found.' );
 				return;
 			}
 
-			WP_CLI::line( sprintf( 'Found %d posts.', count( $post_ids ) ) );
+			WP_CLI::log( sprintf( 'Found %d subscriptions.', count( $subscription_ids ) ) );
 
 			// In strict mode, only continue if all posts can be migrated.
 			if ( $strict ) {
-				$errors = [];
-				foreach ( $post_ids as $post_id ) {
-					$can_migrate = Distributor_Migrator::can_migrate_outgoing_post( $post_id );
+				$errors = new WP_Error();
+				foreach ( $subscription_ids as $subscription_id ) {
+					$can_migrate = Distributor_Migrator::can_migrate_subscription( $subscription_id );
 					if ( is_wp_error( $can_migrate ) ) {
-						$errors[] = sprintf( 'Unable to migrate post %d: %s', $post_id, $can_migrate->get_error_message() );
+						$errors->add( $can_migrate->get_error_code(), sprintf( 'Unable to migrate subscription %d: %s', $subscription_id, $can_migrate->get_error_message() ) );
 					}
 				}
-				if ( ! empty( $errors ) ) {
-					WP_CLI::error( 'Strict mode is enabled: ' . PHP_EOL . implode( PHP_EOL, $errors ) );
+				if ( $errors->has_errors() ) {
+					WP_CLI::error( 'Strict mode is enabled: ' . PHP_EOL . implode( PHP_EOL, $errors->get_error_messages() ) );
 				}
 			}
 
 			// Migrate posts.
 			$errors     = new WP_Error();
 			$batch_size = $assoc_args['batch-size'] ?? 50;
-			$batches    = array_chunk( $post_ids, $batch_size );
+			$batches    = array_chunk( $subscription_ids, $batch_size );
 
 			foreach ( $batches as $i => $batch ) {
 				if ( ! $dry_run ) {
-					$result = Distributor_Migrator::migrate_outgoing_posts( $batch );
+					$result = Distributor_Migrator::migrate_subscriptions( $batch );
 					if ( is_wp_error( $result ) ) {
 						$message = sprintf( '(%d/%d) Error migrating batch: %s', $i + 1, count( $batches ), $result->get_error_message() );
 						if ( $strict ) {
 							WP_CLI::error( $message );
 						} else {
 							$errors->add( $result->get_error_code(), $result->get_error_message() );
-							WP_CLI::line( $message );
+							WP_CLI::log( $message );
 						}
 					} else {
-						WP_CLI::line( sprintf( '(%d/%d) Batch migrated.', $i + 1, count( $batches ) ) );
+						WP_CLI::log( sprintf( '(%d/%d) Batch migrated.', $i + 1, count( $batches ) ) );
 					}
 				} else {
-					WP_CLI::line( sprintf( '(%d/%d) Batch would be migrated.', $i + 1, count( $batches ) ) );
+					WP_CLI::log( sprintf( '(%d/%d) Batch would be migrated.', $i + 1, count( $batches ) ) );
 				}
 			}
 
 			if ( ! $dry_run && isset( $assoc_args['delete'] ) && ! $errors->has_errors() ) {
 				deactivate_plugins( [ 'distributor/distributor.php' ] );
 				delete_plugins( [ 'distributor/distributor.php' ] );
-				WP_CLI::line( 'Distributor plugin is deactivated and deleted.' );
+				WP_CLI::log( 'Distributor plugin is deactivated and deleted.' );
 			}
 		} else {
 			$can_migrate = Distributor_Migrator::can_migrate_outgoing_post( $post_id );

--- a/includes/content-distribution/class-distributor-migrator.php
+++ b/includes/content-distribution/class-distributor-migrator.php
@@ -22,6 +22,11 @@ class Distributor_Migrator {
 	const MIGRATION_LOCK_TRANSIENT_NAME = 'newspack_network_distributor_migration_lock';
 
 	/**
+	 * Log indentation level.
+	 */
+	private static $log_indentation = 0;
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -36,10 +41,11 @@ class Distributor_Migrator {
 	 * @param string $message The message to log.
 	 */
 	public static function log( $message ) {
+		$message = str_repeat( '  ', self::$log_indentation ) . $message;
 		if ( defined( 'WP_CLI' ) ) {
 			WP_CLI::log( $message );
-		} else {
-			error_log( $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		} elseif ( method_exists( 'Newspack\Logger', 'log' ) ) {
+			\Newspack\Logger::log( $message );
 		}
 	}
 
@@ -432,10 +438,13 @@ class Distributor_Migrator {
 
 		$errors = new WP_Error();
 		foreach ( $subscription_ids as $subscription_id ) {
+			self::$log_indentation++;
 			self::log( sprintf( 'Migrating subscription %d.', $subscription_id ) );
 			$remote_post_id = get_post_meta( $subscription_id, 'dt_subscription_remote_post_id', true );
 			$site_url       = get_post_meta( $subscription_id, 'dt_subscription_target_url', true );
+			self::$log_indentation++;
 			$migration_result = self::migrate_subscription( $subscription_id, false );
+			--self::$log_indentation;
 			if ( is_wp_error( $migration_result ) ) {
 				$errors->add( $migration_result->get_error_code(), $migration_result->get_error_message() );
 				continue;
@@ -446,6 +455,7 @@ class Distributor_Migrator {
 				'site_url' => $site_url,
 				'post_id'  => $remote_post_id,
 			];
+			--self::$log_indentation;
 		}
 
 		if ( ! empty( $incoming_posts ) ) {
@@ -489,14 +499,17 @@ class Distributor_Migrator {
 		) {
 			return $distribution;
 		}
+		self::log( sprintf( 'Set distribution for post %d to %s.', $post_id, $network_url ) );
 
 		// Clear the subscription meta from the post.
 		$subscriptions = get_post_meta( $post_id, 'dt_subscriptions', true );
 		$subscriptions = array_diff( $subscriptions, [ $subscription_id ] );
 		if ( empty( $subscriptions ) ) {
 			delete_post_meta( $post_id, 'dt_subscriptions' );
+			self::log( sprintf( 'Deleted subscriptions for post %d.', $post_id ) );
 		} else {
 			update_post_meta( $post_id, 'dt_subscriptions', $subscriptions );
+			self::log( sprintf( 'Updated subscriptions for post %d.', $post_id ) );
 		}
 
 		// Clear the connection map from the post.
@@ -511,12 +524,15 @@ class Distributor_Migrator {
 		}
 		if ( empty( $connection_map['external'] ) && empty( $connection_map['internal'] ) ) {
 			delete_post_meta( $post_id, 'dt_connection_map' );
+			self::log( sprintf( 'Deleted connection map for post %d.', $post_id ) );
 		} else {
 			update_post_meta( $post_id, 'dt_connection_map', $connection_map );
+			self::log( sprintf( 'Updated connection map for post %d.', $post_id ) );
 		}
 
 		// Delete the subscription post.
 		wp_delete_post( $subscription_id );
+		self::log( sprintf( 'Deleted subscription %d.', $subscription_id ) );
 
 		if ( $migrate_incoming_post ) {
 			self::dispatch_incoming_posts_migration(

--- a/includes/content-distribution/class-distributor-migrator.php
+++ b/includes/content-distribution/class-distributor-migrator.php
@@ -21,8 +21,12 @@ class Distributor_Migrator {
 
 	const MIGRATION_LOCK_TRANSIENT_NAME = 'newspack_network_distributor_migration_lock';
 
+	const MIGRATION_DATA_META = '_newspack_network_distributor_migration_data';
+
 	/**
 	 * Log indentation level.
+	 *
+	 * @var int
 	 */
 	private static $log_indentation = 0;
 
@@ -482,8 +486,10 @@ class Distributor_Migrator {
 			return $can_migrate;
 		}
 
-		$post_id     = get_post_meta( $subscription_id, 'dt_subscription_post_id', true );
-		$network_url = self::get_network_url( get_post_meta( $subscription_id, 'dt_subscription_target_url', true ) );
+		$post_id = get_post_meta( $subscription_id, 'dt_subscription_post_id', true );
+		$remote_post_id = get_post_meta( $subscription_id, 'dt_subscription_remote_post_id', true );
+		$target_url = get_post_meta( $subscription_id, 'dt_subscription_target_url', true );
+		$network_url = self::get_network_url( $target_url );
 
 		// Configure distribution.
 		try {
@@ -503,36 +509,55 @@ class Distributor_Migrator {
 
 		// Clear the subscription meta from the post.
 		$subscriptions = get_post_meta( $post_id, 'dt_subscriptions', true );
-		$subscriptions = array_diff( $subscriptions, [ $subscription_id ] );
 		if ( empty( $subscriptions ) ) {
-			delete_post_meta( $post_id, 'dt_subscriptions' );
-			self::log( sprintf( 'Deleted subscriptions for post %d.', $post_id ) );
+			self::log( sprintf( 'No subscription meta found for post %d.', $post_id ) );
 		} else {
-			update_post_meta( $post_id, 'dt_subscriptions', $subscriptions );
-			self::log( sprintf( 'Updated subscriptions for post %d.', $post_id ) );
+				$subscriptions = array_diff( $subscriptions, [ $subscription_id ] );
+			if ( empty( $subscriptions ) ) {
+				delete_post_meta( $post_id, 'dt_subscriptions' );
+				self::log( sprintf( 'Deleted subscriptions for post %d.', $post_id ) );
+			} else {
+				update_post_meta( $post_id, 'dt_subscriptions', $subscriptions );
+				self::log( sprintf( 'Updated subscriptions for post %d.', $post_id ) );
+			}
 		}
 
 		// Clear the connection map from the post.
 		$connection_map = get_post_meta( $post_id, 'dt_connection_map', true );
-		$remote_post_id = get_post_meta( $subscription_id, 'dt_subscription_remote_post_id', true );
-		if ( ! empty( $connection_map['external'] ) ) {
-			foreach ( $connection_map['external'] as $connection_id => $value ) {
-				if ( absint( $value['post_id'] ) === absint( $remote_post_id ) ) {
-					unset( $connection_map['external'][ $connection_id ] );
+		if ( empty( $connection_map ) ) {
+			self::log( sprintf( 'No connection map meta found for post %d.', $post_id ) );
+		} else {
+			if ( ! empty( $connection_map['external'] ) ) {
+				foreach ( $connection_map['external'] as $connection_id => $value ) {
+					if ( absint( $value['post_id'] ) === absint( $remote_post_id ) ) {
+						unset( $connection_map['external'][ $connection_id ] );
+					}
 				}
 			}
-		}
-		if ( empty( $connection_map['external'] ) && empty( $connection_map['internal'] ) ) {
-			delete_post_meta( $post_id, 'dt_connection_map' );
-			self::log( sprintf( 'Deleted connection map for post %d.', $post_id ) );
-		} else {
-			update_post_meta( $post_id, 'dt_connection_map', $connection_map );
-			self::log( sprintf( 'Updated connection map for post %d.', $post_id ) );
+			if ( empty( $connection_map['external'] ) && empty( $connection_map['internal'] ) ) {
+				delete_post_meta( $post_id, 'dt_connection_map' );
+				self::log( sprintf( 'Deleted connection map for post %d.', $post_id ) );
+			} else {
+				update_post_meta( $post_id, 'dt_connection_map', $connection_map );
+				self::log( sprintf( 'Updated connection map for post %d.', $post_id ) );
+			}
 		}
 
 		// Delete the subscription post.
 		wp_delete_post( $subscription_id );
 		self::log( sprintf( 'Deleted subscription %d.', $subscription_id ) );
+
+		// Add migration data to the post.
+		add_post_meta(
+			$post_id,
+			self::MIGRATION_DATA_META,
+			[
+				'timestamp'       => time(),
+				'subscription_id' => $subscription_id,
+				'remote_post_id'  => $remote_post_id,
+				'target_url'      => $target_url,
+			]
+		);
 
 		if ( $migrate_incoming_post ) {
 			self::dispatch_incoming_posts_migration(

--- a/includes/content-distribution/class-distributor-migrator.php
+++ b/includes/content-distribution/class-distributor-migrator.php
@@ -236,24 +236,6 @@ class Distributor_Migrator {
 	}
 
 	/**
-	 * Get posts with Distributor subscriptions.
-	 *
-	 * @return int[] Array of post IDs.
-	 */
-	public static function get_posts_with_distributor_subscriptions() {
-		$subscriptions = self::get_distributor_subscriptions();
-		$posts         = [];
-		foreach ( $subscriptions as $subscription_id ) {
-			$post_id = get_post_meta( $subscription_id, 'dt_subscription_post_id', true );
-			if ( ! $post_id ) {
-				continue;
-			}
-			$posts[ $post_id ] = $post_id;
-		}
-		return array_values( $posts );
-	}
-
-	/**
 	 * Validate whether a post can be migrated.
 	 *
 	 * @param int $post_id The ID of the post to check.

--- a/includes/content-distribution/class-distributor-migrator.php
+++ b/includes/content-distribution/class-distributor-migrator.php
@@ -11,6 +11,7 @@ use Newspack_Network\Content_Distribution;
 use Newspack\Data_Events;
 use Newspack_Network\Utils\Network;
 use WP_Error;
+use WP_CLI;
 use InvalidArgumentException;
 
 /**
@@ -27,6 +28,19 @@ class Distributor_Migrator {
 		add_action( 'init', [ __CLASS__, 'register_data_event_actions' ] );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'filter_migration_lock_cap' ], 10, 4 );
 		add_action( 'admin_notices', [ __CLASS__, 'migration_lock_notice' ] );
+	}
+
+	/**
+	 * Log a message.
+	 *
+	 * @param string $message The message to log.
+	 */
+	public static function log( $message ) {
+		if ( defined( 'WP_CLI' ) ) {
+			WP_CLI::log( $message );
+		} else {
+			error_log( $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		}
 	}
 
 	/**
@@ -150,6 +164,7 @@ class Distributor_Migrator {
 			'dt_syndicate_time',
 			'dt_unlinked',
 			'dt_subscriptions',
+			'dt_subscription_update',
 			'dt_connection_map',
 		];
 
@@ -295,6 +310,17 @@ class Distributor_Migrator {
 		$errors = new WP_Error();
 		foreach ( $post_ids as $post_id ) {
 			$subscriptions = get_post_meta( $post_id, 'dt_subscriptions', true );
+			if ( empty( $subscriptions ) || ! is_array( $subscriptions ) ) {
+				$errors->add(
+					'no_subscriptions',
+					sprintf(
+						// translators: post ID.
+						__( 'No subscriptions found for post %d.', 'newspack-network' ),
+						$post_id
+					)
+				);
+				continue;
+			}
 			foreach ( $subscriptions as $subscription_id ) { // phpcs:ignore WordPressVIPMinimum.Functions.CheckReturnValue.NonCheckedVariable
 				$remote_post_id = get_post_meta( $subscription_id, 'dt_subscription_remote_post_id', true );
 				$site_url       = get_post_meta( $subscription_id, 'dt_subscription_target_url', true );
@@ -354,7 +380,7 @@ class Distributor_Migrator {
 	 *
 	 * @return true|WP_Error True if the subscription can be migrated, WP_Error on failure.
 	 */
-	protected static function can_migrate_subscription( $subscription_id ) {
+	public static function can_migrate_subscription( $subscription_id ) {
 		$subscription = get_post( $subscription_id );
 		if ( ! $subscription ) {
 			return new WP_Error( 'subscription_not_found', __( 'Subscription not found.', 'newspack-network' ) );
@@ -387,6 +413,52 @@ class Distributor_Migrator {
 	}
 
 	/**
+	 * Migrate subscriptions from Distributor to Newspack Network Content Distribution.
+	 *
+	 * @param int[] $subscription_ids The IDs of the subscriptions to migrate.
+	 *
+	 * @return WP_Error|void WP_Error on failure, void on success.
+	 */
+	public static function migrate_subscriptions( $subscription_ids ) {
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			return new WP_Error( 'data_events_not_found', __( 'Data Events not found.', 'newspack-network' ) );
+		}
+
+		if ( empty( $subscription_ids ) || ! is_array( $subscription_ids ) ) {
+			return new WP_Error( 'invalid_subscription_ids', __( 'Invalid subscription IDs.', 'newspack-network' ) );
+		}
+
+		$incoming_posts = [];
+
+		$errors = new WP_Error();
+		foreach ( $subscription_ids as $subscription_id ) {
+			self::log( sprintf( 'Migrating subscription %d.', $subscription_id ) );
+			$remote_post_id = get_post_meta( $subscription_id, 'dt_subscription_remote_post_id', true );
+			$site_url       = get_post_meta( $subscription_id, 'dt_subscription_target_url', true );
+			$migration_result = self::migrate_subscription( $subscription_id, false );
+			if ( is_wp_error( $migration_result ) ) {
+				$errors->add( $migration_result->get_error_code(), $migration_result->get_error_message() );
+				continue;
+			}
+			$site_url = self::get_network_url( $site_url );
+			self::log( sprintf( 'Migrated subscription %d for remote post %d on %s.', $subscription_id, $remote_post_id, $site_url ) );
+			$incoming_posts[] = [
+				'site_url' => $site_url,
+				'post_id'  => $remote_post_id,
+			];
+		}
+
+		if ( ! empty( $incoming_posts ) ) {
+			self::log( sprintf( 'Dispatching incoming posts migration for %d posts.', count( $incoming_posts ) ) );
+			self::dispatch_incoming_posts_migration( $incoming_posts );
+		}
+
+		if ( $errors->has_errors() ) {
+			return $errors;
+		}
+	}
+
+	/**
 	 * Migrate a post subscription from Distributor to Newspack Network Content Distribution.
 	 *
 	 * @param int  $subscription_id       The ID of the subscription to migrate.
@@ -394,7 +466,7 @@ class Distributor_Migrator {
 	 *
 	 * @return Outgoing_Post|WP_Error Outgoing_Post on success, WP_Error on failure.
 	 */
-	protected static function migrate_subscription( $subscription_id, $migrate_incoming_post = true ) {
+	public static function migrate_subscription( $subscription_id, $migrate_incoming_post = true ) {
 		$can_migrate = self::can_migrate_subscription( $subscription_id );
 		if ( is_wp_error( $can_migrate ) ) {
 			return $can_migrate;

--- a/includes/content-distribution/class-distributor-migrator.php
+++ b/includes/content-distribution/class-distributor-migrator.php
@@ -450,15 +450,16 @@ class Distributor_Migrator {
 			$migration_result = self::migrate_subscription( $subscription_id, false );
 			--self::$log_indentation;
 			if ( is_wp_error( $migration_result ) ) {
+				self::log( sprintf( 'Error migrating subscription %d (post: %d, target: %s): %s.', $subscription_id, $remote_post_id, $site_url, $migration_result->get_error_message() ) );
 				$errors->add( $migration_result->get_error_code(), $migration_result->get_error_message() );
-				continue;
+			} else {
+				$site_url = self::get_network_url( $site_url );
+				self::log( sprintf( 'Migrated subscription %d for remote post %d on %s.', $subscription_id, $remote_post_id, $site_url ) );
+				$incoming_posts[] = [
+					'site_url' => $site_url,
+					'post_id'  => $remote_post_id,
+				];
 			}
-			$site_url = self::get_network_url( $site_url );
-			self::log( sprintf( 'Migrated subscription %d for remote post %d on %s.', $subscription_id, $remote_post_id, $site_url ) );
-			$incoming_posts[] = [
-				'site_url' => $site_url,
-				'post_id'  => $remote_post_id,
-			];
 			--self::$log_indentation;
 		}
 

--- a/includes/utils/class-network.php
+++ b/includes/utils/class-network.php
@@ -32,7 +32,8 @@ class Network {
 			...array_map( fn( $node ) => $node['url'], get_option( Hub_Node::HUB_NODES_SYNCED_OPTION, [] ) ),
 		];
 
-		return array_map( 'untrailingslashit', $urls );
+		// Filter out empty values and apply untrailingslashit.
+		return array_map( 'untrailingslashit', array_filter( $urls ) );
 	}
 
 	/**

--- a/tests/unit-tests/content-distribution/test-distributor-migrator.php
+++ b/tests/unit-tests/content-distribution/test-distributor-migrator.php
@@ -188,7 +188,7 @@ class TestDistributorMigrator extends \WP_UnitTestCase {
 		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
 			// Create a simple mock class instead of using Mockery.
 			if ( ! class_exists( 'Newspack\Data_Events' ) ) {
-				eval(
+				eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
 					'
 					namespace Newspack {
 						class Data_Events {
@@ -247,7 +247,7 @@ class TestDistributorMigrator extends \WP_UnitTestCase {
 		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
 			// Create a simple mock class instead of using Mockery.
 			if ( ! class_exists( 'Newspack\Data_Events' ) ) {
-				eval(
+				eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
 					'
 					namespace Newspack {
 						class Data_Events {

--- a/tests/unit-tests/content-distribution/test-distributor-migrator.php
+++ b/tests/unit-tests/content-distribution/test-distributor-migrator.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * Class TestDistributorMigrator
+ *
+ * @package Newspack_Network
+ */
+
+namespace Test\Content_Distribution;
+
+use Newspack_Network\Content_Distribution\Distributor_Migrator;
+use Newspack_Network\Content_Distribution\Outgoing_Post;
+use Newspack_Network\Hub\Node as Hub_Node;
+
+/**
+ * Test the Distributor_Migrator class.
+ */
+class TestDistributorMigrator extends \WP_UnitTestCase {
+	/**
+	 * "Mocked" network nodes.
+	 *
+	 * @var array
+	 */
+	protected $network = [
+		[
+			'id'    => 1234,
+			'title' => 'Test Node',
+			'url'   => 'https://node.test',
+		],
+		[
+			'id'    => 5678,
+			'title' => 'Test Node 2',
+			'url'   => 'https://other-node.test',
+		],
+	];
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// "Mock" the network node(s).
+		update_option( Hub_Node::HUB_NODES_SYNCED_OPTION, $this->network );
+	}
+
+	/**
+	 * Test that get_network_url correctly matches URLs to network nodes.
+	 */
+	public function test_get_network_url() {
+		// Test direct match.
+		$this->assertEquals(
+			'https://node.test',
+			$this->call_protected_method( 'get_network_url', 'https://node.test/some/path' )
+		);
+
+		// Test subdirectory match.
+		$this->assertEquals(
+			'https://node.test',
+			$this->call_protected_method( 'get_network_url', 'https://node.test/wp-admin/post.php?post=123' )
+		);
+
+		// Test no match.
+		$this->assertFalse(
+			$this->call_protected_method( 'get_network_url', 'https://external.test/some/path' )
+		);
+	}
+
+	/**
+	 * Test that get_distributor_subscriptions returns subscription post IDs.
+	 */
+	public function test_get_distributor_subscriptions() {
+		// Create some subscription posts.
+		$subscription_1 = $this->factory->post->create( [ 'post_type' => 'dt_subscription' ] );
+		$subscription_2 = $this->factory->post->create( [ 'post_type' => 'dt_subscription' ] );
+		$regular_post = $this->factory->post->create();
+
+		$subscriptions = Distributor_Migrator::get_distributor_subscriptions();
+
+		$this->assertCount( 2, $subscriptions );
+		$this->assertContains( $subscription_1, $subscriptions );
+		$this->assertContains( $subscription_2, $subscriptions );
+		$this->assertNotContains( $regular_post, $subscriptions );
+	}
+
+	/**
+	 * Test can_migrate_subscription validation.
+	 */
+	public function test_can_migrate_subscription() {
+		// Create a post and subscription.
+		$post_id = $this->factory->post->create();
+		$subscription_id = $this->factory->post->create( [ 'post_type' => 'dt_subscription' ] );
+
+		// Test with missing post ID.
+		$result = Distributor_Migrator::can_migrate_subscription( $subscription_id );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'post_not_found', $result->get_error_code() );
+
+		// Add post ID but no target URL.
+		update_post_meta( $subscription_id, 'dt_subscription_post_id', $post_id );
+		$result = Distributor_Migrator::can_migrate_subscription( $subscription_id );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'target_url_not_found', $result->get_error_code() );
+
+		// Add target URL but not networked.
+		update_post_meta( $subscription_id, 'dt_subscription_target_url', 'https://external.test' );
+		$result = Distributor_Migrator::can_migrate_subscription( $subscription_id );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'target_url_not_networked', $result->get_error_code() );
+
+		// Add valid networked target URL.
+		update_post_meta( $subscription_id, 'dt_subscription_target_url', 'https://node.test' );
+		$result = Distributor_Migrator::can_migrate_subscription( $subscription_id );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test can_migrate_outgoing_post validation.
+	 */
+	public function test_can_migrate_outgoing_post() {
+		$post_id = $this->factory->post->create();
+
+		// Test with no connection map.
+		$result = Distributor_Migrator::can_migrate_outgoing_post( $post_id );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'no_connection_map', $result->get_error_code() );
+
+		// Test with internal connections (not supported).
+		update_post_meta(
+			$post_id,
+			'dt_connection_map',
+			[
+				'internal' => [ 'some_connection' ],
+				'external' => [ 'external_connection' => [ 'post_id' => 123 ] ],
+			]
+		);
+		$result = Distributor_Migrator::can_migrate_outgoing_post( $post_id );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'internal_connection', $result->get_error_code() );
+
+		// Test with external connections but no subscriptions.
+		update_post_meta(
+			$post_id,
+			'dt_connection_map',
+			[
+				'external' => [ 'external_connection' => [ 'post_id' => 123 ] ],
+			]
+		);
+		$result = Distributor_Migrator::can_migrate_outgoing_post( $post_id );
+		$this->assertWPError( $result );
+		$this->assertEquals( 'subscriptions_not_found', $result->get_error_code() );
+
+		// Test with valid setup.
+		$subscription_id = $this->factory->post->create( [ 'post_type' => 'dt_subscription' ] );
+		update_post_meta( $subscription_id, 'dt_subscription_post_id', $post_id );
+		update_post_meta( $subscription_id, 'dt_subscription_target_url', 'https://node.test' );
+		update_post_meta( $post_id, 'dt_subscriptions', [ $subscription_id ] );
+
+		$result = Distributor_Migrator::can_migrate_outgoing_post( $post_id );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that migration data meta is added during subscription migration.
+	 */
+	public function test_migration_data_meta_tracking() {
+		// Create post and subscription.
+		$post_id = $this->factory->post->create();
+		$subscription_id = $this->factory->post->create( [ 'post_type' => 'dt_subscription' ] );
+
+		// Set up subscription meta.
+		update_post_meta( $subscription_id, 'dt_subscription_post_id', $post_id );
+		update_post_meta( $subscription_id, 'dt_subscription_target_url', 'https://node.test' );
+		update_post_meta( $subscription_id, 'dt_subscription_remote_post_id', 456 );
+
+		// Add required post meta for migration.
+		update_post_meta( $post_id, 'dt_subscriptions', [ $subscription_id ] );
+		update_post_meta(
+			$post_id,
+			'dt_connection_map',
+			[
+				'external' => [
+					'external_connection' => [ 'post_id' => 456 ],
+				],
+			]
+		);
+
+		// Mock Data_Events class to prevent actual dispatch.
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			// Create a simple mock class instead of using Mockery.
+			if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+				eval(
+					'
+					namespace Newspack {
+						class Data_Events {
+							public static function dispatch( $event, $data = [] ) {
+								return true;
+							}
+						}
+					}
+				'
+				);
+			}
+		}
+
+		// Migrate the subscription.
+		$result = Distributor_Migrator::migrate_subscription( $subscription_id, false );
+
+		// Verify migration data was added.
+		$migration_data = get_post_meta( $post_id, Distributor_Migrator::MIGRATION_DATA_META, true );
+		$this->assertIsArray( $migration_data );
+		$this->assertArrayHasKey( 'timestamp', $migration_data );
+		$this->assertArrayHasKey( 'subscription_id', $migration_data );
+		$this->assertArrayHasKey( 'remote_post_id', $migration_data );
+		$this->assertArrayHasKey( 'target_url', $migration_data );
+
+		$this->assertEquals( $subscription_id, $migration_data['subscription_id'] );
+		$this->assertEquals( 456, $migration_data['remote_post_id'] );
+		$this->assertEquals( 'https://node.test', $migration_data['target_url'] );
+	}
+
+	/**
+	 * Test that distributor meta is properly cleaned up during migration.
+	 */
+	public function test_distributor_meta_cleanup() {
+		// Create post and subscription.
+		$post_id = $this->factory->post->create();
+		$subscription_id = $this->factory->post->create( [ 'post_type' => 'dt_subscription' ] );
+
+		// Set up subscription meta.
+		update_post_meta( $subscription_id, 'dt_subscription_post_id', $post_id );
+		update_post_meta( $subscription_id, 'dt_subscription_target_url', 'https://node.test' );
+		update_post_meta( $subscription_id, 'dt_subscription_remote_post_id', 456 );
+
+		// Add distributor meta to post.
+		update_post_meta( $post_id, 'dt_subscriptions', [ $subscription_id ] );
+		update_post_meta(
+			$post_id,
+			'dt_connection_map',
+			[
+				'external' => [
+					'connection_1' => [ 'post_id' => 456 ],
+				],
+			]
+		);
+
+		// Mock Data_Events class.
+		if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+			// Create a simple mock class instead of using Mockery.
+			if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+				eval(
+					'
+					namespace Newspack {
+						class Data_Events {
+							public static function dispatch( $event, $data = [] ) {
+								return true;
+							}
+						}
+					}
+				'
+				);
+			}
+		}
+
+		// Migrate the subscription.
+		$result = Distributor_Migrator::migrate_subscription( $subscription_id, false );
+
+		// Verify subscription meta was cleaned up.
+		$remaining_subscriptions = get_post_meta( $post_id, 'dt_subscriptions', true );
+		$this->assertEmpty( $remaining_subscriptions );
+
+		// Verify connection map was cleaned up.
+		$remaining_connection_map = get_post_meta( $post_id, 'dt_connection_map', true );
+		$this->assertEmpty( $remaining_connection_map );
+
+		// Verify subscription post was deleted.
+		$this->assertNull( get_post( $subscription_id ) );
+	}
+
+	/**
+	 * Call a protected method on the Distributor_Migrator class.
+	 *
+	 * @param string $method The method name.
+	 * @param mixed  ...$args The method arguments.
+	 * @return mixed The method result.
+	 */
+	private function call_protected_method( $method, ...$args ) {
+		$reflection = new \ReflectionClass( Distributor_Migrator::class );
+		$method_reflection = $reflection->getMethod( $method );
+		$method_reflection->setAccessible( true );
+		return $method_reflection->invoke( null, ...$args );
+	}
+}


### PR DESCRIPTION
To handle edge cases in Distributor metadata, this hotfix tweaks the migration strategy to rely on the subscription post type rather than the origin post "subscriptions" post meta (`dt_subscriptions`).

It was discovered that some distributed content will not have its relationship stored in `dt_subscriptions` but in the `dt_connection_map` post meta. `dt_connection_map` is also not a reliable source for that information because it's not always present either. The subscription post, which includes all the data we need to safely migrate, is always present.

This PR also improves the migration logging and, for convenience, adds native support for Newspack Listings to migrate publisher content.

### Testing

1. In a Network setup with at least 1 hub and 2 nodes, make sure you have Distributor installed and configured for all sites
2. Use Distributor to distribute a post from each site to a different site in your network
3. Also with Distributor, distribute a post to all sites in the network
4. In one of the sites, navigate to Distributor -> Pull content
5. Select all posts and pull
6. Make sure you have content distribution enabled (`define( 'NEWPACK_NETWORK_CONTENT_DISTRIBUTION', true );`)
7. On each site, run the migration command in dry run:

```
wp newspack network distributor migrate --all --dry-run
```

8. Confirm the result is similar to:

```
Found 10 subscriptions.
(1/1) Batch would be migrated.
Success: Migration completed. (Dry-run)
```

9. Run the migration:

```
wp newspack network distributor migrate --all
```

10. Confirm the result is similar to, with variations regarding the "subscription meta" and "connection map" lines, but no errors:

```
Found 10 subscriptions.
  Migrating subscription 184747.
    Set distribution for post 184655 to http://example.com.
    No subscription meta found for post 184655.
    Deleted connection map for post 184655.
    Deleted subscription 184747.
  Migrated subscription 184747 for remote post 557345 on http://example.com.
  Migrating subscription 174363.
    Set distribution for post 174324 to http://example.com.
    No subscription meta found for post 174324.
    Deleted connection map for post 174324.
    Deleted subscription 174363.
  Migrated subscription 174363 for remote post 544091 on http://example.com.
  Migrating subscription 173997.
    Set distribution for post 173995 to http://example.com.
    No subscription meta found for post 173995.
    Deleted connection map for post 173995.
    Deleted subscription 173997.
  Migrated subscription 173997 for remote post 543688 on http://example.com.
  Migrating subscription 172773.
    Set distribution for post 172634 to http://example.com.
    No subscription meta found for post 172634.
    Deleted connection map for post 172634.
    Deleted subscription 172773.
  Migrated subscription 172773 for remote post 541796 on http://example.com.
  Migrating subscription 159138.
    Set distribution for post 159135 to http://example.com.
    No subscription meta found for post 159135.
    Deleted connection map for post 159135.
    Deleted subscription 159138.
  Migrated subscription 159138 for remote post 527539 on http://example.com.
  Migrating subscription 158045.
    Set distribution for post 158012 to http://example.com.
    No subscription meta found for post 158012.
    Deleted connection map for post 158012.
    Deleted subscription 158045.
  Migrated subscription 158045 for remote post 523959 on http://example.com.
  Migrating subscription 157466.
    Set distribution for post 157421 to http://example.com.
    No subscription meta found for post 157421.
    Deleted connection map for post 157421.
    Deleted subscription 157466.
  Migrated subscription 157466 for remote post 523021 on http://example.com.
  Migrating subscription 156735.
    Set distribution for post 156733 to http://example.com.
    No subscription meta found for post 156733.
    Deleted connection map for post 156733.
    Deleted subscription 156735.
  Migrated subscription 156735 for remote post 522118 on http://example.com.
  Migrating subscription 156501.
    Set distribution for post 156468 to http://example.com.
    No subscription meta found for post 156468.
    Deleted connection map for post 156468.
    Deleted subscription 156501.
  Migrated subscription 156501 for remote post 521849 on http://example.com.
  Migrating subscription 150375.
    Set distribution for post 150373 to http://example.com.
    No subscription meta found for post 150373.
    Deleted connection map for post 150373.
    Deleted subscription 150375.
  Migrated subscription 150375 for remote post 513603 on http://example.com.
Dispatching incoming posts migration for 10 posts.
(1/1) Batch migrated.
Success: Migration completed.
```

11. Wait for the network events to propagate and confirm the destination posts have been migrated:

```shell
wp post meta get {post_id} newspack_network_post_id # An md5 hash
wp post meta get {post_id} newspack_network_post_payload # Post payload
wp post meta get {post_id} dt_subscription_signature # Should be empty
wp post meta get {post_id} dt_original_site_url # Should be empty
```

12. Confirm on each site that there are no subscription posts and no posts with Distributor metadata

```shell
wp post list --post_type="dt_subscription"
wp eval "echo ( new WP_Query( [ 'meta_query' => [ [ 'key' => 'dt_connection_map', 'compare' => 'EXISTS' ], [ 'key' => 'dt_subscriptions', 'compare' => 'EXISTS' ], 'relation' => 'OR' ] ] ) )->found_posts;"
```