### PR TITLE
Hotfix/handle empty taxonomies - NPPM-2460

### DIFF
--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -537,6 +537,9 @@ class Incoming_Post {
 				if ( is_wp_error( $result ) ) {
 					self::log( 'Failed to set terms for taxonomy ' . $taxonomy . ' with message: ' . $result->get_error_message() );
 				}
+			} elseif ( empty( $terms ) ) {
+				// If there are no terms, remove all terms from the taxonomy.
+				wp_set_object_terms( $this->ID, [], $taxonomy );
 			}
 		}
 	}

--- a/includes/content-distribution/class-taxonomy-terms.php
+++ b/includes/content-distribution/class-taxonomy-terms.php
@@ -90,7 +90,7 @@ class Taxonomy_Terms {
 			}
 			$terms = get_the_terms( $post->ID, $taxonomy->name );
 			if ( ! $terms ) {
-				continue;
+				$terms = [];
 			}
 
 			$data[ $taxonomy->name ] = array_map(

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -747,4 +747,83 @@ class TestIncomingPost extends \WP_UnitTestCase {
 		// Assert that the thumbnail is unchanged.
 		$this->assertSame( $thumbnail_id, get_post_thumbnail_id( $post_id ) );
 	}
+
+	/**
+	 * Test removing all terms from a taxonomy with empty array.
+	 */
+	public function test_remove_all_terms_with_empty_array() {
+		$payload = $this->get_sample_payload();
+
+		// Insert the linked post with categories.
+		$post_id = $this->incoming_post->insert( $payload );
+
+		// Assert that the post has categories.
+		$terms = wp_get_post_terms( $post_id, 'category' );
+		$this->assertNotEmpty( $terms );
+		$this->assertCount( 2, $terms );
+
+		// Update the payload to have an empty array for categories.
+		$payload['post_data']['taxonomy']['category'] = [];
+
+		// Insert the updated linked post.
+		$this->incoming_post->insert( $payload );
+
+		// Assert that all categories have been removed.
+		$terms = wp_get_post_terms( $post_id, 'category' );
+		$this->assertEmpty( $terms );
+
+		// Assert that tags are still present.
+		$tags = wp_get_post_terms( $post_id, 'post_tag' );
+		$this->assertNotEmpty( $tags );
+		$this->assertCount( 2, $tags );
+	}
+
+	/**
+	 * Test removing all terms from multiple taxonomies with empty arrays.
+	 */
+	public function test_remove_all_terms_from_multiple_taxonomies() {
+		$payload = $this->get_sample_payload();
+
+		// Insert the linked post with categories and tags.
+		$post_id = $this->incoming_post->insert( $payload );
+
+		// Assert that the post has categories and tags.
+		$categories = wp_get_post_terms( $post_id, 'category' );
+		$tags = wp_get_post_terms( $post_id, 'post_tag' );
+		$this->assertNotEmpty( $categories );
+		$this->assertNotEmpty( $tags );
+
+		// Update the payload to have empty arrays for both taxonomies.
+		$payload['post_data']['taxonomy']['category'] = [];
+		$payload['post_data']['taxonomy']['post_tag'] = [];
+
+		// Insert the updated linked post.
+		$this->incoming_post->insert( $payload );
+
+		// Assert that all categories and tags have been removed.
+		$categories = wp_get_post_terms( $post_id, 'category' );
+		$tags = wp_get_post_terms( $post_id, 'post_tag' );
+		$this->assertEmpty( $categories );
+		$this->assertEmpty( $tags );
+	}
+
+	/**
+	 * Test empty taxonomy array creates post without terms.
+	 */
+	public function test_insert_post_with_empty_taxonomy_array() {
+		$payload = $this->get_sample_payload();
+
+		// Set taxonomies to empty arrays before inserting.
+		$payload['post_data']['taxonomy']['category'] = [];
+		$payload['post_data']['taxonomy']['post_tag'] = [];
+
+		// Insert the linked post.
+		$post_id = $this->incoming_post->insert( $payload );
+
+		// Assert that the post was created without any terms.
+		$categories = wp_get_post_terms( $post_id, 'category' );
+		$tags = wp_get_post_terms( $post_id, 'post_tag' );
+		$this->assertEmpty( $categories );
+		$this->assertEmpty( $tags );
+	}
 }

--- a/tests/unit-tests/content-distribution/test-outgoing-post.php
+++ b/tests/unit-tests/content-distribution/test-outgoing-post.php
@@ -224,6 +224,56 @@ class TestOutgoingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test empty taxonomies are included in the payload.
+	 */
+	public function test_empty_taxonomies_included_in_payload() {
+		// Create a post without any terms.
+		$post = $this->factory->post->create_and_get(
+			[
+				'post_type'   => 'post',
+				'post_author' => $this->some_editor->ID,
+			]
+		);
+		$outgoing_post = new Outgoing_Post( $post );
+		$outgoing_post->set_distribution( [ $this->network[0]['url'] ] );
+
+		$payload = $outgoing_post->get_payload();
+
+		// Assert that category and post_tag exist in the payload as empty arrays.
+		$this->assertArrayHasKey( 'taxonomy', $payload['post_data'] );
+		$this->assertArrayHasKey( 'post_tag', $payload['post_data']['taxonomy'] );
+		$this->assertIsArray( $payload['post_data']['taxonomy']['post_tag'] );
+		$this->assertEmpty( $payload['post_data']['taxonomy']['post_tag'] );
+	}
+
+	/**
+	 * Test empty custom taxonomy is included in the payload.
+	 */
+	public function test_empty_custom_taxonomy_included_in_payload() {
+		// Register a custom taxonomy.
+		$custom_taxonomy = 'custom_taxonomy';
+		register_taxonomy( $custom_taxonomy, 'post', [ 'public' => true ] );
+
+		// Create a post without any terms in the custom taxonomy.
+		$post = $this->factory->post->create_and_get(
+			[
+				'post_type'   => 'post',
+				'post_author' => $this->some_editor->ID,
+			]
+		);
+		$outgoing_post = new Outgoing_Post( $post );
+		$outgoing_post->set_distribution( [ $this->network[0]['url'] ] );
+
+		$payload = $outgoing_post->get_payload();
+
+		// Assert that the custom taxonomy exists in the payload as an empty array.
+		$this->assertArrayHasKey( 'taxonomy', $payload['post_data'] );
+		$this->assertArrayHasKey( $custom_taxonomy, $payload['post_data']['taxonomy'] );
+		$this->assertIsArray( $payload['post_data']['taxonomy'][ $custom_taxonomy ] );
+		$this->assertEmpty( $payload['post_data']['taxonomy'][ $custom_taxonomy ] );
+	}
+
+	/**
 	 * Test get partial payload.
 	 */
 	public function test_get_partial_payload() {

--- a/tests/unit-tests/content-distribution/test-taxonomy-terms.php
+++ b/tests/unit-tests/content-distribution/test-taxonomy-terms.php
@@ -674,4 +674,73 @@ class TestTaxonomyTerms extends \WP_UnitTestCase {
 		$this->assertNotFalse( $new_term );
 		$this->assertContains( $new_term->term_id, $term_ids );
 	}
+
+	/**
+	 * Test get_post_taxonomy_terms with no terms returns empty array.
+	 */
+	public function test_get_post_taxonomy_terms_no_terms_returns_empty_array() {
+		// Create a post without any terms.
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Test Post' ] );
+		$post = get_post( $post_id );
+
+		// Get taxonomy terms.
+		$terms = Taxonomy_Terms::get_post_taxonomy_terms( $post );
+
+		// Assert that categories and tags exist in the array as empty arrays.
+		$this->assertArrayHasKey( 'post_tag', $terms );
+		$this->assertIsArray( $terms['post_tag'] );
+		$this->assertEmpty( $terms['post_tag'] );
+	}
+
+	/**
+	 * Test get_post_taxonomy_terms with mixed terms (some empty, some not).
+	 */
+	public function test_get_post_taxonomy_terms_mixed_empty_and_populated() {
+		// Create a post.
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Test Post' ] );
+		$post = get_post( $post_id );
+
+		// Create and assign categories but not tags.
+		$category_1 = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Category 1',
+			]
+		);
+		wp_set_post_terms( $post_id, [ $category_1 ], 'category' );
+
+		// Get taxonomy terms.
+		$terms = Taxonomy_Terms::get_post_taxonomy_terms( $post );
+
+		// Assert that categories are populated.
+		$this->assertArrayHasKey( 'category', $terms );
+		$this->assertNotEmpty( $terms['category'] );
+		$this->assertCount( 1, $terms['category'] );
+		$this->assertSame( 'Category 1', $terms['category'][0]['name'] );
+
+		// Assert that tags are present but empty.
+		$this->assertArrayHasKey( 'post_tag', $terms );
+		$this->assertIsArray( $terms['post_tag'] );
+		$this->assertEmpty( $terms['post_tag'] );
+	}
+
+	/**
+	 * Test get_post_taxonomy_terms with custom taxonomy having no terms.
+	 */
+	public function test_get_post_taxonomy_terms_custom_taxonomy_no_terms() {
+		// Register a custom taxonomy.
+		register_taxonomy( 'custom_taxonomy', 'post', [ 'public' => true ] );
+
+		// Create a post without any custom taxonomy terms.
+		$post_id = $this->factory->post->create( [ 'post_title' => 'Test Post' ] );
+		$post = get_post( $post_id );
+
+		// Get taxonomy terms.
+		$terms = Taxonomy_Terms::get_post_taxonomy_terms( $post );
+
+		// Assert that custom taxonomy exists in the array as an empty array.
+		$this->assertArrayHasKey( 'custom_taxonomy', $terms );
+		$this->assertIsArray( $terms['custom_taxonomy'] );
+		$this->assertEmpty( $terms['custom_taxonomy'] );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Taxonomy terms are kept in sync on content distribution. However, when all terms are removed in the original post, the taxonomy is completely ignored, and the terms are never deleted from distributed posts

### How to test the changes in this Pull Request:

1. Create a post, add some tags, and distribute it
2. Check the distributed post has the correct tags in the target site
3. Edit the origin post and remove one tag - but leaving others. save it
4. Confirm the tag is properly removed from the distributed post
5. Back to the origin post, remove all tags and save
6. Confirm all tags are removed from the distributed post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
