### PR TITLE
fix(sync): cast role to array for backwards compatibility

### DIFF
--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -80,7 +80,7 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 
 		// Update user role if changed.
 		$user_current_roles = $user->roles;
-		$user_new_roles     = $data->role ?? [];
+		$user_new_roles     = (array) ( $data->role ?? [] );
 		$remove_roles       = array_diff( $user_current_roles, $user_new_roles );
 		$add_roles          = array_diff( $user_new_roles, $user_current_roles );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hotfix for backwards compatibility with pre-#187 events.

PR #187 changed the role field from a string to an array when syncing users. However, some nodes still had older events in their queue where role is a string. The nodes that haven't processed past the old-format events have been stuck, as array_diff() is erroring when it receives a string instead of an array.

This fix casts $data->role to an array, handling both formats gracefully.

Closes #291.

### How to test the changes in this Pull Request:

This is difficult to test so I'll describe this small change a bit more. Please also see #291 and `NPPM-2565`

The (array) cast handles both the old string format and the new array format. With a string value like "subscriber", it becomes ["subscriber"]. With an array value like ["subscriber", "customer"], it passes through unchanged. Both cases produce a valid array for array_diff()

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

