### PR TITLE
fix(sync): cast role to array for backwards compatibility

### DIFF
--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -80,7 +80,7 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 
 		// Update user role if changed.
 		$user_current_roles = $user->roles;
-		$user_new_roles     = $data->role ?? [];
+		$user_new_roles     = (array) ( $data->role ?? [] );
 		$remove_roles       = array_diff( $user_current_roles, $user_new_roles );
 		$add_roles          = array_diff( $user_new_roles, $user_current_roles );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Casts `$data->role` to an array in `class-user-manually-synced.php` to maintain backwards compatibility with pre-#187 events in the event log.

[PR #187](https://github.com/Automattic/newspack-network/pull/187) changed the `role` field from a string to an array on the sending side (`class-user-manual-sync.php`), but the receiving side (`class-user-manually-synced.php`) wasn't made backwards-compatible with events already in the event log.

Nodes that haven't processed past the old-format events get permanently stuck, as `array_diff()` is erroring when it receives a string instead of an array. 

Since this error occurs right before `set_last_processed_id()` in `process_pulled_data()`, the last processed ID never advances, and the node re-pulls the same failing batch indefinitely.

You can see the mixed types in the `network_manual_sync_user` events here:

7218 "role":"subscriber" ← string (pre-#187)
36531 "role":"customer" ← string
...
122559 "role":["subscriber"] ← array (post-#187)
146730 "role":["contributor"] ← array


### How to test the changes in this Pull Request:

The (array) cast handles both the old string format and the new array format. With a string value like "subscriber", it becomes ["subscriber"]. With an array value like ["subscriber", "customer"], it passes through unchanged. Both cases produce a valid array for array_diff() 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

I'm not able to test this full loop locally, but I have tested that the (array) cast will work with both a string and an array.
