### PR TITLE
feat(memberships): improve integrity check and handle ownership transfers

### DIFF
--- a/includes/cli/class-integrity-check.php
+++ b/includes/cli/class-integrity-check.php
@@ -145,10 +145,10 @@ class Integrity_Check {
 			// Prepare table data with node columns.
 			$table_data = [];
 			foreach ( $all_discrepancies as $discrepancy ) {
-				// Fill in missing node statuses with empty string.
+				// Fill in missing node statuses with the hub status (node is in sync with hub).
 				foreach ( $node_columns as $column ) {
 					if ( ! isset( $discrepancy[ $column ] ) && ! in_array( $column, [ 'email', 'network_id', 'hub_status' ] ) ) {
-						$discrepancy[ $column ] = '';
+						$discrepancy[ $column ] = $discrepancy['hub_status'];
 					}
 				}
 				$table_data[] = $discrepancy;

--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -135,12 +135,17 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 				)
 				AND post_id IN (
 					SELECT ID FROM $wpdb->posts WHERE post_type = 'wc_user_membership' AND post_parent = %d
+				)
+				AND post_id IN (
+					SELECT post_id FROM $wpdb->postmeta
+					WHERE meta_key = %s
 				)",
 				Memberships_Admin::REMOTE_ID_META_KEY,
 				$remote_membership_id,
 				Memberships_Admin::SITE_URL_META_KEY,
 				$this->get_site(),
-				$local_plan_id
+				$local_plan_id,
+				Memberships_Admin::NETWORK_MANAGED_META_KEY
 			)
 		);
 
@@ -177,12 +182,19 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 		}
 
 		// Reassign the membership to the new owner.
-		wp_update_post(
+		$updated_post_id = wp_update_post(
 			[
 				'ID'          => $existing_membership_id,
 				'post_author' => $new_user->ID,
-			]
+			],
+			true
 		);
+
+		if ( is_wp_error( $updated_post_id ) || ! $updated_post_id ) {
+			$error_message = is_wp_error( $updated_post_id ) ? $updated_post_id->get_error_message() : 'Unknown error';
+			Debugger::log( 'Error transferring membership: failed to update post author. ' . $error_message );
+			return;
+		}
 
 		$user_membership = wc_memberships_get_user_membership( $existing_membership_id );
 

--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -74,6 +74,13 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 
 		$user = User_Utils::get_or_create_user_by_email( $email, $this->get_site(), $this->data->user_id ?? '' );
 
+		// Handle membership ownership transfer.
+		$previous_email = $this->get_previous_email();
+		if ( $previous_email ) {
+			$this->transfer_membership( $user, $local_plan_id, $previous_email );
+			return;
+		}
+
 		$user_membership = wc_memberships_get_user_membership( $user->ID, $local_plan_id );
 
 		if ( null === $user_membership ) {
@@ -96,6 +103,116 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 			return;
 		}
 
+		$this->apply_membership_update( $user_membership );
+	}
+
+	/**
+	 * Transfer a managed membership from the previous owner to the new owner.
+	 *
+	 * Finds the existing membership by remote_id and reassigns it.
+	 * Falls back to creating a new membership if the existing one can't be found.
+	 *
+	 * @param \WP_User $new_user The new owner.
+	 * @param int      $local_plan_id The local plan ID.
+	 * @param string   $previous_email The previous owner's email.
+	 * @return void
+	 */
+	private function transfer_membership( $new_user, $local_plan_id, $previous_email ) {
+		global $wpdb;
+
+		Debugger::log( 'Processing membership transfer from ' . $previous_email . ' to ' . $new_user->user_email );
+
+		$remote_membership_id = $this->get_membership_id();
+
+		// Find the existing managed membership by remote_id.
+		$existing_membership_id = $wpdb->get_var( // phpcs:ignore
+			$wpdb->prepare(
+				"SELECT post_id FROM $wpdb->postmeta
+				WHERE meta_key = %s AND meta_value = %s
+				AND post_id IN (
+					SELECT post_id FROM $wpdb->postmeta
+					WHERE meta_key = %s AND meta_value = %s
+				)
+				AND post_id IN (
+					SELECT ID FROM $wpdb->posts WHERE post_type = 'wc_user_membership' AND post_parent = %d
+				)",
+				Memberships_Admin::REMOTE_ID_META_KEY,
+				$remote_membership_id,
+				Memberships_Admin::SITE_URL_META_KEY,
+				$this->get_site(),
+				$local_plan_id
+			)
+		);
+
+		if ( ! $existing_membership_id ) {
+			Debugger::log( 'Managed membership not found by remote_id, falling back to previous owner lookup.' );
+
+			// Try finding by previous owner + plan.
+			$previous_user = get_user_by( 'email', $previous_email );
+			if ( $previous_user ) {
+				$previous_membership = wc_memberships_get_user_membership( $previous_user->ID, $local_plan_id );
+				if ( $previous_membership ) {
+					$existing_membership_id = $previous_membership->get_id();
+				}
+			}
+		}
+
+		if ( ! $existing_membership_id ) {
+			Debugger::log( 'No existing membership found to transfer, creating new one.' );
+
+			$user_membership = wc_memberships_create_user_membership(
+				[
+					'plan_id' => $local_plan_id,
+					'user_id' => $new_user->ID,
+				]
+			);
+
+			if ( is_wp_error( $user_membership ) || ! $user_membership instanceof WC_Memberships_User_Membership ) {
+				Debugger::log( 'Error creating membership for transfer.' );
+				return;
+			}
+
+			$this->apply_membership_update( $user_membership );
+			return;
+		}
+
+		// Reassign the membership to the new owner.
+		wp_update_post(
+			[
+				'ID'          => $existing_membership_id,
+				'post_author' => $new_user->ID,
+			]
+		);
+
+		$user_membership = wc_memberships_get_user_membership( $existing_membership_id );
+
+		if ( ! $user_membership instanceof WC_Memberships_User_Membership ) {
+			Debugger::log( 'Error retrieving membership after transfer.' );
+			return;
+		}
+
+		$user_membership->add_note(
+			sprintf(
+				// translators: 1: previous owner email, 2: new owner email, 3: site URL.
+				__( 'Membership transferred from %1$s to %2$s via Newspack Network. Propagated from %3$s.', 'newspack-network' ),
+				$previous_email,
+				$new_user->user_email,
+				$this->get_site()
+			)
+		);
+
+		$this->apply_membership_update( $user_membership );
+
+		Debugger::log( 'Membership transferred successfully.' );
+	}
+
+	/**
+	 * Apply status, end date, and managed meta to a membership.
+	 *
+	 * @param WC_Memberships_User_Membership $user_membership The membership to update.
+	 * @return void
+	 */
+	private function apply_membership_update( $user_membership ) {
 		$status     = $this->get_new_status();
 		$is_managed = get_post_meta( $user_membership->get_id(), Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
 
@@ -171,5 +288,14 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 	 */
 	public function get_end_date() {
 		return $this->data->end_date ?? null;
+	}
+
+	/**
+	 * Get the previous owner's email (set during ownership transfers).
+	 *
+	 * @return ?string
+	 */
+	public function get_previous_email() {
+		return $this->data->previous_email ?? null;
 	}
 }

--- a/includes/woocommerce-memberships/class-events.php
+++ b/includes/woocommerce-memberships/class-events.php
@@ -48,6 +48,7 @@ class Events {
 		Data_Events::register_listener( 'wc_memberships_user_membership_status_changed', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_status_changed' ] );
 		Data_Events::register_listener( 'wc_memberships_user_membership_saved', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_saved' ] );
 		Data_Events::register_listener( 'wc_memberships_user_membership_deleted', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_deleted' ] );
+		Data_Events::register_listener( 'wc_memberships_user_membership_transferred', 'newspack_network_woo_membership_updated', [ __CLASS__, 'membership_transferred' ] );
 		Data_Events::register_listener( 'newspack_network_save_membership_plan', 'newspack_network_membership_plan_updated', [ __CLASS__, 'membership_plan_updated' ] );
 	}
 
@@ -184,6 +185,37 @@ class Events {
 			'membership_id'   => $user_membership->get_id(),
 			'new_status'      => $user_membership->get_status(),
 			'end_date'        => $user_membership->get_end_date(),
+		];
+	}
+
+	/**
+	 * Transforms the data of the wc_memberships_user_membership_transferred hook to trigger the newspack_network_woo_membership_updated data event
+	 *
+	 * @param \WC_Memberships_User_Membership $user_membership The User Membership object that was transferred.
+	 * @param \WP_User                        $new_owner The new owner of the membership.
+	 * @param \WP_User                        $previous_owner The previous owner of the membership.
+	 * @return array|void
+	 */
+	public static function membership_transferred( $user_membership, $new_owner, $previous_owner ) {
+		if ( self::$pause_events ) {
+			return;
+		}
+
+		$plan_id = $user_membership->get_plan()->get_id();
+
+		$plan_network_id = get_post_meta( $plan_id, Admin::NETWORK_ID_META_KEY, true );
+		if ( ! $plan_network_id ) {
+			return;
+		}
+
+		return [
+			'email'           => $new_owner->user_email,
+			'user_id'         => $new_owner->ID,
+			'plan_network_id' => $plan_network_id,
+			'membership_id'   => $user_membership->get_id(),
+			'new_status'      => $user_membership->get_status(),
+			'end_date'        => $user_membership->get_end_date(),
+			'previous_email'  => $previous_owner->user_email,
 		];
 	}
 

--- a/tests/unit-tests/mock-wc-memberships.php
+++ b/tests/unit-tests/mock-wc-memberships.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Stubs for WooCommerce Memberships functions used in tests.
+ *
+ * @package Newspack_Network
+ */
+
+if ( ! function_exists( 'wc_memberships_get_user_membership' ) ) {
+	/**
+	 * Stub for wc_memberships_get_user_membership.
+	 *
+	 * @param mixed $user_id_or_membership User ID or membership post ID.
+	 * @param mixed $plan_id              Optional plan ID.
+	 * @return null
+	 */
+	function wc_memberships_get_user_membership( $user_id_or_membership = null, $plan_id = null ) { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+		return null;
+	}
+}
+if ( ! function_exists( 'wc_memberships_create_user_membership' ) ) {
+	/**
+	 * Stub for wc_memberships_create_user_membership.
+	 *
+	 * @param array $args Membership args.
+	 * @return null
+	 */
+	function wc_memberships_create_user_membership( $args = [] ) { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+		return null;
+	}
+}

--- a/tests/unit-tests/test-membership-transfer.php
+++ b/tests/unit-tests/test-membership-transfer.php
@@ -150,10 +150,15 @@ class TestMembershipTransfer extends WP_UnitTestCase {
 	 * Test that Events::membership_transferred returns null when events are paused.
 	 */
 	public function test_events_listener_paused() {
-		Memberships_Events::$pause_events = true;
-		$result = Memberships_Events::membership_transferred( null, null, null );
-		$this->assertNull( $result );
-		Memberships_Events::$pause_events = false;
+		$previous_pause_events = Memberships_Events::$pause_events;
+
+		try {
+			Memberships_Events::$pause_events = true;
+			$result = Memberships_Events::membership_transferred( null, null, null );
+			$this->assertNull( $result );
+		} finally {
+			Memberships_Events::$pause_events = $previous_pause_events;
+		}
 	}
 
 	/**

--- a/tests/unit-tests/test-membership-transfer.php
+++ b/tests/unit-tests/test-membership-transfer.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Class TestMembershipTransfer
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Incoming_Events\Woocommerce_Membership_Updated;
+use Newspack_Network\Woocommerce_Memberships\Admin as Memberships_Admin;
+use Newspack_Network\Woocommerce_Memberships\Events as Memberships_Events;
+
+require_once __DIR__ . '/mock-wc-memberships.php';
+
+/**
+ * Test membership ownership transfer handling.
+ *
+ * @group membership-transfer
+ */
+class TestMembershipTransfer extends WP_UnitTestCase {
+
+	/**
+	 * Test that the transfer path reassigns membership post_author when found by remote_id.
+	 *
+	 * The WC Memberships functions are stubbed to return null, so the method will
+	 * successfully do the wp_update_post (pure WP) but exit after that since the
+	 * stub returns null for wc_memberships_get_user_membership.
+	 */
+	public function test_transfer_reassigns_post_author_by_remote_id() {
+		$old_user_id = $this->factory->user->create( [ 'user_email' => 'oldowner@example.com' ] );
+		$new_user_id = $this->factory->user->create( [ 'user_email' => 'newowner@example.com' ] );
+
+		$plan_id = $this->factory->post->create(
+			[
+				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
+				'post_status' => 'publish',
+				'post_title'  => 'Test Plan',
+			]
+		);
+		update_post_meta( $plan_id, Memberships_Admin::NETWORK_ID_META_KEY, 'test-plan' );
+
+		$membership_id = $this->factory->post->create(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'wcm-active',
+				'post_author' => $old_user_id,
+				'post_parent' => $plan_id,
+			]
+		);
+		update_post_meta( $membership_id, Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
+		update_post_meta( $membership_id, Memberships_Admin::REMOTE_ID_META_KEY, 999 );
+		update_post_meta( $membership_id, Memberships_Admin::SITE_URL_META_KEY, 'https://hub.example.com' );
+
+		// Verify initial ownership.
+		$this->assertEquals( $old_user_id, (int) get_post( $membership_id )->post_author );
+
+		$transfer_event = new Woocommerce_Membership_Updated(
+			'https://hub.example.com',
+			[
+				'email'           => 'newowner@example.com',
+				'user_id'         => $new_user_id,
+				'plan_network_id' => 'test-plan',
+				'membership_id'   => 999,
+				'new_status'      => 'active',
+				'end_date'        => null,
+				'previous_email'  => 'oldowner@example.com',
+			],
+			time()
+		);
+
+		$transfer_method = new ReflectionMethod( Woocommerce_Membership_Updated::class, 'transfer_membership' );
+		$transfer_method->setAccessible( true );
+
+		$new_user = get_user_by( 'id', $new_user_id );
+		$transfer_method->invoke( $transfer_event, $new_user, $plan_id, 'oldowner@example.com' );
+
+		// Verify ownership was transferred via wp_update_post.
+		$this->assertEquals( $new_user_id, (int) get_post( $membership_id )->post_author );
+	}
+
+	/**
+	 * Test that transfer does not affect memberships with a different remote_id.
+	 */
+	public function test_transfer_does_not_touch_unrelated_membership() {
+		$old_user_id = $this->factory->user->create( [ 'user_email' => 'oldowner2@example.com' ] );
+		$new_user_id = $this->factory->user->create( [ 'user_email' => 'newowner2@example.com' ] );
+		$other_user_id = $this->factory->user->create( [ 'user_email' => 'other@example.com' ] );
+
+		$plan_id = $this->factory->post->create(
+			[
+				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $plan_id, Memberships_Admin::NETWORK_ID_META_KEY, 'test-plan' );
+
+		// Target membership (remote_id = 999).
+		$target_membership_id = $this->factory->post->create(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'wcm-active',
+				'post_author' => $old_user_id,
+				'post_parent' => $plan_id,
+			]
+		);
+		update_post_meta( $target_membership_id, Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
+		update_post_meta( $target_membership_id, Memberships_Admin::REMOTE_ID_META_KEY, 999 );
+		update_post_meta( $target_membership_id, Memberships_Admin::SITE_URL_META_KEY, 'https://hub.example.com' );
+
+		// Unrelated membership (remote_id = 888).
+		$unrelated_membership_id = $this->factory->post->create(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'wcm-active',
+				'post_author' => $other_user_id,
+				'post_parent' => $plan_id,
+			]
+		);
+		update_post_meta( $unrelated_membership_id, Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
+		update_post_meta( $unrelated_membership_id, Memberships_Admin::REMOTE_ID_META_KEY, 888 );
+		update_post_meta( $unrelated_membership_id, Memberships_Admin::SITE_URL_META_KEY, 'https://hub.example.com' );
+
+		$transfer_event = new Woocommerce_Membership_Updated(
+			'https://hub.example.com',
+			[
+				'email'           => 'newowner2@example.com',
+				'user_id'         => $new_user_id,
+				'plan_network_id' => 'test-plan',
+				'membership_id'   => 999,
+				'new_status'      => 'active',
+				'end_date'        => null,
+				'previous_email'  => 'oldowner2@example.com',
+			],
+			time()
+		);
+
+		$transfer_method = new ReflectionMethod( Woocommerce_Membership_Updated::class, 'transfer_membership' );
+		$transfer_method->setAccessible( true );
+
+		$new_user = get_user_by( 'id', $new_user_id );
+		$transfer_method->invoke( $transfer_event, $new_user, $plan_id, 'oldowner2@example.com' );
+
+		// Target should be transferred.
+		$this->assertEquals( $new_user_id, (int) get_post( $target_membership_id )->post_author );
+
+		// Unrelated should not be touched.
+		$this->assertEquals( $other_user_id, (int) get_post( $unrelated_membership_id )->post_author );
+	}
+
+	/**
+	 * Test that Events::membership_transferred returns null when events are paused.
+	 */
+	public function test_events_listener_paused() {
+		Memberships_Events::$pause_events = true;
+		$result = Memberships_Events::membership_transferred( null, null, null );
+		$this->assertNull( $result );
+		Memberships_Events::$pause_events = false;
+	}
+
+	/**
+	 * Test the full update_membership flow routes to transfer when previous_email is set.
+	 *
+	 * With stubbed WC functions (returning null), the method will find the plan via DB,
+	 * enter the transfer path, do the wp_update_post, then gracefully exit when
+	 * wc_memberships_get_user_membership returns null.
+	 */
+	public function test_update_membership_routes_to_transfer() {
+		$old_user_id = $this->factory->user->create( [ 'user_email' => 'oldowner3@example.com' ] );
+		$new_user_id = $this->factory->user->create( [ 'user_email' => 'newowner3@example.com' ] );
+
+		$plan_id = $this->factory->post->create(
+			[
+				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $plan_id, Memberships_Admin::NETWORK_ID_META_KEY, 'test-plan-full' );
+
+		$membership_id = $this->factory->post->create(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'wcm-active',
+				'post_author' => $old_user_id,
+				'post_parent' => $plan_id,
+			]
+		);
+		update_post_meta( $membership_id, Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
+		update_post_meta( $membership_id, Memberships_Admin::REMOTE_ID_META_KEY, 777 );
+		update_post_meta( $membership_id, Memberships_Admin::SITE_URL_META_KEY, 'https://hub.example.com' );
+
+		$transfer_event = new Woocommerce_Membership_Updated(
+			'https://hub.example.com',
+			[
+				'email'           => 'newowner3@example.com',
+				'user_id'         => $new_user_id,
+				'plan_network_id' => 'test-plan-full',
+				'membership_id'   => 777,
+				'new_status'      => 'active',
+				'end_date'        => null,
+				'previous_email'  => 'oldowner3@example.com',
+			],
+			time()
+		);
+
+		// Call the full update_membership flow (which now has the WC function stubs).
+		$transfer_event->update_membership();
+
+		// Verify the membership was transferred.
+		$this->assertEquals( $new_user_id, (int) get_post( $membership_id )->post_author );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Integrity check: show actual status for in-sync nodes.** When the `wp newspack-network integrity-check` command displays its discrepancy table, nodes that are in sync with the hub for a given row previously showed an empty cell. This was ambiguous – it was unclear whether the node had the membership or not. Now it shows the hub's status value, making it clear the node matches.

**Membership ownership transfers.** When a WooCommerce Membership is transferred from one user to another (via the WC Memberships admin UI), the ownership change was not propagated to other sites in the network. This caused integrity check discrepancies where the membership appeared under the old owner's email on nodes but under the new owner's email on the hub. Now the plugin listens to the `wc_memberships_user_membership_transferred` hook and dispatches a membership update event with the new owner's email and a `previous_email` field. On receiving sites, the existing managed membership is found by its `_remote_id` and reassigned to the new owner.

### How to test the changes in this Pull Request:

#### Integrity check display fix
1. Set up a Hub + Node network with some membership discrepancies across 3+ nodes.
2. Run `wp newspack-network integrity-check --verbose` on the hub.
3. In the discrepancy table, verify that nodes which are in sync with the hub for a given row show the hub's status (e.g., `wcm-active`) instead of an empty cell.

#### Membership transfer propagation
1. Set up a Hub + Node network with WooCommerce Memberships and a membership plan that has a `_newspack_network_id`.
2. Create a membership for User A on the hub. Verify it syncs to the node.
3. On the hub, transfer the membership to User B using the WooCommerce Memberships admin (edit the membership → Transfer).
4. Verify that the node receives the transfer event and the membership is now owned by User B (check `post_author` and the membership note).
5. Verify that transferring a membership on a plan without a network ID does not fire any events.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?