### PR TITLE
Fix for CAP GA logic

### DIFF
--- a/includes/content-distribution/class-cap-authors.php
+++ b/includes/content-distribution/class-cap-authors.php
@@ -162,7 +162,7 @@ class Cap_Authors {
 			}
 		}
 
-		do_action( 'newspack_network_incoming_cap_guest_authors', $post->ID, $guest_authors );
+		do_action( 'newspack_network_incoming_cap_guest_authors', $post->ID, $guest_authors, $cap_authors_from_payload );
 
 		global $coauthors_plus;
 		$coauthors_plus->add_coauthors( $post->ID, $guest_contributors );

--- a/includes/content-distribution/class-cap-guest-authors.php
+++ b/includes/content-distribution/class-cap-guest-authors.php
@@ -20,9 +20,9 @@ class Cap_Guest_Authors {
 	const GUEST_AUTHORS_META_KEY = 'newspack_network_guest_authors_distributed';
 
 	/**
-	 * Meta key to keep track of how many authors there are.
+	 * Meta key to keep track of which authors and guest authors are assigned to a post.
 	 */
-	const AUTHOR_COUNT_META_KEY = 'newspack_network_author_count';
+	const ASSIGNED_AUTHORS_META_KEY = 'newspack_network_assigned_authors';
 
 	/**
 	 * Go!
@@ -96,33 +96,34 @@ class Cap_Guest_Authors {
 			return $coauthors;
 		}
 
-		$distributed_authors = get_post_meta( $post_id, self::GUEST_AUTHORS_META_KEY, true );
-		$number_of_authors   = get_post_meta( $post_id, self::AUTHOR_COUNT_META_KEY, true );
+		$distributed_authors   = get_post_meta( $post_id, self::GUEST_AUTHORS_META_KEY, true );
+		$assigned_author_names = get_post_meta( $post_id, self::ASSIGNED_AUTHORS_META_KEY, true );
 
 		if ( ! $distributed_authors ) {
 			return $coauthors;
 		}
 
-		$guest_authors = [];
+		$assigned_authors = [];
+		foreach ( $coauthors as $coauthor ) {
+			if ( empty( $assigned_author_names ) || in_array( $coauthor->display_name, $assigned_author_names ) ) {
+				$assigned_authors[] = $coauthor;
+			}
+		}
 
 		foreach ( $distributed_authors as $distributed_author ) {
-
 			if ( 'guest_author' !== $distributed_author['type'] ) {
 				continue;
 			}
-			// This removes the author URL from the guest author.
-			$distributed_author['user_nicename'] = '';
-			$distributed_author['ID']            = - 2;
 
-			$guest_authors[] = (object) $distributed_author;
+			if ( empty( $assigned_author_names ) || in_array( $distributed_author['display_name'], $assigned_author_names ) ) {
+				// This removes the author URL from the guest author.
+				$distributed_author['user_nicename'] = '';
+				$distributed_author['ID']            = - 2;
+				$assigned_authors[] = (object) $distributed_author;
+			}
 		}
 
-		// If a post has only guest authors, don't include the non-guest authors.
-		if ( $number_of_authors && (int) $number_of_authors === count( $guest_authors ) ) {
-			return [ ...$guest_authors ];
-		}
-
-		return [ ...$coauthors, ...$guest_authors ];
+		return $assigned_authors;
 	}
 
 	/**
@@ -173,11 +174,11 @@ class Cap_Guest_Authors {
 	public static function on_guest_authors_incoming( $post_id, $guest_authors, $all_authors ): void {
 		if ( empty( $guest_authors ) ) {
 			delete_post_meta( $post_id, self::GUEST_AUTHORS_META_KEY );
-			delete_post_meta( $post_id, self::AUTHOR_COUNT_META_KEY );
+			delete_post_meta( $post_id, self::ASSIGNED_AUTHORS_META_KEY );
 			return;
 		}
 
-		update_post_meta( $post_id, self::AUTHOR_COUNT_META_KEY, count( $all_authors ) );
+		update_post_meta( $post_id, self::ASSIGNED_AUTHORS_META_KEY, wp_list_pluck( $all_authors, 'display_name' ) );
 		update_post_meta( $post_id, self::GUEST_AUTHORS_META_KEY, $guest_authors );
 	}
 
@@ -192,7 +193,7 @@ class Cap_Guest_Authors {
 	 */
 	public static function filter_ignored_post_meta_keys( array $ignored_keys ): array {
 		$ignored_keys[] = self::GUEST_AUTHORS_META_KEY;
-		$ignored_keys[] = self::AUTHOR_COUNT_META_KEY;
+		$ignored_keys[] = self::ASSIGNED_AUTHORS_META_KEY;
 
 		return $ignored_keys;
 	}

--- a/includes/content-distribution/class-cap-guest-authors.php
+++ b/includes/content-distribution/class-cap-guest-authors.php
@@ -20,6 +20,11 @@ class Cap_Guest_Authors {
 	const GUEST_AUTHORS_META_KEY = 'newspack_network_guest_authors_distributed';
 
 	/**
+	 * Meta key to keep track of how many authors there are.
+	 */
+	const AUTHOR_COUNT_META_KEY = 'newspack_network_author_count';
+
+	/**
 	 * Go!
 	 *
 	 * @return void
@@ -35,7 +40,7 @@ class Cap_Guest_Authors {
 
 		add_filter( 'newspack_network_content_distribution_ignored_post_meta_keys', [ __CLASS__, 'filter_ignored_post_meta_keys' ], 10, 2 );
 		add_filter( 'newspack_network_outgoing_non_wp_user_author', [ __CLASS__, 'filter_outgoing_non_wp_user_author' ], 10, 2 );
-		add_action( 'newspack_network_incoming_cap_guest_authors', [ __CLASS__, 'on_guest_authors_incoming' ], 10, 2 );
+		add_action( 'newspack_network_incoming_cap_guest_authors', [ __CLASS__, 'on_guest_authors_incoming' ], 10, 3 );
 
 
 		if ( ! is_admin() ) {
@@ -92,6 +97,7 @@ class Cap_Guest_Authors {
 		}
 
 		$distributed_authors = get_post_meta( $post_id, self::GUEST_AUTHORS_META_KEY, true );
+		$number_of_authors   = get_post_meta( $post_id, self::AUTHOR_COUNT_META_KEY, true );
 
 		if ( ! $distributed_authors ) {
 			return $coauthors;
@@ -109,6 +115,11 @@ class Cap_Guest_Authors {
 			$distributed_author['ID']            = - 2;
 
 			$guest_authors[] = (object) $distributed_author;
+		}
+
+		// If a post has only guest authors, don't include the non-guest authors.
+		if ( $number_of_authors && (int) $number_of_authors === count( $guest_authors ) ) {
+			return [ ...$guest_authors ];
 		}
 
 		return [ ...$coauthors, ...$guest_authors ];
@@ -151,20 +162,22 @@ class Cap_Guest_Authors {
 	}
 
 	/**
-	 * Action callback for reacting to incoimng guest authors.
+	 * Action callback for reacting to incoming guest authors.
 	 *
 	 * @param int   $post_id The post ID.
 	 * @param array $guest_authors The guest authors.
+	 * @param array $all_authors All synced authors.
 	 *
 	 * @return void
 	 */
-	public static function on_guest_authors_incoming( $post_id, $guest_authors ): void {
+	public static function on_guest_authors_incoming( $post_id, $guest_authors, $all_authors ): void {
 		if ( empty( $guest_authors ) ) {
 			delete_post_meta( $post_id, self::GUEST_AUTHORS_META_KEY );
-
+			delete_post_meta( $post_id, self::AUTHOR_COUNT_META_KEY );
 			return;
 		}
 
+		update_post_meta( $post_id, self::AUTHOR_COUNT_META_KEY, count( $all_authors ) );
 		update_post_meta( $post_id, self::GUEST_AUTHORS_META_KEY, $guest_authors );
 	}
 
@@ -179,6 +192,7 @@ class Cap_Guest_Authors {
 	 */
 	public static function filter_ignored_post_meta_keys( array $ignored_keys ): array {
 		$ignored_keys[] = self::GUEST_AUTHORS_META_KEY;
+		$ignored_keys[] = self::AUTHOR_COUNT_META_KEY;
 
 		return $ignored_keys;
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix.**

Closes NPPM-2299

Currently when a post is distributed with one active guest author

### How to test the changes in this Pull Request:

1. You'll need 2 sites connected with content distribution capabilities, and guest authors enabled with the `NEWSPACK_ENABLE_CAP_GUEST_AUTHORS` constant enabled.
2. Before applying this patch, create a post with only one **guest author** assigned. Distribute it. On the target site observe the author is e.g. "adminnewspack and My Guest Author"
3. Create another post, but this time with a real author and a guest author. Distribute it. On the target site observe the author is also e.g. "adminnewspack and My Guest Author"
4. Apply this patch. Make an update to those posts and distribute it. On the target site observe the author on the first post is e.g. "My Guest Author" and the author on the second post is still "adminnewspack and My Guest Author"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
