### PR TITLE
feat(content-gate): network product and access control

### DIFF
--- a/includes/class-accepted-actions.php
+++ b/includes/class-accepted-actions.php
@@ -45,6 +45,7 @@ class Accepted_Actions {
 		'network_incoming_post_deleted'            => 'Network_Incoming_Post_Deleted',
 		'newspack_network_distributor_migrate_incoming_posts' => 'Distributor_Migrate_Incoming_Posts',
 		'network_hub_name_updated'                 => 'Hub_Name_Updated',
+		'newspack_network_product_updated'         => 'Product_Updated',
 	];
 
 	/**
@@ -71,5 +72,6 @@ class Accepted_Actions {
 		'network_incoming_post_deleted',
 		'newspack_network_distributor_migrate_incoming_posts',
 		'network_hub_name_updated',
+		'newspack_network_product_updated',
 	];
 }

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -67,6 +67,7 @@ class Initializer {
 		Woocommerce_Memberships\Subscriptions_Integration::init();
 		Woocommerce_Memberships\Limit_Purchase::init();
 		Content_Gate\Access::init();
+		Content_Gate\Limit_Purchase::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -66,6 +66,7 @@ class Initializer {
 		Woocommerce_Memberships\Events::init();
 		Woocommerce_Memberships\Subscriptions_Integration::init();
 		Woocommerce_Memberships\Limit_Purchase::init();
+		Content_Gate\Access::init();
 
 		register_activation_hook( NEWSPACK_NETWORK_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
 	}

--- a/includes/class-initializer.php
+++ b/includes/class-initializer.php
@@ -60,6 +60,7 @@ class Initializer {
 		CLI\Integrity_Check::init();
 
 		Woocommerce\Events::init();
+		Woocommerce\Product_Admin::init();
 		Woocommerce_Subscriptions\My_Account::init();
 		Woocommerce_Memberships\Admin::init();
 		Woocommerce_Memberships\Events::init();

--- a/includes/cli/backfillers/class-product-updated.php
+++ b/includes/cli/backfillers/class-product-updated.php
@@ -33,6 +33,10 @@ class Product_Updated extends Abstract_Backfiller {
 	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
 	 */
 	public function get_events() {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return [];
+		}
+
 		$products = get_posts(
 			[
 				'post_type'   => 'product',

--- a/includes/cli/backfillers/class-product-updated.php
+++ b/includes/cli/backfillers/class-product-updated.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Data Backfiller for product_updated events.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Backfillers;
+
+use Newspack_Network\Woocommerce\Product_Admin;
+use Newspack_Network\Woocommerce\Events as Woocommerce_Events;
+use WP_CLI;
+
+/**
+ * Backfiller class.
+ */
+class Product_Updated extends Abstract_Backfiller {
+
+	/**
+	 * Gets the output line about the processed item being processed in verbose mode.
+	 *
+	 * @param \Newspack_Network\Incoming_Events\Abstract_Incoming_Event $event The event.
+	 *
+	 * @return string
+	 */
+	protected function get_processed_item_output( $event ) {
+		return sprintf( 'Product #%d', $event->get_id() );
+	}
+
+	/**
+	 * Gets the events to be processed.
+	 *
+	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 */
+	public function get_events() {
+		$products = get_posts(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => Product_Admin::NETWORK_ID_META_KEY,
+						'compare' => '!=',
+						'value'   => '',
+					],
+				],
+				'date_query'  => [
+					'column'    => 'post_modified_gmt',
+					'after'     => $this->start,
+					'before'    => $this->end,
+					'inclusive' => true,
+				],
+			]
+		);
+
+		$this->maybe_initialize_progress_bar( 'Processing products', count( $products ) );
+
+		$events = [];
+		WP_CLI::line( '' );
+		WP_CLI::line( sprintf( 'Found %s product(s) with Network IDs eligible for sync.', count( $products ) ) );
+		WP_CLI::line( '' );
+
+		foreach ( $products as $product ) {
+			$product_data = Woocommerce_Events::product_updated( $product->ID );
+			if ( ! $product_data ) {
+				continue;
+			}
+			$timestamp = strtotime( $product->post_modified_gmt );
+			$events[]  = new \Newspack_Network\Incoming_Events\Product_Updated( get_bloginfo( 'url' ), $product_data, $timestamp );
+		}
+
+		return $events;
+	}
+}

--- a/includes/content-gate/class-access.php
+++ b/includes/content-gate/class-access.php
@@ -90,7 +90,7 @@ class Access {
 	public static function get_network_ids_for_products( $product_ids ) {
 		$network_ids = [];
 		foreach ( $product_ids as $product_id ) {
-			$network_id = get_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, true );
+			$network_id = Product_Admin::get_network_id( $product_id );
 			if ( ! empty( $network_id ) ) {
 				$network_ids[] = $network_id;
 			}

--- a/includes/content-gate/class-access.php
+++ b/includes/content-gate/class-access.php
@@ -67,7 +67,7 @@ class Access {
 			$site_products = $network_products[ $site ] ?? [];
 			foreach ( $subscriptions as $subscription ) {
 				foreach ( $subscription['products'] as $product ) {
-					$product_id        = $product['id'];
+					$product_id = $product['id'];
 					// Look up this product's Network ID from synced data.
 					$remote_network_id = $site_products[ $product_id ]['network_id'] ?? '';
 					if ( ! empty( $remote_network_id ) && in_array( $remote_network_id, $network_ids, true ) ) {
@@ -116,7 +116,7 @@ class Access {
 			$site_products = $network_products[ $site ] ?? [];
 			foreach ( $subscriptions as $subscription ) {
 				foreach ( $subscription['products'] as $product ) {
-					$product_id        = $product['id'];
+					$product_id = $product['id'];
 					$remote_network_id = $site_products[ $product_id ]['network_id'] ?? '';
 					if ( ! empty( $remote_network_id ) && $remote_network_id === $network_id ) {
 						return [

--- a/includes/content-gate/class-access.php
+++ b/includes/content-gate/class-access.php
@@ -67,7 +67,8 @@ class Access {
 			$site_products = $network_products[ $site ] ?? [];
 			foreach ( $subscriptions as $subscription ) {
 				foreach ( $subscription['products'] as $product ) {
-					$product_id = $product['id'];
+					// Cast to string to handle int/string key mismatch from JSON round-tripping.
+					$product_id = (string) $product['id'];
 					// Look up this product's Network ID from synced data.
 					$remote_network_id = $site_products[ $product_id ]['network_id'] ?? '';
 					if ( ! empty( $remote_network_id ) && in_array( $remote_network_id, $network_ids, true ) ) {
@@ -116,7 +117,8 @@ class Access {
 			$site_products = $network_products[ $site ] ?? [];
 			foreach ( $subscriptions as $subscription ) {
 				foreach ( $subscription['products'] as $product ) {
-					$product_id = $product['id'];
+					// Cast to string to handle int/string key mismatch from JSON round-tripping.
+					$product_id = (string) $product['id'];
 					$remote_network_id = $site_products[ $product_id ]['network_id'] ?? '';
 					if ( ! empty( $remote_network_id ) && $remote_network_id === $network_id ) {
 						return [

--- a/includes/content-gate/class-access.php
+++ b/includes/content-gate/class-access.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Newspack Network Content Gate Access integration.
+ *
+ * Hooks into newspack-plugin's access rules to grant access
+ * when a user has an active subscription on another network site
+ * for a product with a matching Network ID.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Content_Gate;
+
+use Newspack_Network\Incoming_Events\Subscription_Changed;
+use Newspack_Network\Incoming_Events\Product_Updated;
+use Newspack_Network\Woocommerce\Product_Admin;
+
+/**
+ * Class to handle network-aware content gate access.
+ */
+class Access {
+
+	/**
+	 * Initializer.
+	 */
+	public static function init() {
+		add_filter( 'newspack_access_rules_has_active_subscription', [ __CLASS__, 'check_network_subscriptions' ], 10, 3 );
+	}
+
+	/**
+	 * Check if the user has an active subscription on another network site
+	 * for a product with a matching Network ID.
+	 *
+	 * @param bool  $has_subscription Whether the user already has an active subscription (from local checks).
+	 * @param int   $user_id          User ID.
+	 * @param array $product_ids      Required product IDs (local).
+	 * @return bool
+	 */
+	public static function check_network_subscriptions( $has_subscription, $user_id, $product_ids ) {
+		// If local check already passed, no need to check network.
+		if ( $has_subscription ) {
+			return true;
+		}
+
+		// If no products specified, we can't match by Network ID.
+		if ( empty( $product_ids ) ) {
+			return $has_subscription;
+		}
+
+		// Get Network IDs for the required local products.
+		$network_ids = self::get_network_ids_for_products( $product_ids );
+		if ( empty( $network_ids ) ) {
+			return $has_subscription;
+		}
+
+		// Get user's network subscriptions.
+		$network_subscriptions = self::get_user_network_active_subscriptions( $user_id );
+		if ( empty( $network_subscriptions ) ) {
+			return $has_subscription;
+		}
+
+		// Get synced product data from all network sites.
+		$network_products = get_option( Product_Updated::OPTION_NAME, [] );
+
+		// Check if any network subscription has a product with a matching Network ID.
+		foreach ( $network_subscriptions as $site => $subscriptions ) {
+			$site_products = $network_products[ $site ] ?? [];
+			foreach ( $subscriptions as $subscription ) {
+				foreach ( $subscription['products'] as $product ) {
+					$product_id        = $product['id'];
+					// Look up this product's Network ID from synced data.
+					$remote_network_id = $site_products[ $product_id ]['network_id'] ?? '';
+					if ( ! empty( $remote_network_id ) && in_array( $remote_network_id, $network_ids, true ) ) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return $has_subscription;
+	}
+
+	/**
+	 * Get Network IDs for the given local product IDs.
+	 *
+	 * @param array $product_ids Local product IDs.
+	 * @return array Array of Network IDs (non-empty values only).
+	 */
+	public static function get_network_ids_for_products( $product_ids ) {
+		$network_ids = [];
+		foreach ( $product_ids as $product_id ) {
+			$network_id = get_post_meta( $product_id, Product_Admin::NETWORK_ID_META_KEY, true );
+			if ( ! empty( $network_id ) ) {
+				$network_ids[] = $network_id;
+			}
+		}
+		return array_unique( $network_ids );
+	}
+
+	/**
+	 * Check if a user has an active network subscription for a given Network ID.
+	 *
+	 * @param int    $user_id    The user ID.
+	 * @param string $network_id The product Network ID to match.
+	 * @return array|false Array with 'site' and 'subscription' keys if found, false otherwise.
+	 */
+	public static function user_has_active_network_subscription_for_network_id( $user_id, $network_id ) {
+		$network_subscriptions = self::get_user_network_active_subscriptions( $user_id );
+		if ( empty( $network_subscriptions ) ) {
+			return false;
+		}
+
+		$network_products = get_option( Product_Updated::OPTION_NAME, [] );
+
+		foreach ( $network_subscriptions as $site => $subscriptions ) {
+			$site_products = $network_products[ $site ] ?? [];
+			foreach ( $subscriptions as $subscription ) {
+				foreach ( $subscription['products'] as $product ) {
+					$product_id        = $product['id'];
+					$remote_network_id = $site_products[ $product_id ]['network_id'] ?? '';
+					if ( ! empty( $remote_network_id ) && $remote_network_id === $network_id ) {
+						return [
+							'site'         => $site,
+							'subscription' => $subscription,
+						];
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Gets all active subscriptions for a user across all network sites.
+	 *
+	 * @param int $user_id The user ID.
+	 * @return array An array with the site as key and an array of subscriptions as value.
+	 */
+	public static function get_user_network_active_subscriptions( $user_id ) {
+		$meta = get_user_meta( $user_id, Subscription_Changed::USER_SUBSCRIPTIONS_META_KEY, true );
+		if ( ! $meta ) {
+			return [];
+		}
+
+		$returned_subs = [];
+
+		foreach ( $meta as $site => $subscriptions ) {
+			$returned_subs[ $site ] = array_filter(
+				$subscriptions,
+				function ( $sub ) {
+					return in_array( $sub['status'], [ 'active', 'pending-cancel' ], true );
+				}
+			);
+			if ( empty( $returned_subs[ $site ] ) ) {
+				unset( $returned_subs[ $site ] );
+			}
+		}
+
+		return $returned_subs;
+	}
+}

--- a/includes/content-gate/class-limit-purchase.php
+++ b/includes/content-gate/class-limit-purchase.php
@@ -70,7 +70,7 @@ class Limit_Purchase {
 			return;
 		}
 
-		$network_id = get_post_meta( $product->get_id(), Product_Admin::NETWORK_ID_META_KEY, true );
+		$network_id = Product_Admin::get_network_id( $product->get_id() );
 		if ( empty( $network_id ) ) {
 			return;
 		}

--- a/includes/content-gate/class-limit-purchase.php
+++ b/includes/content-gate/class-limit-purchase.php
@@ -65,6 +65,11 @@ class Limit_Purchase {
 			return;
 		}
 
+		// Only restrict subscription products.
+		if ( ! $product->is_type( [ 'subscription', 'subscription_variation', 'variable-subscription' ] ) ) {
+			return;
+		}
+
 		$network_id = get_post_meta( $product->get_id(), Product_Admin::NETWORK_ID_META_KEY, true );
 		if ( empty( $network_id ) ) {
 			return;

--- a/includes/content-gate/class-limit-purchase.php
+++ b/includes/content-gate/class-limit-purchase.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Newspack Network purchase limiter for Content Gate subscription products.
+ *
+ * Prevents users from purchasing a subscription product when they already
+ * have an active subscription to a product with the same Network ID on
+ * another site in the network.
+ *
+ * This is the Content Gate equivalent of Woocommerce_Memberships\Limit_Purchase,
+ * which works through membership plans. This class works directly with product
+ * Network IDs.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Content_Gate;
+
+use Newspack_Network\Woocommerce\Product_Admin;
+
+/**
+ * Handles limiting WooCommerce Subscriptions purchases by product Network ID.
+ */
+class Limit_Purchase {
+
+	/**
+	 * Initializer.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_subscription_is_purchasable', [ __CLASS__, 'restrict_network_subscriptions' ], 10, 2 );
+		add_filter( 'woocommerce_cart_product_cannot_be_purchased_message', [ __CLASS__, 'cart_product_cannot_be_purchased_message' ], 10, 2 );
+		add_action( 'woocommerce_after_checkout_validation', [ __CLASS__, 'validate_network_subscription' ], 10, 2 );
+	}
+
+	/**
+	 * Restricts subscription purchasing if the user already has an equivalent network subscription.
+	 *
+	 * @param bool        $purchasable Whether the subscription product is purchasable.
+	 * @param \WC_Product $subscription_product The subscription product.
+	 * @return bool
+	 */
+	public static function restrict_network_subscriptions( $purchasable, $subscription_product ) {
+		if ( ! is_user_logged_in() ) {
+			return $purchasable;
+		}
+		return self::get_network_equivalent_subscription( $subscription_product ) ? false : $purchasable;
+	}
+
+	/**
+	 * Given a product, check if the current user has an active subscription on another
+	 * network site for a product with the same Network ID.
+	 *
+	 * @param \WC_Product $product Product data.
+	 * @param int|null    $user_id User ID, defaults to the current user.
+	 * @return array|void Array with 'site' and 'subscription' keys if found, void otherwise.
+	 */
+	private static function get_network_equivalent_subscription( \WC_Product $product, $user_id = null ) {
+		if ( is_null( $user_id ) ) {
+			$user_id = self::get_user_id_from_email();
+			if ( ! $user_id ) {
+				$user_id = get_current_user_id();
+			}
+		}
+
+		if ( ! $user_id ) {
+			return;
+		}
+
+		$network_id = get_post_meta( $product->get_id(), Product_Admin::NETWORK_ID_META_KEY, true );
+		if ( empty( $network_id ) ) {
+			return;
+		}
+
+		return Access::user_has_active_network_subscription_for_network_id( $user_id, $network_id );
+	}
+
+	/**
+	 * Filters the error message shown when a product can't be added to the cart.
+	 *
+	 * @param string      $message Message.
+	 * @param \WC_Product $product_data Product data.
+	 * @return string
+	 */
+	public static function cart_product_cannot_be_purchased_message( $message, \WC_Product $product_data ) {
+		$network_subscription = self::get_network_equivalent_subscription( $product_data );
+		if ( $network_subscription ) {
+			$message = sprintf(
+				/* translators: %s: Site URL */
+				__( "You can't buy this subscription because you already have it active on %s", 'newspack-network' ),
+				$network_subscription['site']
+			);
+		}
+		return $message;
+	}
+
+	/**
+	 * Get user from email.
+	 *
+	 * @return false|int User ID if found by email address, false otherwise.
+	 */
+	private static function get_user_id_from_email() {
+		$billing_email = filter_input( INPUT_POST, 'billing_email', FILTER_SANITIZE_EMAIL );
+		if ( $billing_email ) {
+			$customer = \get_user_by( 'email', $billing_email );
+			if ( $customer ) {
+				return $customer->ID;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Validate network subscription for logged out readers.
+	 *
+	 * @param array     $data   Checkout data.
+	 * @param \WP_Error $errors Checkout errors.
+	 */
+	public static function validate_network_subscription( $data, $errors ) {
+		if ( is_user_logged_in() || ! function_exists( 'WC' ) ) {
+			return;
+		}
+		$id_from_email = self::get_user_id_from_email();
+		if ( $id_from_email ) {
+			$cart_items = WC()->cart->get_cart();
+			foreach ( $cart_items as $cart_item ) {
+				$product                     = $cart_item['data'];
+				$network_active_subscription = self::get_network_equivalent_subscription( $product, $id_from_email );
+				if ( $network_active_subscription ) {
+					$error_message = __( 'Oops! You already have a subscription on another site in this network that grants you access to this site as well. Please log in using the same email address.', 'newspack-network' );
+					$errors->add( 'network_subscription', $error_message );
+				}
+			}
+		}
+	}
+}

--- a/includes/content-gate/class-limit-purchase.php
+++ b/includes/content-gate/class-limit-purchase.php
@@ -127,6 +127,7 @@ class Limit_Purchase {
 				if ( $network_active_subscription ) {
 					$error_message = __( 'Oops! You already have a subscription on another site in this network that grants you access to this site as well. Please log in using the same email address.', 'newspack-network' );
 					$errors->add( 'network_subscription', $error_message );
+					break;
 				}
 			}
 		}

--- a/includes/hub/stores/event-log-items/class-product-updated.php
+++ b/includes/hub/stores/event-log-items/class-product-updated.php
@@ -26,7 +26,7 @@ class Product_Updated extends Abstract_Event_Log_Item {
 			/* translators: 1: Product name 2: Network ID 3: site url */
 			__( 'Product "%1$s" (Network ID: %2$s) updated on %3$s', 'newspack-network' ),
 			$data->name ?? __( 'Unknown', 'newspack-network' ),
-			$data->network_id ?? __( 'none', 'newspack-network' ),
+			empty( $data->network_id ) ? __( 'none', 'newspack-network' ) : $data->network_id,
 			$url
 		);
 	}

--- a/includes/hub/stores/event-log-items/class-product-updated.php
+++ b/includes/hub/stores/event-log-items/class-product-updated.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Newspack Hub Product Updated Event Log Item
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Hub\Stores\Event_Log_Items;
+
+use Newspack_Network\Hub\Stores\Abstract_Event_Log_Item;
+
+/**
+ * Class to handle the Product Updated Event Log Item
+ */
+class Product_Updated extends Abstract_Event_Log_Item {
+
+	/**
+	 * Gets a summary for this event.
+	 *
+	 * @return string
+	 */
+	public function get_summary() {
+		$url  = empty( $this->get_node_id() ) ? get_bloginfo( 'url' ) : $this->get_node_url();
+		$data = $this->get_data();
+		return sprintf(
+			/* translators: 1: Product name 2: Network ID 3: site url */
+			__( 'Product "%1$s" (Network ID: %2$s) updated on %3$s', 'newspack-network' ),
+			$data->name ?? __( 'Unknown', 'newspack-network' ),
+			$data->network_id ?? __( 'none', 'newspack-network' ),
+			$url
+		);
+	}
+}

--- a/includes/incoming-events/class-product-updated.php
+++ b/includes/incoming-events/class-product-updated.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Newspack Hub Product Updated Incoming Event class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Incoming_Events;
+
+use Newspack_Network\Debugger;
+
+/**
+ * Class to handle the Product Updated Incoming Event
+ */
+class Product_Updated extends Abstract_Incoming_Event {
+
+	const OPTION_NAME = 'newspack_network_products';
+
+	/**
+	 * Processes the event in Hub.
+	 *
+	 * @return void
+	 */
+	public function post_process_in_hub() {
+		$this->update_option();
+	}
+
+	/**
+	 * Process event in Node.
+	 *
+	 * @return void
+	 */
+	public function process_in_node() {
+		$this->update_option();
+	}
+
+	/**
+	 * Updates the option with the product data.
+	 *
+	 * @return void
+	 */
+	public function update_option() {
+		Debugger::log( 'Processing product_updated' );
+
+		$current_value = get_option( self::OPTION_NAME, [] );
+
+		if ( ! is_array( $current_value ) ) {
+			$current_value = [];
+		}
+
+		if ( ! isset( $current_value[ $this->get_site() ] ) ) {
+			$current_value[ $this->get_site() ] = [];
+		}
+
+		$current_value[ $this->get_site() ][ $this->get_id() ] = [
+			'id'         => $this->get_id(),
+			'name'       => $this->get_name(),
+			'slug'       => $this->get_slug(),
+			'network_id' => $this->get_network_id(),
+		];
+
+		update_option( self::OPTION_NAME, $current_value );
+	}
+
+	/**
+	 * Returns the id property.
+	 *
+	 * @return ?int
+	 */
+	public function get_id() {
+		return $this->data->id ?? null;
+	}
+
+	/**
+	 * Returns the name property.
+	 *
+	 * @return ?string
+	 */
+	public function get_name() {
+		return $this->data->name ?? null;
+	}
+
+	/**
+	 * Returns the slug property.
+	 *
+	 * @return ?string
+	 */
+	public function get_slug() {
+		return $this->data->slug ?? null;
+	}
+
+	/**
+	 * Returns the network_id property.
+	 *
+	 * @return ?string
+	 */
+	public function get_network_id() {
+		return $this->data->network_id ?? null;
+	}
+}

--- a/includes/incoming-events/class-product-updated.php
+++ b/includes/incoming-events/class-product-updated.php
@@ -59,6 +59,15 @@ class Product_Updated extends Abstract_Incoming_Event {
 			'network_id' => $this->get_network_id(),
 		];
 
+		// Also store entries for variations so that variation IDs resolve to the parent's Network ID.
+		$variation_ids = $this->get_variation_ids();
+		foreach ( $variation_ids as $variation_id ) {
+			$current_value[ $this->get_site() ][ $variation_id ] = [
+				'id'         => $variation_id,
+				'network_id' => $this->get_network_id(),
+			];
+		}
+
 		update_option( self::OPTION_NAME, $current_value, false );
 	}
 
@@ -96,5 +105,14 @@ class Product_Updated extends Abstract_Incoming_Event {
 	 */
 	public function get_network_id() {
 		return $this->data->network_id ?? null;
+	}
+
+	/**
+	 * Returns the variation IDs.
+	 *
+	 * @return array
+	 */
+	public function get_variation_ids() {
+		return $this->data->variation_ids ?? [];
 	}
 }

--- a/includes/incoming-events/class-product-updated.php
+++ b/includes/incoming-events/class-product-updated.php
@@ -59,7 +59,7 @@ class Product_Updated extends Abstract_Incoming_Event {
 			'network_id' => $this->get_network_id(),
 		];
 
-		update_option( self::OPTION_NAME, $current_value );
+		update_option( self::OPTION_NAME, $current_value, false );
 	}
 
 	/**

--- a/includes/incoming-events/class-product-updated.php
+++ b/includes/incoming-events/class-product-updated.php
@@ -21,7 +21,7 @@ class Product_Updated extends Abstract_Incoming_Event {
 	 *
 	 * @return void
 	 */
-	public function post_process_in_hub() {
+	public function always_process_in_hub() {
 		$this->update_option();
 	}
 

--- a/includes/woocommerce/class-events.php
+++ b/includes/woocommerce/class-events.php
@@ -64,7 +64,7 @@ class Events {
 		];
 
 		// Include variation IDs so they are also mapped to this Network ID.
-		if ( $product->is_type( 'variable-subscription' ) && ! empty( $network_id ) ) {
+		if ( $product->is_type( 'variable-subscription' ) ) {
 			$result['variation_ids'] = $product->get_children();
 		}
 

--- a/includes/woocommerce/class-events.php
+++ b/includes/woocommerce/class-events.php
@@ -58,12 +58,21 @@ class Events {
 		if ( ! $product ) {
 			return;
 		}
-		return [
+		$network_id = get_post_meta( $product->get_id(), Product_Admin::NETWORK_ID_META_KEY, true );
+
+		$result = [
 			'id'         => $product->get_id(),
-			'network_id' => get_post_meta( $product->get_id(), Product_Admin::NETWORK_ID_META_KEY, true ),
+			'network_id' => $network_id,
 			'name'       => $product->get_name(),
 			'slug'       => $product->get_slug(),
 		];
+
+		// Include variation IDs so they are also mapped to this Network ID.
+		if ( $product->is_type( 'variable-subscription' ) && ! empty( $network_id ) ) {
+			$result['variation_ids'] = $product->get_children();
+		}
+
+		return $result;
 	}
 
 	/**
@@ -132,11 +141,16 @@ class Events {
 		$items = $item->get_items();
 		foreach ( $items as $item ) {
 			$product = $item->get_product();
-			$result['products'][ $product->get_id() ] = [
+			$product_data = [
 				'id'   => $product->get_id(),
 				'name' => $product->get_name(),
 				'slug' => $product->get_slug(),
 			];
+			// Include parent ID for variations so network matching can resolve the parent product.
+			if ( $product->get_parent_id() ) {
+				$product_data['parent_id'] = $product->get_parent_id();
+			}
+			$result['products'][ $product->get_id() ] = $product_data;
 		}
 
 		return $result;

--- a/includes/woocommerce/class-events.php
+++ b/includes/woocommerce/class-events.php
@@ -37,11 +37,7 @@ class Events {
 
 		Data_Events::register_listener( 'woocommerce_order_status_changed', 'newspack_node_order_changed', [ __CLASS__, 'item_changed' ] );
 		Data_Events::register_listener( 'woocommerce_subscription_status_changed', 'newspack_node_subscription_changed', [ __CLASS__, 'subscription_changed' ] );
-		Data_Events::register_listener(
-			'newspack_network_save_product',
-			'newspack_network_product_updated',
-			[ __CLASS__, 'product_updated' ]
-		);
+		Data_Events::register_listener( 'newspack_network_save_product', 'newspack_network_product_updated', [ __CLASS__, 'product_updated' ] );
 	}
 
 	/**
@@ -141,16 +137,11 @@ class Events {
 		$items = $item->get_items();
 		foreach ( $items as $item ) {
 			$product = $item->get_product();
-			$product_data = [
+			$result['products'][ $product->get_id() ] = [
 				'id'   => $product->get_id(),
 				'name' => $product->get_name(),
 				'slug' => $product->get_slug(),
 			];
-			// Include parent ID for variations so network matching can resolve the parent product.
-			if ( $product->get_parent_id() ) {
-				$product_data['parent_id'] = $product->get_parent_id();
-			}
-			$result['products'][ $product->get_id() ] = $product_data;
 		}
 
 		return $result;

--- a/includes/woocommerce/class-events.php
+++ b/includes/woocommerce/class-events.php
@@ -51,6 +51,9 @@ class Events {
 	 * @return array|void
 	 */
 	public static function product_updated( $product_id ) {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return;
+		}
 		$product = wc_get_product( $product_id );
 		if ( ! $product ) {
 			return;

--- a/includes/woocommerce/class-events.php
+++ b/includes/woocommerce/class-events.php
@@ -9,6 +9,7 @@ namespace Newspack_Network\Woocommerce;
 
 use Newspack\Data_Events;
 use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+use Newspack_Network\Woocommerce\Product_Admin;
 
 /**
  * Class to register additional listeners to the Newspack Data Events API
@@ -36,6 +37,30 @@ class Events {
 
 		Data_Events::register_listener( 'woocommerce_order_status_changed', 'newspack_node_order_changed', [ __CLASS__, 'item_changed' ] );
 		Data_Events::register_listener( 'woocommerce_subscription_status_changed', 'newspack_node_subscription_changed', [ __CLASS__, 'subscription_changed' ] );
+		Data_Events::register_listener(
+			'newspack_network_save_product',
+			'newspack_network_product_updated',
+			[ __CLASS__, 'product_updated' ]
+		);
+	}
+
+	/**
+	 * Triggers a data event when a product's Network ID is updated.
+	 *
+	 * @param int $product_id The product post ID.
+	 * @return array|void
+	 */
+	public static function product_updated( $product_id ) {
+		$product = wc_get_product( $product_id );
+		if ( ! $product ) {
+			return;
+		}
+		return [
+			'id'         => $product->get_id(),
+			'network_id' => get_post_meta( $product->get_id(), Product_Admin::NETWORK_ID_META_KEY, true ),
+			'name'       => $product->get_name(),
+			'slug'       => $product->get_slug(),
+		];
 	}
 
 	/**

--- a/includes/woocommerce/class-product-admin.php
+++ b/includes/woocommerce/class-product-admin.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Newspack Network Admin customizations for WooCommerce products.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Woocommerce;
+
+/**
+ * Handles admin tweaks for WooCommerce products.
+ *
+ * Adds a metabox to the product edit screen to allow the user to add a network id metadata.
+ */
+class Product_Admin {
+
+	/**
+	 * The network id meta key.
+	 *
+	 * @var string
+	 */
+	const NETWORK_ID_META_KEY = '_newspack_network_product_id';
+
+	/**
+	 * Initializer.
+	 */
+	public static function init() {
+		add_action( 'add_meta_boxes', [ __CLASS__, 'add_meta_box' ] );
+		add_action( 'save_post', [ __CLASS__, 'save_meta_box' ] );
+	}
+
+	/**
+	 * Adds a meta box to the product edit screen.
+	 */
+	public static function add_meta_box() {
+		add_meta_box(
+			'newspack-network-product-meta-box',
+			__( 'Newspack Network', 'newspack-network' ),
+			[ __CLASS__, 'render_meta_box' ],
+			'product',
+			'side'
+		);
+	}
+
+	/**
+	 * Renders the meta box.
+	 *
+	 * @param \WP_Post $post The post object.
+	 */
+	public static function render_meta_box( $post ) {
+		$network_id = get_post_meta( $post->ID, self::NETWORK_ID_META_KEY, true );
+		wp_nonce_field( 'newspack_network_save_product', 'newspack_network_save_product_nonce' );
+		?>
+		<label for="newspack-network-product-id"><?php esc_html_e( 'Network ID', 'newspack-network' ); ?></label>
+		<input type="text" id="newspack-network-product-id" name="newspack_network_product_id" value="<?php echo esc_attr( $network_id ); ?>" style="width:100%;" />
+		<p class="description"><?php esc_html_e( 'If set, this product will be linked to products with the same Network ID on other sites in the network. Users with an active subscription to any linked product will be granted access across all sites.', 'newspack-network' ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Saves the meta box.
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public static function save_meta_box( $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( 'product' !== $post->post_type ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['newspack_network_save_product_nonce'] ) ||
+			! wp_verify_nonce( sanitize_text_field( $_POST['newspack_network_save_product_nonce'] ), 'newspack_network_save_product' )
+		) {
+			return;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$network_id = sanitize_text_field( wp_unslash( $_POST['newspack_network_product_id'] ?? '' ) );
+		$network_id = self::unique_network_id( $network_id, $post_id );
+
+		update_post_meta( $post_id, self::NETWORK_ID_META_KEY, $network_id );
+
+		/**
+		 * Triggers an action when a product's network id is saved.
+		 *
+		 * @param int $post_id The product post ID.
+		 */
+		do_action( 'newspack_network_save_product', $post_id );
+	}
+
+	/**
+	 * Given a network id, makes it unique among all products.
+	 *
+	 * @param string $network_id The network id to make unique.
+	 * @param int    $post_id The post ID that is being saved.
+	 * @return string The unique network id.
+	 */
+	private static function unique_network_id( $network_id, $post_id ) {
+		if ( empty( $network_id ) ) {
+			return '';
+		}
+		global $wpdb;
+		$network_id = sanitize_text_field( $network_id );
+		$query      = $wpdb->prepare(
+			"SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = %s AND post_id != %d",
+			self::NETWORK_ID_META_KEY,
+			$post_id
+		);
+
+		$ids = $wpdb->get_col( $query ); // phpcs:ignore
+
+		$count               = 2;
+		$original_network_id = $network_id;
+
+		while ( in_array( $network_id, $ids, true ) ) {
+			$network_id = $original_network_id . '-' . $count;
+			$count++;
+		}
+
+		return $network_id;
+	}
+}

--- a/includes/woocommerce/class-product-admin.php
+++ b/includes/woocommerce/class-product-admin.php
@@ -26,13 +26,16 @@ class Product_Admin {
 	 */
 	public static function init() {
 		add_action( 'add_meta_boxes', [ __CLASS__, 'add_meta_box' ] );
-		add_action( 'save_post', [ __CLASS__, 'save_meta_box' ] );
+		add_action( 'save_post_product', [ __CLASS__, 'save_meta_box' ] );
 	}
 
 	/**
 	 * Adds a meta box to the product edit screen.
 	 */
 	public static function add_meta_box() {
+		if ( ! function_exists( 'wc_get_product' ) ) {
+			return;
+		}
 		global $post;
 		$product = wc_get_product( $post );
 		if ( ! $product || ! $product->is_type( [ 'subscription', 'variable-subscription' ] ) ) {
@@ -68,12 +71,6 @@ class Product_Admin {
 	 * @param int $post_id The post ID.
 	 */
 	public static function save_meta_box( $post_id ) {
-		$post = get_post( $post_id );
-
-		if ( 'product' !== $post->post_type ) {
-			return;
-		}
-
 		if ( ! isset( $_POST['newspack_network_save_product_nonce'] ) ||
 			! wp_verify_nonce( sanitize_text_field( $_POST['newspack_network_save_product_nonce'] ), 'newspack_network_save_product' )
 		) {

--- a/includes/woocommerce/class-product-admin.php
+++ b/includes/woocommerce/class-product-admin.php
@@ -22,6 +22,30 @@ class Product_Admin {
 	const NETWORK_ID_META_KEY = '_newspack_network_product_id';
 
 	/**
+	 * Get the Network ID for a product, falling back to the parent product
+	 * for variations of a variable-subscription.
+	 *
+	 * @param int $product_id The product ID.
+	 * @return string The Network ID, or empty string if not set.
+	 */
+	public static function get_network_id( $product_id ) {
+		$network_id = get_post_meta( $product_id, self::NETWORK_ID_META_KEY, true );
+		if ( ! empty( $network_id ) ) {
+			return $network_id;
+		}
+
+		// If this is a variation, check the parent product.
+		if ( function_exists( 'wc_get_product' ) ) {
+			$product = wc_get_product( $product_id );
+			if ( $product && $product->get_parent_id() ) {
+				return get_post_meta( $product->get_parent_id(), self::NETWORK_ID_META_KEY, true );
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Initializer.
 	 */
 	public static function init() {

--- a/includes/woocommerce/class-product-admin.php
+++ b/includes/woocommerce/class-product-admin.php
@@ -84,7 +84,6 @@ class Product_Admin {
 		}
 
 		$network_id = sanitize_text_field( wp_unslash( $_POST['newspack_network_product_id'] ?? '' ) );
-		$network_id = self::unique_network_id( $network_id, $post_id );
 
 		update_post_meta( $post_id, self::NETWORK_ID_META_KEY, $network_id );
 
@@ -94,37 +93,5 @@ class Product_Admin {
 		 * @param int $post_id The product post ID.
 		 */
 		do_action( 'newspack_network_save_product', $post_id );
-	}
-
-	/**
-	 * Given a network id, makes it unique among all products.
-	 *
-	 * @param string $network_id The network id to make unique.
-	 * @param int    $post_id The post ID that is being saved.
-	 * @return string The unique network id.
-	 */
-	private static function unique_network_id( $network_id, $post_id ) {
-		if ( empty( $network_id ) ) {
-			return '';
-		}
-		global $wpdb;
-		$network_id = sanitize_text_field( $network_id );
-		$query      = $wpdb->prepare(
-			"SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = %s AND post_id != %d",
-			self::NETWORK_ID_META_KEY,
-			$post_id
-		);
-
-		$ids = $wpdb->get_col( $query ); // phpcs:ignore
-
-		$count               = 2;
-		$original_network_id = $network_id;
-
-		while ( in_array( $network_id, $ids, true ) ) {
-			$network_id = $original_network_id . '-' . $count;
-			$count++;
-		}
-
-		return $network_id;
 	}
 }

--- a/includes/woocommerce/class-product-admin.php
+++ b/includes/woocommerce/class-product-admin.php
@@ -33,6 +33,11 @@ class Product_Admin {
 	 * Adds a meta box to the product edit screen.
 	 */
 	public static function add_meta_box() {
+		global $post;
+		$product = wc_get_product( $post );
+		if ( ! $product || ! $product->is_type( [ 'subscription', 'variable-subscription' ] ) ) {
+			return;
+		}
 		add_meta_box(
 			'newspack-network-product-meta-box',
 			__( 'Newspack Network', 'newspack-network' ),
@@ -80,6 +85,11 @@ class Product_Admin {
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$product = wc_get_product( $post_id );
+		if ( ! $product || ! $product->is_type( [ 'subscription', 'variable-subscription' ] ) ) {
 			return;
 		}
 

--- a/tests/unit-tests/test-content-gate-access.php
+++ b/tests/unit-tests/test-content-gate-access.php
@@ -317,18 +317,18 @@ class TestContentGateAccess extends WP_UnitTestCase {
 				'nonexistent',
 				false,
 			],
-			'pending-cancel sub, matching network ID'  => [
+			'pending-cancel sub, matching network ID' => [
 				'user_with_pending_cancel_sub',
 				'premium',
 				501,
 				'http://site2',
 			],
-			'cancelled sub, matching network ID'       => [
+			'cancelled sub, matching network ID'      => [
 				'user_with_cancelled_sub',
 				'premium',
 				false,
 			],
-			'no subs, matching network ID'             => [
+			'no subs, matching network ID'            => [
 				'user_without_subs',
 				'premium',
 				false,

--- a/tests/unit-tests/test-content-gate-access.php
+++ b/tests/unit-tests/test-content-gate-access.php
@@ -1,0 +1,399 @@
+<?php
+/**
+ * Class TestContentGateAccess
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Content_Gate\Access;
+use Newspack_Network\Incoming_Events\Product_Updated;
+use Newspack_Network\Incoming_Events\Subscription_Changed;
+use Newspack_Network\Woocommerce\Product_Admin;
+
+/**
+ * Test the Content_Gate\Access class.
+ */
+class TestContentGateAccess extends WP_UnitTestCase {
+
+	/**
+	 * User with an active subscription on site1 for product 100.
+	 *
+	 * @var int
+	 */
+	public static $user_with_active_sub;
+
+	/**
+	 * User with a pending-cancel subscription on site2.
+	 *
+	 * @var int
+	 */
+	public static $user_with_pending_cancel_sub;
+
+	/**
+	 * User with a cancelled subscription on site2.
+	 *
+	 * @var int
+	 */
+	public static $user_with_cancelled_sub;
+
+	/**
+	 * User with no network subscriptions.
+	 *
+	 * @var int
+	 */
+	public static $user_without_subs;
+
+	/**
+	 * Local product ID with Network ID 'premium'.
+	 *
+	 * @var int
+	 */
+	public static $local_product_premium;
+
+	/**
+	 * Local product ID with Network ID 'basic'.
+	 *
+	 * @var int
+	 */
+	public static $local_product_basic;
+
+	/**
+	 * Local product ID with no Network ID.
+	 *
+	 * @var int
+	 */
+	public static $local_product_no_network;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class() {
+		// Set up synced network products data.
+		$products = [
+			'http://site1' => [
+				100 => [
+					'id'         => 100,
+					'name'       => 'Premium Monthly',
+					'slug'       => 'premium-monthly',
+					'network_id' => 'premium',
+				],
+				101 => [
+					'id'         => 101,
+					'name'       => 'Basic Plan',
+					'slug'       => 'basic-plan',
+					'network_id' => 'basic',
+				],
+				102 => [
+					'id'         => 102,
+					'name'       => 'Local Only',
+					'slug'       => 'local-only',
+					'network_id' => '',
+				],
+			],
+			'http://site2' => [
+				200 => [
+					'id'         => 200,
+					'name'       => 'Premium Yearly',
+					'slug'       => 'premium-yearly',
+					'network_id' => 'premium',
+				],
+			],
+		];
+		update_option( Product_Updated::OPTION_NAME, $products, false );
+
+		// Create local products with Network ID meta.
+		self::$local_product_premium = wp_insert_post(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Local Premium',
+			]
+		);
+		update_post_meta( self::$local_product_premium, Product_Admin::NETWORK_ID_META_KEY, 'premium' );
+
+		self::$local_product_basic = wp_insert_post(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Local Basic',
+			]
+		);
+		update_post_meta( self::$local_product_basic, Product_Admin::NETWORK_ID_META_KEY, 'basic' );
+
+		self::$local_product_no_network = wp_insert_post(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'No Network ID',
+			]
+		);
+
+		// Create test users with network subscription meta.
+		self::$user_with_active_sub = wp_insert_user(
+			[
+				'user_login' => 'cg_user_active_sub',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			]
+		);
+		add_user_meta(
+			self::$user_with_active_sub,
+			Subscription_Changed::USER_SUBSCRIPTIONS_META_KEY,
+			[
+				'http://site1' => [
+					500 => [
+						'id'       => 500,
+						'status'   => 'active',
+						'products' => [
+							100 => [
+								'id'   => 100,
+								'name' => 'Premium Monthly',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		self::$user_with_pending_cancel_sub = wp_insert_user(
+			[
+				'user_login' => 'cg_user_pending_sub',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			]
+		);
+		add_user_meta(
+			self::$user_with_pending_cancel_sub,
+			Subscription_Changed::USER_SUBSCRIPTIONS_META_KEY,
+			[
+				'http://site2' => [
+					501 => [
+						'id'       => 501,
+						'status'   => 'pending-cancel',
+						'products' => [
+							200 => [
+								'id'   => 200,
+								'name' => 'Premium Yearly',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		self::$user_with_cancelled_sub = wp_insert_user(
+			[
+				'user_login' => 'cg_user_cancelled_sub',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			]
+		);
+		add_user_meta(
+			self::$user_with_cancelled_sub,
+			Subscription_Changed::USER_SUBSCRIPTIONS_META_KEY,
+			[
+				'http://site2' => [
+					502 => [
+						'id'       => 502,
+						'status'   => 'cancelled',
+						'products' => [
+							200 => [
+								'id'   => 200,
+								'name' => 'Premium Yearly',
+							],
+						],
+					],
+				],
+			]
+		);
+
+		self::$user_without_subs = wp_insert_user(
+			[
+				'user_login' => 'cg_user_no_subs',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			]
+		);
+	}
+
+	/**
+	 * When $has_subscription is already true, the filter should short-circuit and return true.
+	 */
+	public function test_check_network_subscriptions_already_granted() {
+		$result = Access::check_network_subscriptions( true, self::$user_without_subs, [ self::$local_product_premium ] );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * When product_ids is empty, the filter should return the original value.
+	 */
+	public function test_check_network_subscriptions_empty_product_ids() {
+		$result = Access::check_network_subscriptions( false, self::$user_with_active_sub, [] );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * When the local product has no Network ID, the filter should return the original value.
+	 */
+	public function test_check_network_subscriptions_no_network_id_on_product() {
+		$result = Access::check_network_subscriptions( false, self::$user_with_active_sub, [ self::$local_product_no_network ] );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * When the user has no network subscriptions, the filter should return the original value.
+	 */
+	public function test_check_network_subscriptions_user_without_subs() {
+		$result = Access::check_network_subscriptions( false, self::$user_without_subs, [ self::$local_product_premium ] );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * When the user has an active subscription on another site for a product with a matching
+	 * Network ID, access should be granted.
+	 */
+	public function test_check_network_subscriptions_matching_network_id() {
+		$result = Access::check_network_subscriptions( false, self::$user_with_active_sub, [ self::$local_product_premium ] );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Pending-cancel subscriptions should still grant access.
+	 */
+	public function test_check_network_subscriptions_pending_cancel_grants_access() {
+		$result = Access::check_network_subscriptions( false, self::$user_with_pending_cancel_sub, [ self::$local_product_premium ] );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Cancelled subscriptions should not grant access.
+	 */
+	public function test_check_network_subscriptions_cancelled_does_not_grant_access() {
+		$result = Access::check_network_subscriptions( false, self::$user_with_cancelled_sub, [ self::$local_product_premium ] );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * When the user's subscription is for a different Network ID, access should not be granted.
+	 */
+	public function test_check_network_subscriptions_non_matching_network_id() {
+		$result = Access::check_network_subscriptions( false, self::$user_with_active_sub, [ self::$local_product_basic ] );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * When the synced product data is missing (option not set), access should not be granted.
+	 */
+	public function test_check_network_subscriptions_missing_synced_product_data() {
+		$original = get_option( Product_Updated::OPTION_NAME );
+		delete_option( Product_Updated::OPTION_NAME );
+
+		$result = Access::check_network_subscriptions( false, self::$user_with_active_sub, [ self::$local_product_premium ] );
+		$this->assertFalse( $result );
+
+		update_option( Product_Updated::OPTION_NAME, $original, false );
+	}
+
+	/**
+	 * Data provider for test_user_has_active_network_subscription_for_network_id.
+	 *
+	 * @return array
+	 */
+	public function network_subscription_for_network_id_data() {
+		return [
+			'active sub, matching network ID'         => [
+				'user_with_active_sub',
+				'premium',
+				500,
+				'http://site1',
+			],
+			'active sub, non-matching network ID'     => [
+				'user_with_active_sub',
+				'basic',
+				false,
+			],
+			'active sub, nonexistent network ID'      => [
+				'user_with_active_sub',
+				'nonexistent',
+				false,
+			],
+			'pending-cancel sub, matching network ID'  => [
+				'user_with_pending_cancel_sub',
+				'premium',
+				501,
+				'http://site2',
+			],
+			'cancelled sub, matching network ID'       => [
+				'user_with_cancelled_sub',
+				'premium',
+				false,
+			],
+			'no subs, matching network ID'             => [
+				'user_without_subs',
+				'premium',
+				false,
+			],
+		];
+	}
+
+	/**
+	 * Test user_has_active_network_subscription_for_network_id.
+	 *
+	 * @param string   $user_property Static property name for the user ID.
+	 * @param string   $network_id    Product Network ID to look up.
+	 * @param int|bool $expected_id   Expected subscription ID, or false.
+	 * @param string   $expected_site Expected site URL (only when $expected_id is not false).
+	 * @dataProvider network_subscription_for_network_id_data
+	 */
+	public function test_user_has_active_network_subscription_for_network_id( $user_property, $network_id, $expected_id, $expected_site = '' ) {
+		$result = Access::user_has_active_network_subscription_for_network_id( self::$$user_property, $network_id );
+		if ( $expected_id ) {
+			$this->assertIsArray( $result );
+			$this->assertArrayHasKey( 'site', $result );
+			$this->assertArrayHasKey( 'subscription', $result );
+			$this->assertEquals( $expected_id, $result['subscription']['id'] );
+			$this->assertEquals( $expected_site, $result['site'] );
+		} else {
+			$this->assertFalse( $result );
+		}
+	}
+
+	/**
+	 * Test get_network_ids_for_products returns correct Network IDs.
+	 */
+	public function test_get_network_ids_for_products() {
+		$network_ids = Access::get_network_ids_for_products( [ self::$local_product_premium, self::$local_product_basic ] );
+		$this->assertCount( 2, $network_ids );
+		$this->assertContains( 'premium', $network_ids );
+		$this->assertContains( 'basic', $network_ids );
+	}
+
+	/**
+	 * Test get_network_ids_for_products skips products without Network IDs.
+	 */
+	public function test_get_network_ids_for_products_skips_empty() {
+		$network_ids = Access::get_network_ids_for_products( [ self::$local_product_no_network ] );
+		$this->assertEmpty( $network_ids );
+	}
+
+	/**
+	 * Test get_network_ids_for_products deduplicates.
+	 */
+	public function test_get_network_ids_for_products_deduplicates() {
+		// Create another product with the same Network ID.
+		$another_premium = wp_insert_post(
+			[
+				'post_type'   => 'product',
+				'post_status' => 'publish',
+				'post_title'  => 'Another Premium',
+			]
+		);
+		update_post_meta( $another_premium, Product_Admin::NETWORK_ID_META_KEY, 'premium' );
+
+		$network_ids = Access::get_network_ids_for_products( [ self::$local_product_premium, $another_premium ] );
+		$this->assertCount( 1, $network_ids );
+		$this->assertContains( 'premium', $network_ids );
+
+		wp_delete_post( $another_premium, true );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add product-level Network IDs to integrate with content gating. This enables cross-site subscription access and purchase restrictions.

- **Network ID on products**: Adds a "Network ID" metabox to WooCommerce product edit screens, allowing admins to link subscription products across sites in a network.
- **Event sync**: Syncs product Network IDs via a new `newspack_network_product_updated` data event, with incoming event handler, event log item, and CLI backfiller.
- **Access rules**: Hooks into the `newspack_access_rules_has_active_subscription` filter. When a user has an active subscription on another network site for a product with a matching Network ID, access is granted.
- **Purchase restrictions**: Prevents users from purchasing a subscription product when they already have an active subscription to a product with the same Network ID on another network site.

Closes NPPD-1162.

### How to test the changes in this Pull Request:

1. Set up a network with at least two sites (hub+node)
2. On both sites, create a WooCommerce subscription product and assign the same Network ID (e.g., premium-access) via the "Newspack Network" metabox on the product edit screen.
3. On both sites, create a content gate with an access rule requiring that subscription product.
4. As a reader, purchase the subscription on Site A.
5. Wait for the subscription data to sync (nodes pull every 2 minutes), or manually trigger a backfill.
6. On Site B, verify:
    - The reader can bypass the content gate (access granted via network subscription).
    - The reader cannot purchase the same subscription product — it should show as non-purchasable with a message referencing Site A.
7. As a logged-out user with the same billing email, attempt to checkout with the subscription on Site B — verify the checkout validation error appears.
8. On the Hub, check the event log for "Product updated" entries with the correct product name and Network ID.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
