### PR TITLE
fix(content-distribution): account for null get_post return value

### DIFF
--- a/includes/content-distribution/class-editor.php
+++ b/includes/content-distribution/class-editor.php
@@ -74,6 +74,10 @@ class Editor {
 
 		$post = get_post();
 
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
 		if ( Content_Distribution_Class::is_post_incoming( $post ) ) {
 			self::enqueue_block_editor_assets_for_incoming_post( $post );
 		} else {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue where a `null` return value of `get_post` when loading the content distribution editor scripts can cause a fatal:

```
[19-Aug-2025 14:31:56 UTC] PHP Fatal error:  Uncaught TypeError: Newspack_Network\Content_Distribution\Editor::enqueue_block_editor_assets_for_outgoing_post(): Argument #1 ($post) must be of type WP_Post, null given, called in ...
```

### How to test the changes in this Pull Request:

We weren't able to replicate on a site other than my local, but code review should be fine. I was able to get this fatal by going to WP Admin > Pages.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
