### PR TITLE
fix: avoid post status collision

### DIFF
--- a/includes/hub/admin/css/woo-cpts.css
+++ b/includes/hub/admin/css/woo-cpts.css
@@ -21,51 +21,51 @@
     text-overflow: ellipsis;
 }
 
-.order-status.status-np-net-completed {
+.order-status.status-npn-completed {
     background: #c8d7e1;
     color: #2e4453;
 }
 
-.order-status.status-np-net-on-hold {
+.order-status.status-npn-on-hold {
     background: #f8dda7;
     color: #94660c;
 }
 
-.order-status.status-np-net-failed {
+.order-status.status-npn-failed {
     background: #eba3a3;
     color: #761919;
 }
 
-.order-status.status-np-net-processing {
+.order-status.status-npn-processing {
     background: #c6e1c6;
     color: #5b841b;
 }
 
-.order-status.status-np-net-trash {
+.order-status.status-npn-trash {
     background: #eba3a3;
     color: #761919;
 }
-.subscription-status.status-np-net-active {
+.subscription-status.status-npn-active {
     background: #c6e1c6;
     color: #5b841b;
 }
 
-.subscription-status.status-np-net-expired {
+.subscription-status.status-npn-expired {
     background: #bd94af;
     color: #724663;
 }
 
-.subscription-status.status-np-net-pending-cancel {
+.subscription-status.status-npn-pending-cancel {
     background: #bfbfbf;
     color: #737373;
 }
 
-.subscription-status.status-np-net-on-hold {
+.subscription-status.status-npn-on-hold {
     background: #f8dda7;
     color: #94660c;
 }
 
-.subscription-status.status-np-net-expired {
+.subscription-status.status-npn-expired {
     background: #bd94af;
     color: #724663;
 }

--- a/includes/hub/admin/css/woo-cpts.css
+++ b/includes/hub/admin/css/woo-cpts.css
@@ -21,51 +21,51 @@
     text-overflow: ellipsis;
 }
 
-.order-status.status-completed {
+.order-status.status-np-net-completed {
     background: #c8d7e1;
     color: #2e4453;
 }
 
-.order-status.status-on-hold {
+.order-status.status-np-net-on-hold {
     background: #f8dda7;
     color: #94660c;
 }
 
-.order-status.status-failed {
+.order-status.status-np-net-failed {
     background: #eba3a3;
     color: #761919;
 }
 
-.order-status.status-processing {
+.order-status.status-np-net-processing {
     background: #c6e1c6;
     color: #5b841b;
 }
 
-.order-status.status-trash {
+.order-status.status-np-net-trash {
     background: #eba3a3;
     color: #761919;
 }
-.subscription-status.status-active {
+.subscription-status.status-np-net-active {
     background: #c6e1c6;
     color: #5b841b;
 }
 
-.subscription-status.status-expired {
+.subscription-status.status-np-net-expired {
     background: #bd94af;
     color: #724663;
 }
 
-.subscription-status.status-pending-cancel {
+.subscription-status.status-np-net-pending-cancel {
     background: #bfbfbf;
     color: #737373;
 }
 
-.subscription-status.status-on-hold {
+.subscription-status.status-np-net-on-hold {
     background: #f8dda7;
     color: #94660c;
 }
 
-.subscription-status.status-expired {
+.subscription-status.status-np-net-expired {
     background: #bd94af;
     color: #724663;
 }

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -169,6 +169,8 @@ class Orders {
 			}
 
 			update_option( 'np_hub_orders_db_version', self::DB_VERSION );
+
+			wp_cache_flush();
 		}
 	}
 }

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -24,6 +24,20 @@ class Orders {
 	const POST_TYPE_SLUG = 'np_hub_orders';
 
 	/**
+	 * DB_VERSION for Node Orders.
+	 *
+	 * @var int
+	 */
+	const DB_VERSION = 2;
+
+	/**
+	 * POST_STATUS_PREFIX for Node Orders.
+	 *
+	 * @var string
+	 */
+	const POST_STATUS_PREFIX = 'np-net-';
+
+	/**
 	 * Initialize this class and register hooks
 	 *
 	 * @return void
@@ -31,6 +45,7 @@ class Orders {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'register_post_statuses' ] );
+		add_action( 'init', [ __CLASS__, 'update_db_version' ], 1 );
 	}
 
 	/**
@@ -96,13 +111,13 @@ class Orders {
 	 */
 	public static function register_post_statuses() {
 		$subscription_statuses = array(
-			'pending'    => _x( 'Pending', 'Order status', 'newspack-network' ),
-			'processing' => _x( 'Processing', 'Order status', 'newspack-network' ),
-			'completed'  => _x( 'Completed', 'Order status', 'newspack-network' ),
-			'on-hold'    => _x( 'On hold', 'Order status', 'newspack-network' ),
-			'cancelled'  => _x( 'Cancelled', 'Order status', 'newspack-network' ),
-			'refunded'   => _x( 'Refunded', 'Order status', 'newspack-network' ),
-			'failed'     => _x( 'Failed', 'Order status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'pending'    => _x( 'Pending', 'Order status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'processing' => _x( 'Processing', 'Order status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'completed'  => _x( 'Completed', 'Order status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'on-hold'    => _x( 'On hold', 'Order status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'cancelled'  => _x( 'Cancelled', 'Order status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'refunded'   => _x( 'Refunded', 'Order status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'failed'     => _x( 'Failed', 'Order status', 'newspack-network' ),
 		);
 		foreach ( $subscription_statuses as $status => $label ) {
 			register_post_status(
@@ -115,6 +130,45 @@ class Orders {
 					'show_in_admin_status_list' => true,
 				)
 			);
+		}
+	}
+
+	/**
+	 * Get the DB version
+	 *
+	 * @return int
+	 */
+	public static function get_db_version() {
+		return get_option( 'np_hub_orders_db_version', 0 );
+	}
+
+	/**
+	 * Update the DB version
+	 *
+	 * @return void
+	 */
+	public static function update_db_version() {
+
+		$current_version = self::get_db_version();
+
+		if ( version_compare( $current_version, self::DB_VERSION, '<' ) ) {
+
+			if ( $current_version < 2 ) {
+				global $wpdb;
+
+				foreach ( [ 'pending', 'processing', 'on-hold', 'completed', 'cancelled', 'refunded', 'failed' ] as $status ) {
+					$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+						$wpdb->posts,
+						[ 'post_status' => self::POST_STATUS_PREFIX . $status ],
+						[
+							'post_status' => $status,
+							'post_type'   => self::POST_TYPE_SLUG,
+						]
+					);
+				}
+			}
+
+			update_option( 'np_hub_orders_db_version', self::DB_VERSION );
 		}
 	}
 }

--- a/includes/hub/database/class-orders.php
+++ b/includes/hub/database/class-orders.php
@@ -35,7 +35,7 @@ class Orders {
 	 *
 	 * @var string
 	 */
-	const POST_STATUS_PREFIX = 'np-net-';
+	const POST_STATUS_PREFIX = 'npn-';
 
 	/**
 	 * Initialize this class and register hooks

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -35,7 +35,7 @@ class Subscriptions {
 	 *
 	 * @var string
 	 */
-	const POST_STATUS_PREFIX = 'np-net-';
+	const POST_STATUS_PREFIX = 'npn-';
 
 	/**
 	 * Initialize this class and register hooks

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -24,6 +24,20 @@ class Subscriptions {
 	const POST_TYPE_SLUG = 'np_hub_subscriptions';
 
 	/**
+	 * DB_VERSION for Node Subscriptions.
+	 *
+	 * @var int
+	 */
+	const DB_VERSION = 2;
+
+	/**
+	 * POST_STATUS_PREFIX for Node Subscriptions.
+	 *
+	 * @var string
+	 */
+	const POST_STATUS_PREFIX = 'np-net-';
+
+	/**
 	 * Initialize this class and register hooks
 	 *
 	 * @return void
@@ -31,6 +45,7 @@ class Subscriptions {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'register_post_statuses' ] );
+		add_action( 'init', [ __CLASS__, 'update_db_version' ], 1 );
 	}
 
 	/**
@@ -96,13 +111,13 @@ class Subscriptions {
 	 */
 	public static function register_post_statuses() {
 		$subscription_statuses = array(
-			'pending'        => _x( 'Pending', 'Subscription status', 'newspack-network' ),
-			'active'         => _x( 'Active', 'Subscription status', 'newspack-network' ),
-			'on-hold'        => _x( 'On hold', 'Subscription status', 'newspack-network' ),
-			'cancelled'      => _x( 'Cancelled', 'Subscription status', 'newspack-network' ),
-			'switched'       => _x( 'Switched', 'Subscription status', 'newspack-network' ),
-			'expired'        => _x( 'Expired', 'Subscription status', 'newspack-network' ),
-			'pending-cancel' => _x( 'Pending Cancellation', 'Subscription status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'pending'        => _x( 'Pending', 'Subscription status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'active'         => _x( 'Active', 'Subscription status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'on-hold'        => _x( 'On hold', 'Subscription status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'cancelled'      => _x( 'Cancelled', 'Subscription status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'switched'       => _x( 'Switched', 'Subscription status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'expired'        => _x( 'Expired', 'Subscription status', 'newspack-network' ),
+			self::POST_STATUS_PREFIX . 'pending-cancel' => _x( 'Pending Cancellation', 'Subscription status', 'newspack-network' ),
 		);
 		foreach ( $subscription_statuses as $status => $label ) {
 			register_post_status(
@@ -115,6 +130,45 @@ class Subscriptions {
 					'show_in_admin_status_list' => true,
 				)
 			);
+		}
+	}
+
+	/**
+	 * Get the DB version
+	 *
+	 * @return int
+	 */
+	public static function get_db_version() {
+		return get_option( 'np_hub_subscriptions_db_version', 0 );
+	}
+
+	/**
+	 * Update the DB version
+	 *
+	 * @return void
+	 */
+	public static function update_db_version() {
+
+		$current_version = self::get_db_version();
+
+		if ( version_compare( $current_version, self::DB_VERSION, '<' ) ) {
+
+			if ( $current_version < 2 ) {
+				global $wpdb;
+
+				foreach ( [ 'pending', 'active', 'on-hold', 'cancelled', 'switched', 'expired', 'pending-cancel' ] as $status ) {
+					$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+						$wpdb->posts,
+						[ 'post_status' => self::POST_STATUS_PREFIX . $status ],
+						[
+							'post_status' => $status,
+							'post_type'   => self::POST_TYPE_SLUG,
+						]
+					);
+				}
+			}
+
+			update_option( 'np_hub_subscriptions_db_version', self::DB_VERSION );
 		}
 	}
 }

--- a/includes/hub/database/class-subscriptions.php
+++ b/includes/hub/database/class-subscriptions.php
@@ -169,6 +169,8 @@ class Subscriptions {
 			}
 
 			update_option( 'np_hub_subscriptions_db_version', self::DB_VERSION );
+
+			wp_cache_flush();
 		}
 	}
 }

--- a/includes/hub/stores/class-orders.php
+++ b/includes/hub/stores/class-orders.php
@@ -44,6 +44,15 @@ class Orders extends Woo_Store {
 	}
 
 	/**
+	 * Gets the post status prefix
+	 *
+	 * @return string
+	 */
+	protected static function get_post_status_prefix() {
+		return Orders_DB::POST_STATUS_PREFIX;
+	}
+
+	/**
 	 * Persists a Order_Changed event by creating or updating a Subscription post.
 	 *
 	 * @param Order_Changed $order The Order_Changed event.
@@ -73,7 +82,7 @@ class Orders extends Woo_Store {
 		Debugger::log( 'Updating post status to ' . $order->get_status_after() );
 		$update_array = [
 			'ID'          => $local_id,
-			'post_status' => $order->get_status_after(),
+			'post_status' => self::get_post_status_for_db( $order->get_status_after() ),
 		];
 		$update       = wp_update_post( $update_array );
 		Debugger::log( 'Updated post status: ' . $update );

--- a/includes/hub/stores/class-subscriptions.php
+++ b/includes/hub/stores/class-subscriptions.php
@@ -44,6 +44,15 @@ class Subscriptions extends Woo_Store {
 	}
 
 	/**
+	 * Gets the post status prefix
+	 *
+	 * @return string
+	 */
+	protected static function get_post_status_prefix() {
+		return Subscriptions_DB::POST_STATUS_PREFIX;
+	}
+
+	/**
 	 * Persists a Subscription_Changed event by creating or updating a Subscription post.
 	 *
 	 * @param Subscription_Changed $subscription The Subscription_Changed event.
@@ -82,7 +91,7 @@ class Subscriptions extends Woo_Store {
 		Debugger::log( 'Updating post status to ' . $subscription->get_status_after() );
 		$update_array = [
 			'ID'          => $local_id,
-			'post_status' => $subscription->get_status_after(),
+			'post_status' => self::get_post_status_for_db( $subscription->get_status_after() ),
 		];
 		$update       = wp_update_post( $update_array );
 		Debugger::log( 'Updated post status: ' . $update );

--- a/includes/hub/stores/class-woo-store.php
+++ b/includes/hub/stores/class-woo-store.php
@@ -38,6 +38,26 @@ abstract class Woo_Store {
 	abstract protected static function get_item_class();
 
 	/**
+	 * Gets the post status prefix
+	 *
+	 * @return string
+	 */
+	abstract protected static function get_post_status_prefix();
+
+	/**
+	 * Gets the post status for the database
+	 *
+	 * @param string $status The status slug.
+	 * @return string The post status.
+	 */
+	public static function get_post_status_for_db( $status ) {
+		if ( 0 === strpos( $status, static::get_post_status_prefix() ) ) {
+			return $status;
+		}
+		return static::get_post_status_prefix() . $status;
+	}
+
+	/**
 	 * Gets an item by its ID
 	 *
 	 * @param int $item_id The item ID.
@@ -92,7 +112,7 @@ abstract class Woo_Store {
 		}
 		$post_arr = [
 			'post_type'   => static::get_post_type_slug(),
-			'post_status' => $woo_item->get_status_after(),
+			'post_status' => static::get_post_status_for_db( $woo_item->get_status_after() ),
 			'post_title'  => '#' . $woo_item_id,
 			'post_author' => $user_id,
 		];


### PR DESCRIPTION
When these post types were first created, we should have added more specific slugs to the custom statuses, because they can conflict with core statuses, as post statuses apply to all post types.

This is in fact happening with "pending", making the core's pending status public.

We could simply remove the "pending" status registration and things would work just fine, as this is already registered by core. But the best thing to do is to add a very specific prefix to avoid these statuses to conflict with anything else in the future.

## Testing

Make sure you have some orders and subscriptions in your Hub's database.

Checkout this branch and make sure things just keep working as usual. The existing items are listed as before, and new items are created and updated as usual.