### PR TITLE
Feat/propagate hub name

### DIFF
--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -44,6 +44,7 @@ class Accepted_Actions {
 		'network_post_deleted'                     => 'Network_Post_Deleted',
 		'network_incoming_post_deleted'            => 'Network_Incoming_Post_Deleted',
 		'newspack_network_distributor_migrate_incoming_posts' => 'Distributor_Migrate_Incoming_Posts',
+		'network_hub_name_updated'                 => 'Hub_Name_Updated',
 	];
 
 	/**
@@ -69,5 +70,6 @@ class Accepted_Actions {
 		'network_post_deleted',
 		'network_incoming_post_deleted',
 		'newspack_network_distributor_migrate_incoming_posts',
+		'network_hub_name_updated',
 	];
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Network;
 
+use Newspack_Network\Utils\Sites;
+
 /**
  * Class to handle the plugin admin pages
  */
@@ -30,6 +32,7 @@ class Admin {
 		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu' ) );
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
+		add_action( 'admin_bar_menu', [ __CLASS__, 'admin_bar_menu' ], 100 );
 	}
 
 	/**
@@ -197,5 +200,37 @@ class Admin {
 	 */
 	public static function use_experimental_auditing_features() {
 		return defined( 'NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_FEATURES' ) ? NEWSPACK_NETWORK_EXPERIMENTAL_AUDITING_FEATURES : false;
+	}
+
+	/**
+	 * Adds the admin bar menu
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 * @return void
+	 */
+	public static function admin_bar_menu( $wp_admin_bar ) {
+		$sites = Sites::get_all_sites_but_current();
+		foreach ( $sites as $site ) {
+			$item_id = 'site-' . sanitize_title( $site['name'] );
+			$wp_admin_bar->add_node(
+				[
+					'id'     => $item_id,
+					'title'  => $site['name'],
+					'href'   => $site['url'],
+					'parent' => 'site-name',
+				]
+			);
+
+			foreach ( Sites::generate_bookmarks( $site['url'] ) as $bookmark ) {
+				$sub_item_id = $item_id . '-' . sanitize_title( $bookmark['label'] );
+				$args        = [
+					'id'     => $sub_item_id,
+					'title'  => $bookmark['label'],
+					'href'   => $bookmark['url'],
+					'parent' => $item_id,
+				];
+				$wp_admin_bar->add_node( $args );
+			}
+		}
 	}
 }

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -209,7 +209,7 @@ class Admin {
 	 * @return void
 	 */
 	public static function admin_bar_menu( $wp_admin_bar ) {
-		$sites = Sites::get_all_sites_but_current();
+		$sites = Sites::get_all_sites_without_current();
 		foreach ( $sites as $site ) {
 			$item_id = 'site-' . sanitize_title( $site['name'] );
 			$wp_admin_bar->add_node(

--- a/includes/class-data-listeners.php
+++ b/includes/class-data-listeners.php
@@ -36,6 +36,10 @@ class Data_Listeners {
 		Data_Events::register_listener( 'newspack_network_user_updated', 'network_user_updated', [ __CLASS__, 'user_updated' ] );
 		Data_Events::register_listener( 'delete_user', 'network_user_deleted', [ __CLASS__, 'user_deleted' ] );
 		Data_Events::register_listener( 'newspack_network_nodes_synced', 'network_nodes_synced', [ __CLASS__, 'nodes_synced' ] );
+
+		if ( Site_Role::is_hub() ) {
+			Data_Events::register_listener( 'update_option_blogname', 'network_hub_name_updated', [ __CLASS__, 'hub_name_updated' ] );
+		}
 	}
 
 	/**
@@ -78,5 +82,16 @@ class Data_Listeners {
 	 */
 	public static function nodes_synced( $nodes_data ) {
 		return [ 'nodes_data' => $nodes_data ];
+	}
+
+	/**
+	 * Filters the blogname data for the event being triggered
+	 *
+	 * @param string $old_value The old blogname.
+	 * @param string $value     The new blogname.
+	 * @return array
+	 */
+	public static function hub_name_updated( $old_value, $value ) {
+		return [ 'name' => $value ];
 	}
 }

--- a/includes/cli/backfillers/class-hub-name-updated.php
+++ b/includes/cli/backfillers/class-hub-name-updated.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Data Backfiller for hub_name_updated events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+use Newspack_Network\Site_Role;
+
+/**
+ * Backfiller class.
+ */
+class Hub_Name_Updated extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Hub name updated to %s.', $event->get_new_name() );
+	}
+
+	/**
+	 * Gets the events to be processed
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		if ( ! Site_Role::is_hub() ) {
+			return [];
+		}
+
+		$this->maybe_initialize_progress_bar( 'Processing hub name', 1 );
+
+		return [ new \Newspack_Network\Incoming_Events\Hub_Name_Updated( get_bloginfo( 'url' ), [ 'name' => get_bloginfo( 'name' ) ], time() ) ];
+	}
+}

--- a/includes/hub/admin/class-nodes-list.php
+++ b/includes/hub/admin/class-nodes-list.php
@@ -24,7 +24,6 @@ class Nodes_List {
 		add_filter( 'manage_' . Nodes::POST_TYPE_SLUG . '_posts_columns', [ __CLASS__, 'posts_columns' ] );
 		add_action( 'manage_' . Nodes::POST_TYPE_SLUG . '_posts_custom_column', [ __CLASS__, 'posts_columns_values' ], 10, 2 );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_bar_menu', [ __CLASS__, 'admin_bar_menu' ], 100 );
 	}
 
 	/**
@@ -183,36 +182,5 @@ class Nodes_List {
 			[],
 			filemtime( NEWSPACK_NETWORK_PLUGIN_DIR . '/includes/hub/admin/css/nodes-list.css' )
 		);
-	}
-
-	/**
-	 * Adds the nodes and their bookmarks to the Admin Bar menu
-	 *
-	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
-	 * @return void
-	 */
-	public static function admin_bar_menu( $wp_admin_bar ) {
-		$nodes = Nodes::get_all_nodes();
-		foreach ( $nodes as $node ) {
-			$item_id = 'node-' . $node->get_id();
-			$args    = [
-				'id'     => $item_id,
-				'title'  => $node->get_name(),
-				'href'   => false,
-				'parent' => 'site-name',
-			];
-			$wp_admin_bar->add_node( $args );
-
-			foreach ( $node->get_bookmarks() as $bookmark ) {
-				$sub_item_id = $item_id . '-' . sanitize_title( $bookmark['label'] );
-				$args        = [
-					'id'     => $sub_item_id,
-					'title'  => $bookmark['label'],
-					'href'   => $bookmark['url'],
-					'parent' => $item_id,
-				];
-				$wp_admin_bar->add_node( $args );
-			}
-		}
 	}
 }

--- a/includes/hub/class-node.php
+++ b/includes/hub/class-node.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Hub;
 
 use Newspack_Network\Crypto;
 use Newspack_Network\Rest_Authenticaton;
+use Newspack_Network\Utils\Sites;
 use WP_Post;
 
 /**
@@ -120,47 +121,6 @@ class Node {
 	}
 
 	/**
-	 * Generates a collection of bookmarks for this Node
-	 *
-	 * @param  string $url The URL of the Node.
-	 * @return array
-	 */
-	public static function generate_bookmarks( $url ) {
-		$base_url = trailingslashit( $url );
-
-		return [
-			[
-				'label' => __( 'Dashboard', 'newspack-network' ),
-				'url'   => $base_url . 'wp-admin/',
-			],
-			[
-				'label' => 'Newspack',
-				'url'   => $base_url . 'wp-admin?page=newspack',
-			],
-			[
-				'label' => 'WooCommerce',
-				'url'   => $base_url . 'wp-admin/admin.php?page=wc-admin',
-			],
-			[
-				'label' => __( 'Posts', 'newspack-network' ),
-				'url'   => $base_url . 'wp-admin/edit.php',
-			],
-			[
-				'label' => __( 'Users', 'newspack-network' ),
-				'url'   => $base_url . 'wp-admin/users.php',
-			],
-			[
-				'label' => __( 'Plugins', 'newspack-network' ),
-				'url'   => $base_url . 'wp-admin/plugins.php',
-			],
-			[
-				'label' => __( 'Settings', 'newspack-network' ),
-				'url'   => $base_url . 'wp-admin/options-general.php',
-			],
-		];
-	}
-
-	/**
 	 * Gets a collection of bookmarks for this Node.
 	 *
 	 * @return array
@@ -168,7 +128,7 @@ class Node {
 	public function get_bookmarks() {
 		$base_url = $this->get_url();
 
-		return self::generate_bookmarks( $base_url );
+		return Sites::generate_bookmarks( $base_url );
 	}
 
 	/**

--- a/includes/incoming-events/class-hub-name-updated.php
+++ b/includes/incoming-events/class-hub-name-updated.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Newspack Hub Name Updated Incoming Event class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Debugger;
+
+/**
+ * Class to handle the Hub Name Updated Event
+ *
+ * This will store the Hub's name on every Node options table.
+ */
+class Hub_Name_Updated extends Abstract_Incoming_Event {
+
+	/**
+	 * Process event in Node
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		update_option( 'newspack_network_hub_name', $this->get_new_name() );
+	}
+
+	/**
+	 * Get the new name
+	 *
+	 * @return string
+	 */
+	public function get_new_name() {
+		return $this->get_data()->name;
+	}
+}

--- a/includes/node/class-settings.php
+++ b/includes/node/class-settings.php
@@ -9,7 +9,6 @@ namespace Newspack_Network\Node;
 
 use Newspack_Network\Admin;
 use Newspack_Network\Crypto;
-use Newspack_Network\Hub\Node as Hub_Node;
 use Newspack_Network\Hub\Nodes as Hub_Nodes;
 use WP_Error;
 
@@ -52,7 +51,6 @@ class Settings {
 		add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
 		add_filter( 'allowed_options', [ __CLASS__, 'allowed_options' ] );
 		add_action( 'admin_init', [ __CLASS__, 'process_connection_form' ] );
-		add_action( 'admin_bar_menu', [ __CLASS__, 'admin_bar_menu' ], 100 );
 	}
 
 	/**
@@ -579,43 +577,5 @@ class Settings {
 			<p><?php echo esc_html( self::$connection_error ); ?></p>
 			</div>
 		<?php
-	}
-	
-	/**
-	 * Adds the nodes and their bookmarks to the Admin Bar menu
-	 *
-	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
-	 * @return void
-	 */
-	public static function admin_bar_menu( $wp_admin_bar ) {
-		$nodes_data   = get_option( Hub_Node::HUB_NODES_SYNCED_OPTION, [] );
-		$nodes_data[] = [
-			'id'    => 0,
-			'url'   => self::get_hub_url(),
-			'title' => __( 'Hub', 'newspack-network' ),
-		];
-
-		foreach ( $nodes_data as $node ) {
-			$item_id = 'node-' . $node['id'];
-			$wp_admin_bar->add_node(
-				[
-					'id'     => $item_id,
-					'title'  => $node['title'],
-					'href'   => $node['url'],
-					'parent' => 'site-name',
-				]
-			);
-
-			foreach ( Hub_Node::generate_bookmarks( $node['url'] ) as $bookmark ) {
-				$wp_admin_bar->add_node(
-					[
-						'id'     => $item_id . '-' . sanitize_title( $bookmark['label'] ),
-						'title'  => $bookmark['label'],
-						'href'   => $bookmark['url'],
-						'parent' => $item_id,
-					]
-				);
-			}
-		}
 	}
 }

--- a/includes/utils/class-sites.php
+++ b/includes/utils/class-sites.php
@@ -36,7 +36,7 @@ class Sites {
 	 *
 	 * @return array Array of arrays with name and url properties.
 	 */
-	public static function get_all_sites_but_current() {
+	public static function get_all_sites_without_current() {
 		$sites = self::get_all_sites();
 		return array_filter(
 			$sites,

--- a/includes/utils/class-sites.php
+++ b/includes/utils/class-sites.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Newspack Network Sites methods.
+ *
+ * Helper methods to get sites lists and info in an easy way.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Utils;
+
+use Newspack_Network\Site_Role;
+use Newspack_Network\Hub\Nodes;
+use Newspack_Network\Hub\Node as Hub_Node;
+use Newspack_Network\Node\Settings as Node_Settings;
+
+/**
+ * Class to watch the user for updates and trigger events
+ */
+class Sites {
+
+	/**
+	 * Get all sites
+	 *
+	 * @return array Array of arrays with name and url properties.
+	 */
+	public static function get_all_sites() {
+		return array_merge( [ self::get_hub() ], self::get_nodes() );
+	}
+
+	/**
+	 * Get all sites but the current one
+	 *
+	 * @return array Array of arrays with name and url properties.
+	 */
+	public static function get_all_sites_but_current() {
+		$sites = self::get_all_sites();
+		return array_filter(
+			$sites,
+			function( $site ) {
+				return $site['url'] !== get_bloginfo( 'url' );
+			}
+		);
+	}
+
+	/**
+	 * Get the hub info
+	 *
+	 * @return array Array with name and url properties.
+	 */
+	public static function get_hub() {
+		if ( Site_Role::is_hub() ) {
+			$name = get_bloginfo( 'name' );
+			$url = get_bloginfo( 'url' );
+		}
+
+		if ( Site_Role::is_node() ) {
+			$url = Node_Settings::get_hub_url();
+			$name = get_option( 'newspack_network_hub_name' );
+			if ( empty( $name ) ) {
+				$name = 'Hub';
+			}
+		}
+
+		return [
+			'name' => $name ?? '',
+			'url'  => $url ?? '',
+		];
+	}
+
+	/**
+	 * Get the nodes info
+	 *
+	 * @return array Array of arrays with name and url properties.
+	 */
+	public static function get_nodes() {
+		$sites = [];
+
+		if ( Site_Role::is_hub() ) {
+			$nodes = Nodes::get_all_nodes();
+			foreach ( $nodes as $node ) {
+				$sites[] = [
+					'name' => $node->get_name(),
+					'url'  => $node->get_url(),
+				];
+			}
+		}
+
+		if ( Site_Role::is_node() ) {
+			$nodes_data = get_option( Hub_Node::HUB_NODES_SYNCED_OPTION, [] );
+			foreach ( $nodes_data as $node_data ) {
+				$sites[] = [
+					'name' => $node_data['title'],
+					'url'  => $node_data['url'],
+				];
+			}
+
+			// Add current node.
+			$sites[] = [
+				'name' => get_bloginfo( 'name' ),
+				'url'  => get_bloginfo( 'url' ),
+			];
+		}
+
+		return $sites;
+	}
+
+	/**
+	 * Generates a collection of bookmarks for a site
+	 *
+	 * @param  string $url The URL of the site.
+	 * @return array Array of arrays with label and url properties.
+	 */
+	public static function generate_bookmarks( $url ) {
+		$base_url = trailingslashit( $url );
+
+		return [
+			[
+				'label' => __( 'Dashboard', 'newspack-network' ),
+				'url'   => $base_url . 'wp-admin/',
+			],
+			[
+				'label' => 'Newspack',
+				'url'   => $base_url . 'wp-admin?page=newspack',
+			],
+			[
+				'label' => 'WooCommerce',
+				'url'   => $base_url . 'wp-admin/admin.php?page=wc-admin',
+			],
+			[
+				'label' => __( 'Posts', 'newspack-network' ),
+				'url'   => $base_url . 'wp-admin/edit.php',
+			],
+			[
+				'label' => __( 'Users', 'newspack-network' ),
+				'url'   => $base_url . 'wp-admin/users.php',
+			],
+			[
+				'label' => __( 'Plugins', 'newspack-network' ),
+				'url'   => $base_url . 'wp-admin/plugins.php',
+			],
+			[
+				'label' => __( 'Settings', 'newspack-network' ),
+				'url'   => $base_url . 'wp-admin/options-general.php',
+			],
+		];
+	}
+}

--- a/includes/utils/class-sites.php
+++ b/includes/utils/class-sites.php
@@ -2,8 +2,6 @@
 /**
  * Newspack Network Sites methods.
  *
- * Helper methods to get sites lists and info in an easy way.
- *
  * @package Newspack
  */
 
@@ -15,7 +13,12 @@ use Newspack_Network\Hub\Node as Hub_Node;
 use Newspack_Network\Node\Settings as Node_Settings;
 
 /**
- * Class to watch the user for updates and trigger events
+ * Class to get information about the sites in the network.
+ *
+ * Helper methods to get sites lists and info in an easy way.
+ *
+ * This is specially useful for third party integration that wants to get a list of the sites in the network.
+ * With these methods, you can get that lists without worrying if you are in a hub or a node and how the data is stored.
  */
 class Sites {
 


### PR DESCRIPTION
This PR does two (3) things :) 

1. It propagates the Hub's name to all Nodes, 
2. Makes the Hub name be used in the Top admin bar menu, where it lists the sites and their bookmarks

(and 3. Refactors the registration of the menu bar to reduce code duplication and adds a Utils\Sites method that is useful for integrations to easily get the list of access not having to worry about whether we are in the hub or the node)

## How to test

1. Load this branch and navigate both on the Hub and Nodes and confirm the admin bar menu still works
2. Confirm the Hub is still called "Hub"
3. Run the backfill on the Hub CLI -> `wp newspack-network data-backfill network_hub_name_updated` (dry run) and `wp newspack-network data-backfill network_hub_name_updated --verbose --live`.
4. Confirm the new event Hub Name Updated added to the Event log
5. Pull the events in a Node
6. Confirm the Hub's name now show up in the admin bar menu in the Node
7. Back to the Hub, go to Settings > General and change the site's name
8. Confirm the event is created in the event log
9. Check the methods available in the Utils\Sites class and test them in WP Shell