### PR TITLE
fix(content-distribution): disable photon for thumbnail url

### DIFF
--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -436,7 +436,7 @@ class Incoming_Post {
 		$thumbnail_url         = $this->payload['post_data']['thumbnail_url'];
 		$payload               = $this->get_post_payload();
 		$current_thumbnail_id  = get_post_thumbnail_id( $this->ID );
-		$current_thumbnail_url = $payload['post_data']['thumbnail_url'];
+		$current_thumbnail_url = $payload ? $payload['post_data']['thumbnail_url'] : '';
 
 		// Bail if the post has a thumbnail and the thumbnail URL is the same.
 		if (

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -433,17 +433,32 @@ class Incoming_Post {
 	 * Upload the thumbnail for a linked post.
 	 */
 	protected function upload_thumbnail() {
-		$thumbnail_url        = $this->payload['post_data']['thumbnail_url'];
-		$payload              = $this->get_post_payload();
-		$current_thumbnail_id = get_post_thumbnail_id( $this->ID );
+		$thumbnail_url         = $this->payload['post_data']['thumbnail_url'];
+		$payload               = $this->get_post_payload();
+		$current_thumbnail_id  = get_post_thumbnail_id( $this->ID );
+		$current_thumbnail_url = $payload['post_data']['thumbnail_url'];
 
 		// Bail if the post has a thumbnail and the thumbnail URL is the same.
 		if (
 			$current_thumbnail_id &&
 			$payload &&
-			$payload['post_data']['thumbnail_url'] === $thumbnail_url
+			$current_thumbnail_url === $thumbnail_url
 		) {
 			return;
+		}
+
+		// Handle Jetpack Photon URLs so we can compare the underlying image URLs.
+		$photon_pattern = '/^https:\/\/i[0-9]\.wp\.com\/([^?]+)(\?.*)?$/';
+		if ( preg_match( $photon_pattern, $thumbnail_url ) || preg_match( $photon_pattern, $current_thumbnail_url ) ) {
+			$strip_photon = function( $url ) use ( $photon_pattern ) {
+				if ( preg_match( $photon_pattern, $url, $matches ) ) {
+					return 'https://' . $matches[1];
+				}
+				return $url;
+			};
+			if ( $strip_photon( $thumbnail_url ) === $strip_photon( $current_thumbnail_url ) ) {
+				return;
+			}
 		}
 
 		if ( ! function_exists( 'media_sideload_image' ) ) {

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -296,7 +296,7 @@ class Outgoing_Post {
 				'comment_status' => $this->post->comment_status,
 				'ping_status'    => $this->post->ping_status,
 				'taxonomy'       => $this->get_post_taxonomy_terms(),
-				'thumbnail_url'  => get_the_post_thumbnail_url( $this->post->ID, 'full' ),
+				'thumbnail_url'  => $this->get_post_thumbnail_url(),
 				'post_meta'      => $this->get_post_meta(),
 			],
 		];
@@ -373,6 +373,21 @@ class Outgoing_Post {
 	 */
 	protected function get_post_taxonomy_terms() {
 		return Taxonomy_Terms::get_post_taxonomy_terms( $this->post );
+	}
+
+	/**
+	 * Get the post thumbnail URL.
+	 *
+	 * @return string The post thumbnail URL.
+	 */
+	protected function get_post_thumbnail_url() {
+		add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+		$thumbnail_url = get_the_post_thumbnail_url( $this->post->ID, 'full' );
+		remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+		if ( ! $thumbnail_url ) {
+			return '';
+		}
+		return $thumbnail_url;
 	}
 
 	/**

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -722,4 +722,25 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		$this->assertSame( 'New Title', get_the_title( $post_id ) );
 		$this->assertSame( '2020-10-01 00:00:00', get_post_field( 'post_modified_gmt', $post_id ) );
 	}
+
+	/**
+	 * Test toggling Jetpack Photon.
+	 */
+	public function test_toggle_jetpack_photon() {
+		$payload = $this->get_sample_payload();
+
+		$payload['post_data']['thumbnail_url'] = 'https://i0.wp.com/newspack.com/wp-content/uploads/2025/02/newspack-logo.png?fit=948%2C192&ssl=1';
+
+		$post_id = $this->incoming_post->insert( $payload );
+
+		$thumbnail_id = get_post_thumbnail_id( $post_id );
+		$this->assertNotEmpty( $thumbnail_id );
+
+		// Update the payload to use the same image without Photon.
+		$payload['post_data']['thumbnail_url'] = 'https://newspack.com/wp-content/uploads/2025/02/newspack-logo.png';
+		$this->incoming_post->insert( $payload );
+
+		// Assert that the thumbnail is unchanged.
+		$this->assertSame( $thumbnail_id, get_post_thumbnail_id( $post_id ) );
+	}
 }


### PR DESCRIPTION
The dynamic URL coming from Jetpack's Image CDN may cause duplicate thumbnails. This PR implements an override filter to prevent the CDN from filtering the thumbnail URL.

A check was also introduced in the incoming post method to prevent photon URLs from triggering thumbnail fetches.

### Testing

1. Make sure you have a site in the network that uses Jetpack's CDN (under Jetpack's Performance tab)
2. While on the release branch, distribute a post with a thumbnail from that site to any other site in the network
3. Check the hub event logs and confirm the payload has the thumbnail URL behind the CDN (`https://i0.wp.com/...`)
4. On the destination site, confirm the thumbnail was created
5. Check out this branch, make changes to the post, and save
6. Confirm in the hub event logs that the thumbnail URL is not behind the CDN
7. On the destination site, confirm no new thumbnail was created