### PR TITLE
fix(content-distribution): keep node post in status_on_publish when hub schedules

### DIFF
--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -682,12 +682,15 @@ class Incoming_Post {
 			/**
 			 * Post status handling.
 			 *
-			 * If post is being published, use the incoming or stored
-			 * `status_on_publish` if available. If post is being scheduled
-			 * (future) and `status_on_publish` is a non-publish status, keep
-			 * the node post in that status. This prevents WP cron from
-			 * scheduling `publish_future_post` and auto-publishing the node
-			 * post. Otherwise, use the post status from the payload.
+			 * If post is being published, apply the stored `status_on_publish`
+			 * override if one exists. For new posts, use the incoming payload
+			 * value instead. If no override is configured, the post status is
+			 * left unchanged for existing posts and defaults to the incoming
+			 * status for new ones. If post is being scheduled (future) and
+			 * `status_on_publish` is a non-publish status, keep the node post
+			 * in that status. This prevents WP cron from scheduling
+			 * `publish_future_post` and auto-publishing the node post.
+			 * Otherwise, use the post status from the payload.
 			 */
 			if ( $post_data['post_status'] === 'publish' ) {
 				if ( $is_new_post ) {

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -691,7 +691,7 @@ class Incoming_Post {
 			 */
 			if ( $post_data['post_status'] === 'publish' ) {
 				if ( $is_new_post ) {
-					$postarr['post_status'] = $this->payload['status_on_publish'];
+					$postarr['post_status'] = isset( $this->payload['status_on_publish'] ) ? $this->payload['status_on_publish'] : '';
 				} else {
 					$status_on_publish = get_post_meta( $this->ID, self::STATUS_ON_PUBLISH_META, true );
 					if ( $status_on_publish ) {
@@ -700,10 +700,15 @@ class Incoming_Post {
 				}
 			} elseif ( $post_data['post_status'] === 'future' ) {
 				if ( $is_new_post ) {
-					$status_on_publish = $this->payload['status_on_publish'];
+					if ( isset( $this->payload['status_on_publish'] ) ) {
+						$status_on_publish = $this->payload['status_on_publish'];
+					} else {
+						$status_on_publish = '';
+					}
 				} else {
 					$status_on_publish = get_post_meta( $this->ID, self::STATUS_ON_PUBLISH_META, true );
 				}
+
 				if ( $status_on_publish && 'publish' !== $status_on_publish ) {
 					$postarr['post_status'] = $status_on_publish;
 				} else {

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -691,7 +691,7 @@ class Incoming_Post {
 			 */
 			if ( $post_data['post_status'] === 'publish' ) {
 				if ( $is_new_post ) {
-					$postarr['post_status'] = isset( $this->payload['status_on_publish'] ) ? $this->payload['status_on_publish'] : '';
+					$postarr['post_status'] = isset( $this->payload['status_on_publish'] ) ? $this->payload['status_on_publish'] : $post_data['post_status'];
 				} else {
 					$status_on_publish = get_post_meta( $this->ID, self::STATUS_ON_PUBLISH_META, true );
 					if ( $status_on_publish ) {
@@ -763,11 +763,16 @@ class Incoming_Post {
 			// Handle `status_on_publish` meta.
 			if ( $post_data['post_status'] !== 'publish' && $is_new_post ) {
 				// Store the publish status for new posts.
-				update_post_meta(
-					$post_id,
-					self::STATUS_ON_PUBLISH_META,
-					$this->payload['status_on_publish']
-				);
+				if ( isset( $this->payload['status_on_publish'] ) ) {
+					// Only store the meta if the key is present. An absent status_on_publish
+					// means no override was configured — the node will fall back to safe
+					// defaults when the hub later sends 'publish' or 'future'.
+					update_post_meta(
+						$post_id,
+						self::STATUS_ON_PUBLISH_META,
+						$this->payload['status_on_publish']
+					);
+				}
 			} elseif ( $post_data['post_status'] === 'publish' && ! $is_new_post ) {
 				// Clean up the meta for published posts so it's not re-published after
 				// being unpublished.

--- a/includes/content-distribution/class-incoming-post.php
+++ b/includes/content-distribution/class-incoming-post.php
@@ -683,8 +683,11 @@ class Incoming_Post {
 			 * Post status handling.
 			 *
 			 * If post is being published, use the incoming or stored
-			 * `status_on_publish` if available. Otherwise, use the post status from
-			 * the payload.
+			 * `status_on_publish` if available. If post is being scheduled
+			 * (future) and `status_on_publish` is a non-publish status, keep
+			 * the node post in that status. This prevents WP cron from
+			 * scheduling `publish_future_post` and auto-publishing the node
+			 * post. Otherwise, use the post status from the payload.
 			 */
 			if ( $post_data['post_status'] === 'publish' ) {
 				if ( $is_new_post ) {
@@ -694,6 +697,18 @@ class Incoming_Post {
 					if ( $status_on_publish ) {
 						$postarr['post_status'] = $status_on_publish;
 					}
+				}
+			} elseif ( $post_data['post_status'] === 'future' ) {
+				if ( $is_new_post ) {
+					$status_on_publish = $this->payload['status_on_publish'];
+				} else {
+					$status_on_publish = get_post_meta( $this->ID, self::STATUS_ON_PUBLISH_META, true );
+				}
+				if ( $status_on_publish && 'publish' !== $status_on_publish ) {
+					$postarr['post_status'] = $status_on_publish;
+				} else {
+					// If status_on_publish is 'publish' or unset, mirror the hub's schedule.
+					$postarr['post_status'] = 'future';
 				}
 			} else {
 				$postarr['post_status'] = $post_data['post_status'];

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -588,7 +588,7 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	 * node when status_on_publish is absent from the payload.
 	 *
 	 * The sample payload includes status_on_publish by default, so it is
-	 * explicitly unset here to simulate a payload that omits the key. 
+	 * explicitly unset here to simulate a payload that omits the key.
 	 * The node should fall back to mirroring the hub's future status.
 	 */
 	public function test_future_status_with_unset_status_on_publish() {

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -525,6 +525,65 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a scheduled (future) hub post does not auto-publish on the node
+	 * when status_on_publish is set to a non-publish status.
+	 *
+	 * Regression test for: hub distributes a draft, then schedules it shortly
+	 * after. The scheduling sync sends post_status='future' to the node. If the
+	 * node applies that status directly, WordPress cron will find a future-status
+	 * post and auto-publish it via wp_publish_post(), bypassing the
+	 * status_on_publish setting entirely.
+	 *
+	 * The node should keep the post in the status_on_publish state, such as draft,
+	 * so that WP cron never has a chance to publish it.
+	 */
+	public function test_future_status_with_non_publish_status_on_publish() {
+		$payload = $this->get_sample_payload();
+
+		// Simulate Event 1: hub distributes the post as a draft.
+		// status_on_publish='draft' means the node should never auto-publish.
+		$payload['post_data']['post_status'] = 'draft';
+		$payload['status_on_publish']        = 'draft';
+
+		$post_id = $this->incoming_post->insert( $payload );
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+
+		// Simulate Event 2: hub schedules the post, syncing post_status='future'.
+		// The node must not apply 'future', as a future-status post with a past date
+		// is auto-published by WP cron, bypassing status_on_publish entirely.
+		$payload['post_data']['post_status'] = 'future';
+		$this->incoming_post->insert( $payload );
+
+		$this->assertSame( 'draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Test that a scheduled (future) hub post mirrors the future status on the
+	 * node when status_on_publish is 'publish'.
+	 *
+	 * When a publisher wants the node to publish in sync with the hub, the node
+	 * should mirror the 'future' status so that WP cron fires on both sites at
+	 * the same scheduled time.
+	 */
+	public function test_future_status_with_publish_status_on_publish() {
+		$payload = $this->get_sample_payload();
+
+		$payload['post_data']['post_status'] = 'draft';
+		$payload['status_on_publish']        = 'publish';
+
+		$post_id = $this->incoming_post->insert( $payload );
+
+		// Hub schedules the post. date_gmt must be in the future or WordPress
+		// will immediately publish the post rather than storing it as 'future'.
+		$payload['post_data']['post_status'] = 'future';
+		$payload['post_data']['date_gmt']    = gmdate( 'Y-m-d H:i:s', strtotime( '+1 week' ) );
+		$this->incoming_post->insert( $payload );
+
+		// Node should mirror the hub's scheduled status so both publish together.
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+	}
+
+	/**
 	 * Test that "status on publish" only applies once.
 	 */
 	public function test_status_on_publish_only_applies_once() {

--- a/tests/unit-tests/content-distribution/test-incoming-post.php
+++ b/tests/unit-tests/content-distribution/test-incoming-post.php
@@ -584,6 +584,33 @@ class TestIncomingPost extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a scheduled (future) hub post mirrors the future status on the
+	 * node when status_on_publish is absent from the payload.
+	 *
+	 * The sample payload includes status_on_publish by default, so it is
+	 * explicitly unset here to simulate a payload that omits the key. 
+	 * The node should fall back to mirroring the hub's future status.
+	 */
+	public function test_future_status_with_unset_status_on_publish() {
+		$payload = $this->get_sample_payload();
+
+		// Remove status_on_publish to simulate a payload that omits the key.
+		unset( $payload['status_on_publish'] );
+
+		$payload['post_data']['post_status'] = 'draft';
+		$post_id                             = $this->incoming_post->insert( $payload );
+
+		// Hub schedules the post. date_gmt must be in the future or WordPress
+		// will immediately publish the post rather than storing it as 'future'.
+		$payload['post_data']['post_status'] = 'future';
+		$payload['post_data']['date_gmt']    = gmdate( 'Y-m-d H:i:s', strtotime( '+1 week' ) );
+		$this->incoming_post->insert( $payload );
+
+		// With no status_on_publish set, the node should mirror the hub's schedule.
+		$this->assertSame( 'future', get_post_status( $post_id ) );
+	}
+
+	/**
 	 * Test that "status on publish" only applies once.
 	 */
 	public function test_status_on_publish_only_applies_once() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a post is distributed to a node as a draft and the hub later schedules it, the node was auto-publishing the post regardless of the `status_on_publish` setting.

The root cause: `post_status = 'future'` fell through to the `else` branch in `Incoming_Post::insert()`, bypassing the `status_on_publish` check.

Once a node post has a `future` status, WordPress schedules the `publish_future_post` cron event, which then calls `wp_publish_post()` directly. This bypasses `class-incoming-post.php` and the `status_on_publish` logic.

This change adds a `future` branch that checks `status_on_publish` before applying the status.

If `status_on_publish` is a non-publish value (e.g. `draft`, `pending`), the node post stays in that status and the WP cron never schedules publication.

If `status_on_publish` is `publish` or unset, the node mirrors the hub's `future` status so both sites publish on the same schedule.

| Hub sends | `status_on_publish` | Node result |
|-----------|---------------------|-------------|
| `future`  | `draft`             | `draft` <-- fixes the bug |
| `future`  | `pending`           | `pending`   |
| `future`  | `publish`           | `future` (mirrors hub schedule) |
| `publish` | any                 | unchanged (existing behaviour) |

Closes `NPPM-2656`

**Note:** Following Copilot's reviews, I added some defensive guards for missing status_on_publish key across three access points in insert() (status handling, meta storage), plus an additional test covering this unset payload scenario. 


### How to test the changes in this Pull Request:

**Before applying this PR:**

1. On the hub, create a new post with an easy-to-identify headline. Save it as a **Draft** and distribute it to a node.
2. On the node, go to **All Posts** (`/wp-admin/edit.php?post_type=post`) and wait ~2 minutes for the post to arrive. It will show as **Draft** as expected.
3. On the hub, modify the headline slightly for easy identification, then schedule it for tomorrow.
4. On the node, wait ~2 minutes for the update to pull. The post will be **Published** <-- this is the bug.

**After applying this PR:**

1. On the hub, create a second new post with an easy-to-identify headline. Save it as a **Draft** and distribute it to a node.
2. On the node, go to **All Posts** and wait ~2 minutes. It will show as **Draft** as expected.
3. On the hub, modify the headline slightly, then schedule it for tomorrow.
4. On the node, wait ~2 minutes. The post will remain **Draft** <-- the bug is fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?