### PR TITLE
fix(content-distribution): handle exceptions in incoming post filter

### DIFF
--- a/includes/content-distribution/blocks/class-image-block.php
+++ b/includes/content-distribution/blocks/class-image-block.php
@@ -36,8 +36,12 @@ class Image_Block {
 	 */
 	public static function hook_incoming_post_filters( $post ) {
 		if ( Content_Distribution_Class::is_post_incoming( $post ) ) {
-			$incoming_post = new Incoming_Post( $post->ID );
-			self::$post_payload = $incoming_post->get_post_payload();
+			try {
+				$incoming_post = new Incoming_Post( $post->ID );
+				self::$post_payload = $incoming_post->get_post_payload();
+			} catch ( \InvalidArgumentException $e ) {
+				return;
+			}
 
 			add_filter( 'render_block_core/image', [ __CLASS__, 'render_lightbox' ], 16, 2 ); // 16 is right after the core filter.
 			add_filter( 'the_content', [ __CLASS__, 'filter_content_image_attributes' ], PHP_INT_MAX );

--- a/includes/content-distribution/blocks/class-image-block.php
+++ b/includes/content-distribution/blocks/class-image-block.php
@@ -40,6 +40,10 @@ class Image_Block {
 				$incoming_post = new Incoming_Post( $post->ID );
 				self::$post_payload = $incoming_post->get_post_payload();
 			} catch ( \InvalidArgumentException $e ) {
+				// Treat an invalid incoming post as "not incoming": clear state and filters.
+				remove_filter( 'render_block_core/image', [ __CLASS__, 'render_lightbox' ], 16 );
+				remove_filter( 'the_content', [ __CLASS__, 'filter_content_image_attributes' ], PHP_INT_MAX );
+				self::$post_payload = null;
 				return;
 			}
 

--- a/includes/content-distribution/class-yoast-primary-cat.php
+++ b/includes/content-distribution/class-yoast-primary-cat.php
@@ -30,8 +30,8 @@ class Yoast_Primary_Cat {
 	/**
 	 * Filter the outgoing post meta.
 	 *
-	 * @param array   $meta The post meta.
-	 * @param WP_Post $post The post object.
+	 * @param array    $meta The post meta.
+	 * @param \WP_Post $post The post object.
 	 * @return array
 	 */
 	public static function filter_outgoing_post( $meta, $post ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`Incoming_Post` will throw an exception if the incoming post payload contains errors, which should be handled in the post filter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
