### PR TITLE
fix(woo-memberships): prevent fatal when membership plan has been deleted

### DIFF
--- a/includes/woocommerce-memberships/class-events.php
+++ b/includes/woocommerce-memberships/class-events.php
@@ -80,7 +80,13 @@ class Events {
 			return;
 		}
 		$user_email = $user->user_email;
-		$plan_id    = $user_membership->get_plan()->get_id();
+
+		// Plan post may have been deleted; skip rather than fatal on ->get_id().
+		$plan = $user_membership->get_plan();
+		if ( ! $plan ) {
+			return;
+		}
+		$plan_id = $plan->get_id();
 
 		$plan_network_id = get_post_meta( $plan_id, Admin::NETWORK_ID_META_KEY, true );
 		if ( ! $plan_network_id ) {
@@ -113,7 +119,13 @@ class Events {
 			return;
 		}
 		$user_email = $user->user_email;
-		$plan_id    = $user_membership->get_plan()->get_id();
+
+		// Plan post may have been deleted; skip rather than fatal on ->get_id().
+		$plan = $user_membership->get_plan();
+		if ( ! $plan ) {
+			return;
+		}
+		$plan_id = $plan->get_id();
 
 		$plan_network_id = get_post_meta( $plan_id, Admin::NETWORK_ID_META_KEY, true );
 		if ( ! $plan_network_id ) {

--- a/tests/unit-tests/test-membership-events-null-plan.php
+++ b/tests/unit-tests/test-membership-events-null-plan.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Test that Events listeners handle memberships with deleted plans gracefully.
+ *
+ * Regression test for NPPM-2742: a membership whose plan post was deleted
+ * caused a PHP fatal in Events::membership_deleted() and
+ * Events::membership_transferred() when calling get_plan()->get_id() on null.
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Woocommerce_Memberships\Events as Memberships_Events;
+
+/**
+ * Minimal stub for WC_Memberships_User_Membership used in Events listener tests.
+ *
+ * Only the methods called by the listeners are implemented.
+ */
+class Mock_User_Membership {
+	/**
+	 * The user.
+	 *
+	 * @var WP_User|null
+	 */
+	private $user;
+
+	/**
+	 * The plan.
+	 *
+	 * @var object|null
+	 */
+	private $plan;
+
+	/**
+	 * The membership ID.
+	 *
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WP_User|null $user The user object.
+	 * @param object|null  $plan The plan object (null to simulate deleted plan).
+	 * @param int          $id   The membership ID.
+	 */
+	public function __construct( $user = null, $plan = null, $id = 1 ) {
+		$this->user = $user;
+		$this->plan = $plan;
+		$this->id   = $id;
+	}
+
+	/**
+	 * Get the user.
+	 *
+	 * @return WP_User|false
+	 */
+	public function get_user() {
+		return $this->user ? $this->user : false;
+	}
+
+	/**
+	 * Get the plan.
+	 *
+	 * @return object|null
+	 */
+	public function get_plan() {
+		return $this->plan;
+	}
+
+	/**
+	 * Get the membership ID.
+	 *
+	 * @return int
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+}
+
+/**
+ * Tests for Events listeners when the membership plan has been deleted.
+ *
+ * @group membership-events
+ */
+class TestMembershipEventsNullPlan extends WP_UnitTestCase {
+
+	/**
+	 * Ensure $pause_events is false for these tests.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Memberships_Events::$pause_events = false;
+	}
+
+	/**
+	 * Restore $pause_events after each test.
+	 */
+	public function tearDown(): void {
+		Memberships_Events::$pause_events = false;
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that membership_deleted returns null (no fatal) when plan is missing.
+	 */
+	public function test_membership_deleted_returns_null_when_plan_missing() {
+		$user = $this->factory->user->create_and_get( [ 'user_email' => 'deleted-plan@example.com' ] );
+
+		$membership = new Mock_User_Membership( $user, null, 42 );
+
+		$result = Memberships_Events::membership_deleted( $membership );
+
+		$this->assertNull( $result, 'membership_deleted should return null when plan is missing, not fatal.' );
+	}
+
+	/**
+	 * Ensure the null-plan fix didn't break the existing no-network-ID early return.
+	 */
+	public function test_membership_deleted_returns_null_when_plan_has_no_network_id() {
+		$user = $this->factory->user->create_and_get( [ 'user_email' => 'no-network-id@example.com' ] );
+
+		$plan_id = $this->factory->post->create( [ 'post_type' => 'wc_membership_plan' ] );
+		$plan    = (object) [ 'id' => $plan_id ];
+		$plan->get_id = function() use ( $plan_id ) {
+			return $plan_id;
+		};
+
+		// Use a proper mock plan object with get_id method.
+		$mock_plan = new class( $plan_id ) {
+			private $id;
+			public function __construct( $id ) {
+				$this->id = $id;
+			}
+			public function get_id() {
+				return $this->id;
+			}
+		};
+
+		$membership = new Mock_User_Membership( $user, $mock_plan, 43 );
+
+		// Plan exists but has no NETWORK_ID_META_KEY, so should return null.
+		$result = Memberships_Events::membership_deleted( $membership );
+
+		$this->assertNull( $result, 'membership_deleted should return null when plan has no network ID.' );
+	}
+
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Woocommerce_Memberships\Events, listener methods called $user_membership->get_plan()->get_id() without checking if get_plan() returns null. When a membership's plan post has been deleted, `get_plan()` returns false, and calling `->get_id()` on false is a PHP fatal.

This fatal can kill the node pull process mid-execution via the `network_user_deleted` path (where `$pause_events` is not set), leaving the pull pointer stuck.

Adds null checks on `get_plan()` in `membership_status_changed()` and `membership_deleted()`, matching the existing `get_user()` null-check pattern already present in those methods.

Related to NPPM-2742.

⚠️ Parked draft - `membership_transferred()` needs the same guard before this is ready. Reopening this as a fresh PR when that work resumes.

### How to test the changes in this Pull Request:

**Reproduce the problem:**
1. On a node site, create a WC membership plan and assign a user to it
2. To simulate the problem, delete the plan post directly from the database (bypassing WC Memberships hooks): `wp db query 'DELETE FROM wp_posts WHERE ID = <plan_id>;'`   Then `wp cache flush`
3. Call the listener directly. The process will die silently after the call with no output (PHP fatal, exit code 1).
 `wp eval '$m = wc_memberships_get_user_membership(<membership_id>); $r = Newspack_Network\Woocommerce_Memberships\Events::membership_deleted($m); var_dump($r);'`

**Verify the fix:**
1. With the fix applied, repeat step 3 above
2. The process completes and prints `NULL`. The listener returns early cleanly instead of fataling
3. Run tests: `n test-php --group membership-events` — all tests pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?