### PR TITLE
feat(content-distribution): add media data to the outgoing post payload

### DIFF
--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -298,6 +298,7 @@ class Outgoing_Post {
 				'taxonomy'       => $this->get_post_taxonomy_terms(),
 				'thumbnail_url'  => $this->get_post_thumbnail_url(),
 				'post_meta'      => $this->get_post_meta(),
+				'media_data'     => $this->get_post_media_data(),
 			],
 		];
 
@@ -435,5 +436,82 @@ class Outgoing_Post {
 		 * @param WP_Post $post The post object.
 		 */
 		return apply_filters( 'newspack_network_distributed_post_meta', $meta, $this->post );
+	}
+
+	/**
+	 * Get the post attachment data for distribution.
+	 *
+	 * @return array The post attachment data.
+	 */
+	protected function get_post_media_data() {
+		$attachment_data = [];
+
+		add_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+
+		$thumbnail_id = get_post_thumbnail_id( $this->post->ID );
+		if ( $thumbnail_id ) {
+			$attachment_data[ $thumbnail_id ] = [
+				'url'        => wp_get_attachment_image_src( $thumbnail_id, 'full' )[0],
+				'caption'    => wp_get_attachment_caption( $thumbnail_id ),
+				'credit'     => get_post_meta( $thumbnail_id, '_media_credit', true ),
+				'credit_url' => get_post_meta( $thumbnail_id, '_media_credit_url', true ),
+				'alt'        => get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true ),
+				'featured'   => true,
+			];
+		}
+
+		$content     = apply_filters( 'the_content', get_the_content( null, false, get_post( $this->post->ID ) ) );
+		$attachments = self::get_content_attachments( $content );
+		foreach ( $attachments as $attachment ) {
+			$attachment_data[ $attachment->ID ] = [
+				'url'      => wp_get_attachment_image_src( $attachment->ID, 'full' )[0],
+				'caption'  => wp_get_attachment_caption( $attachment->ID ),
+				'credit'   => get_post_meta( $attachment->ID, '_media_credit', true ),
+				'alt'      => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
+				'featured' => false,
+			];
+		}
+
+		remove_filter( 'jetpack_photon_override_image_downsize', '__return_true' );
+		return $attachment_data;
+	}
+
+	/**
+	 * Get the attachments given a content string.
+	 *
+	 * @param string $content The content to search for attachment posts.
+	 *
+	 * @return WP_Post[] The attachment posts.
+	 */
+	public static function get_content_attachments( $content ) {
+		$pattern = '/<img[^>]+src="([^"]+)"[^>]*>/i';
+		preg_match_all( $pattern, $content, $matches );
+
+		if ( empty( $matches ) ) {
+			return [];
+		}
+
+		$attachment_ids = [];
+		foreach ( $matches[0] as $image_tag ) {
+			$attachment_id = null;
+			if ( preg_match( '/wp-image-(\d+)/i', $image_tag, $m ) ) {
+				$attachment_id = $m[1];
+			} elseif ( preg_match( '/data-attachment-id="(\d+)"/i', $image_tag, $m ) ) {
+				$attachment_id = $m[1];
+			} elseif ( preg_match( '/data-id="(\d+)"/i', $image_tag, $m ) ) {
+				$attachment_id = $m[1];
+			} elseif ( preg_match( '/id="(\d+)"/i', $image_tag, $m ) ) {
+				$attachment_id = $m[1];
+			}
+			if ( empty( $attachment_id ) ) {
+				continue;
+			}
+			$attachment = get_post( $attachment_id );
+			if ( ! $attachment ) {
+				continue;
+			}
+			$attachment_ids[] = $attachment;
+		}
+		return $attachment_ids;
 	}
 }

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -464,11 +464,12 @@ class Outgoing_Post {
 		$attachments = self::get_content_attachments( $content );
 		foreach ( $attachments as $attachment ) {
 			$attachment_data[ $attachment->ID ] = [
-				'url'      => wp_get_attachment_image_src( $attachment->ID, 'full' )[0],
-				'caption'  => wp_get_attachment_caption( $attachment->ID ),
-				'credit'   => get_post_meta( $attachment->ID, '_media_credit', true ),
-				'alt'      => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
-				'featured' => false,
+				'url'        => wp_get_attachment_image_src( $attachment->ID, 'full' )[0],
+				'caption'    => wp_get_attachment_caption( $attachment->ID ),
+				'credit'     => get_post_meta( $attachment->ID, '_media_credit', true ),
+				'credit_url' => get_post_meta( $attachment->ID, '_media_credit_url', true ),
+				'alt'        => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
+				'featured'   => false,
 			];
 		}
 

--- a/tests/unit-tests/content-distribution/test-outgoing-post-media-data.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post-media-data.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Class TestOutgoingPost
+ *
+ * @package Newspack_Network
+ */
+
+namespace Test\Content_Distribution;
+
+use Newspack_Network\Content_Distribution\Outgoing_Post;
+use Newspack_Network\Hub\Node as Hub_Node;
+use WP_User;
+
+/**
+ * Test the Outgoing_Post class.
+ */
+class TestOutgoingPostMediaData extends \WP_UnitTestCase {
+	/**
+	 * Test get content attachments with no images.
+	 */
+	public function test_get_content_attachments_no_images() {
+		$content = 'This is a test post with no images.';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+		$this->assertEmpty( $attachments );
+	}
+
+	/**
+	 * Test get content attachments with wp-image class.
+	 */
+	public function test_get_content_attachments_wp_image_class() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create_object(
+			'test-image.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '<img src="https://example.com/test-image.jpg" class="wp-image-' . $attachment_id . '" alt="Test Image">';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 1, $attachments );
+		$this->assertEquals( $attachment_id, $attachments[0]->ID );
+		$this->assertEquals( 'attachment', $attachments[0]->post_type );
+	}
+
+	/**
+	 * Test get content attachments with data-attachment-id attribute.
+	 */
+	public function test_get_content_attachments_data_attachment_id() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create_object(
+			'test-image.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '<img src="https://example.com/test-image.jpg" data-attachment-id="' . $attachment_id . '" alt="Test Image">';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 1, $attachments );
+		$this->assertEquals( $attachment_id, $attachments[0]->ID );
+	}
+
+	/**
+	 * Test get content attachments with data-id attribute.
+	 */
+	public function test_get_content_attachments_data_id() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create_object(
+			'test-image.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '<img src="https://example.com/test-image.jpg" data-id="' . $attachment_id . '" alt="Test Image">';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 1, $attachments );
+		$this->assertEquals( $attachment_id, $attachments[0]->ID );
+	}
+
+	/**
+	 * Test get content attachments with id attribute.
+	 */
+	public function test_get_content_attachments_id_attribute() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create_object(
+			'test-image.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '<img src="https://example.com/test-image.jpg" id="' . $attachment_id . '" alt="Test Image">';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 1, $attachments );
+		$this->assertEquals( $attachment_id, $attachments[0]->ID );
+	}
+
+	/**
+	 * Test get content attachments with multiple images.
+	 */
+	public function test_get_content_attachments_multiple_images() {
+		// Create test attachments.
+		$attachment_id_1 = $this->factory->attachment->create_object(
+			'test-image-1.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+		$attachment_id_2 = $this->factory->attachment->create_object(
+			'test-image-2.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '
+			<p>Some text here.</p>
+			<img src="https://example.com/test-image-1.jpg" class="wp-image-' . $attachment_id_1 . '" alt="Test Image 1">
+			<p>More text here.</p>
+			<img src="https://example.com/test-image-2.jpg" data-attachment-id="' . $attachment_id_2 . '" alt="Test Image 2">
+			<p>Final text.</p>
+		';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 2, $attachments );
+		$this->assertEquals( $attachment_id_1, $attachments[0]->ID );
+		$this->assertEquals( $attachment_id_2, $attachments[1]->ID );
+	}
+
+	/**
+	 * Test get content attachments with non-existent attachment ID.
+	 */
+	public function test_get_content_attachments_nonexistent_id() {
+		$content = '<img src="https://example.com/test-image.jpg" class="wp-image-99999" alt="Test Image">';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertEmpty( $attachments );
+	}
+
+	/**
+	 * Test get content attachments with image without attachment ID.
+	 */
+	public function test_get_content_attachments_no_attachment_id() {
+		$content = '<img src="https://example.com/test-image.jpg" alt="Test Image">';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertEmpty( $attachments );
+	}
+
+	/**
+	 * Test get content attachments with mixed valid and invalid images.
+	 */
+	public function test_get_content_attachments_mixed_valid_invalid() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create_object(
+			'test-image.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '
+			<img src="https://example.com/test-image.jpg" alt="No attachment ID">
+			<img src="https://example.com/test-image.jpg" class="wp-image-' . $attachment_id . '" alt="Valid attachment">
+			<img src="https://example.com/test-image.jpg" class="wp-image-99999" alt="Invalid attachment ID">
+		';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 1, $attachments );
+		$this->assertEquals( $attachment_id, $attachments[0]->ID );
+	}
+
+	/**
+	 * Test get content attachments with different attribute orders.
+	 */
+	public function test_get_content_attachments_different_attribute_orders() {
+		// Create test attachments.
+		$attachment_id_1 = $this->factory->attachment->create_object(
+			'test-image-1.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+		$attachment_id_2 = $this->factory->attachment->create_object(
+			'test-image-2.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '
+			<img alt="Test Image 1" src="https://example.com/test-image-1.jpg" class="wp-image-' . $attachment_id_1 . '">
+			<img data-attachment-id="' . $attachment_id_2 . '" alt="Test Image 2" src="https://example.com/test-image-2.jpg">
+		';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 2, $attachments );
+		$this->assertEquals( $attachment_id_1, $attachments[0]->ID );
+		$this->assertEquals( $attachment_id_2, $attachments[1]->ID );
+	}
+
+	/**
+	 * Test get content attachments with case insensitive matching.
+	 */
+	public function test_get_content_attachments_case_insensitive() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create_object(
+			'test-image.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '<img src="https://example.com/test-image.jpg" class="WP-IMAGE-' . $attachment_id . '" alt="Test Image">';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 1, $attachments );
+		$this->assertEquals( $attachment_id, $attachments[0]->ID );
+	}
+
+	/**
+	 * Test get content attachments with self-closing img tags.
+	 */
+	public function test_get_content_attachments_self_closing_tags() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create_object(
+			'test-image.jpg',
+			0,
+			[
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+			]
+		);
+
+		$content = '<img src="https://example.com/test-image.jpg" class="wp-image-' . $attachment_id . '" alt="Test Image" />';
+		$attachments = Outgoing_Post::get_content_attachments( $content );
+
+		$this->assertCount( 1, $attachments );
+		$this->assertEquals( $attachment_id, $attachments[0]->ID );
+	}
+}

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -162,6 +162,7 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 			'thumbnail_url',
 			'taxonomy',
 			'post_meta',
+			'media_data',
 			'author',
 		];
 		$this->assertEmpty( array_diff( $post_data_keys, array_keys( $payload['post_data'] ) ) );

--- a/tests/unit-tests/content-distribution/util.php
+++ b/tests/unit-tests/content-distribution/util.php
@@ -71,6 +71,7 @@ function get_sample_payload( $origin = '', $destination = '' ) {
 				'array'    => [ [ 'a' => 'b', 'c' => 'd' ] ], // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
 				'multiple' => [ 'value 1', 'value 2' ],
 			],
+			'media_data'     => [],
 		],
 	];
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces `media_data` property to the post payload.

### How to test the changes in this Pull Request:

1. Draft a new post, set a featured image, and add the following blocks:
    1. Image
    2. Gallery
    3. Slideshow (jetpack)
    4. Tiled Gallery (jetpack)
2. Save the draft and use wp shell to get the payload:

```
$outgoing_post = new Newspack_Network\Content_Distribution\Outgoing_Post( $post_id );
$outgoing_post->get_payload();
```

3. Confirm all images are in the payload
4. Confirm the unit tests are accurate

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
