### PR TITLE
fix(content-distribution): populate distributed featured image meta

### DIFF
--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -474,6 +474,38 @@ class Incoming_Post {
 			return;
 		}
 
+		/**
+		 * Update the attachment post meta.
+		 */
+		$media_data = $this->payload['post_data']['media_data'];
+		if ( ! empty( $media_data ) ) {
+			$meta = array_filter(
+				$media_data,
+				function( $media_item ) {
+					return $media_item['featured'];
+				}
+			);
+			if ( ! empty( $meta ) ) {
+				$meta = array_shift( $meta );
+				if ( ! empty( $meta['caption'] ) ) {
+					wp_update_post(
+						[
+							'ID'           => $attachment_id,
+							'post_excerpt' => $meta['caption'],
+						]
+					);
+				}
+				if ( ! empty( $meta['alt'] ) ) {
+					update_post_meta( $attachment_id, '_wp_attachment_image_alt', $meta['alt'] );
+				}
+				if ( ! empty( $meta['credit'] ) ) {
+					update_post_meta( $attachment_id, '_media_credit', $meta['credit'] );
+				}
+				if ( ! empty( $meta['credit_url'] ) ) {
+					update_post_meta( $attachment_id, '_media_credit_url', $meta['credit_url'] );
+				}
+			}
+		}
 		update_post_meta( $attachment_id, self::ATTACHMENT_META, true );
 
 		set_post_thumbnail( $this->ID, $attachment_id );

--- a/includes/content-distribution/class-outgoing-post.php
+++ b/includes/content-distribution/class-outgoing-post.php
@@ -463,6 +463,9 @@ class Outgoing_Post {
 		$content     = apply_filters( 'the_content', get_the_content( null, false, get_post( $this->post->ID ) ) );
 		$attachments = self::get_content_attachments( $content );
 		foreach ( $attachments as $attachment ) {
+			if ( isset( $attachment_data[ $attachment->ID ] ) ) {
+				continue;
+			}
 			$attachment_data[ $attachment->ID ] = [
 				'url'        => wp_get_attachment_image_src( $attachment->ID, 'full' )[0],
 				'caption'    => wp_get_attachment_caption( $attachment->ID ),

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -106,6 +106,10 @@ class TestIncomingPost extends \WP_UnitTestCase {
 
 		// Assert featured image.
 		$this->assertNotEmpty( get_post_thumbnail_id( $post_id ) );
+		$this->assertSame( 'Caption', wp_get_attachment_caption( get_post_thumbnail_id( $post_id ) ) );
+		$this->assertSame( 'Credit', get_post_meta( get_post_thumbnail_id( $post_id ), '_media_credit', true ) );
+		$this->assertSame( 'https://credit.url', get_post_meta( get_post_thumbnail_id( $post_id ), '_media_credit_url', true ) );
+		$this->assertSame( 'Alt', get_post_meta( get_post_thumbnail_id( $post_id ), '_wp_attachment_image_alt', true ) );
 
 		// Assert taxonomy terms.
 		$terms = wp_get_post_terms( $post_id, [ 'category', 'post_tag' ] );

--- a/tests/unit-tests/content-distribution/util.php
+++ b/tests/unit-tests/content-distribution/util.php
@@ -71,7 +71,16 @@ function get_sample_payload( $origin = '', $destination = '' ) {
 				'array'    => [ [ 'a' => 'b', 'c' => 'd' ] ], // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
 				'multiple' => [ 'value 1', 'value 2' ],
 			],
-			'media_data'     => [],
+			'media_data'     => [
+				[
+					'url'        => 'https://picsum.photos/id/1/300/300.jpg',
+					'caption'    => 'Caption',
+					'credit'     => 'Credit',
+					'credit_url' => 'https://credit.url',
+					'alt'        => 'Alt',
+					'featured'   => true,
+				],
+			],
 		],
 	];
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use the recently implemented `media_data` payload data to populate meta for the imported featured image.

### How to test the changes in this Pull Request:

1. Double-check unit test changes are accurate
2. In a node, create a draft a set a featured image that contains a caption, alt text, credit and credit url
3. Distribute the post to another node
4. Confirm in the destination that the image meta matches the origin data

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
