### PR TITLE
chore(release): exclude dev-only files from release archive

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -23,12 +23,21 @@ webpack.config.js
 *.tar.gz
 *.zip
 node_modules
+.phpunit.result.cache
+.travis.yml
+AGENTS.md
+CLAUDE.md
+DEV_NOTES.md
+TESTING_SCENARIOS.md
+bun.lockb
 
 # directories
 .cache
+.claude
 .git
 .github
 .circleci
+/src
 /tests
 /bin
 /release


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds dev-only files and directories to `.distignore` so they are excluded from the release archive. The following were being included unnecessarily: `.claude/`, `.phpunit.result.cache`, `.travis.yml`, `AGENTS.md`, `CLAUDE.md`, `DEV_NOTES.md`, `TESTING_SCENARIOS.md`, `bun.lockb`, and `/src/` (compiled output already ships in `dist/`).

### How to test the changes in this Pull Request:

1. Run `npm run release:archive` to generate the release archive.
2. Inspect the contents of `release/newspack-network/` – verify that none of the newly excluded files or directories are present.
3. Verify that the archive still contains all required files: `newspack-network.php`, `includes/`, `dist/`, `vendor/`, `languages/`, `LICENSE`, `CHANGELOG.md`.
4. Install the generated `release/newspack-network.zip` on a WordPress site and confirm the plugin activates and functions correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?