### PR TITLE
fix(memberships): skip team-owned memberships in transfer_membership

### DIFF
--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -185,7 +185,6 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 		// the linked subscription's `_customer_user`, and team_member user meta – rewriting only
 		// `post_author` here would silently desync all of those and break renewal dispatch.
 		// Team ownership transfers must be handled at the team level, not the user_membership level.
-		// See https://linear.app/a8c/issue/NPPM-2741.
 		$team_id = get_post_meta( $existing_membership_id, '_team_id', true );
 		if ( ! empty( $team_id ) ) {
 			Debugger::log(

--- a/includes/incoming-events/class-woocommerce-membership-updated.php
+++ b/includes/incoming-events/class-woocommerce-membership-updated.php
@@ -181,6 +181,25 @@ class Woocommerce_Membership_Updated extends Abstract_Incoming_Event {
 			return;
 		}
 
+		// Skip team-owned memberships: their ownership lives on the team post's `_member_id`,
+		// the linked subscription's `_customer_user`, and team_member user meta – rewriting only
+		// `post_author` here would silently desync all of those and break renewal dispatch.
+		// Team ownership transfers must be handled at the team level, not the user_membership level.
+		// See https://linear.app/a8c/issue/NPPM-2741.
+		$team_id = get_post_meta( $existing_membership_id, '_team_id', true );
+		if ( ! empty( $team_id ) ) {
+			Debugger::log(
+				sprintf(
+					'Skipping transfer of team-owned membership #%d (team #%s) from %s to %s. Team memberships cannot be transferred via post_author alone.',
+					$existing_membership_id,
+					$team_id,
+					$previous_email,
+					$new_user->user_email
+				)
+			);
+			return;
+		}
+
 		// Reassign the membership to the new owner.
 		$updated_post_id = wp_update_post(
 			[

--- a/tests/unit-tests/test-membership-transfer.php
+++ b/tests/unit-tests/test-membership-transfer.php
@@ -212,4 +212,59 @@ class TestMembershipTransfer extends WP_UnitTestCase {
 		// Verify the membership was transferred.
 		$this->assertEquals( $new_user_id, (int) get_post( $membership_id )->post_author );
 	}
+
+	/**
+	 * Team-owned memberships (those with a `_team_id` meta) must not be transferred via
+	 * post_author rewrite. Their ownership lives on the team's `_member_id`, the linked
+	 * subscription's `_customer_user`, and team_member user meta. See NPPM-2741.
+	 */
+	public function test_transfer_skips_team_owned_membership() {
+		$old_user_id = $this->factory->user->create( [ 'user_email' => 'teamold@example.com' ] );
+		$new_user_id = $this->factory->user->create( [ 'user_email' => 'teamnew@example.com' ] );
+
+		$plan_id = $this->factory->post->create(
+			[
+				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $plan_id, Memberships_Admin::NETWORK_ID_META_KEY, 'test-team-plan' );
+
+		$membership_id = $this->factory->post->create(
+			[
+				'post_type'   => 'wc_user_membership',
+				'post_status' => 'wcm-active',
+				'post_author' => $old_user_id,
+				'post_parent' => $plan_id,
+			]
+		);
+		update_post_meta( $membership_id, Memberships_Admin::NETWORK_MANAGED_META_KEY, true );
+		update_post_meta( $membership_id, Memberships_Admin::REMOTE_ID_META_KEY, 555 );
+		update_post_meta( $membership_id, Memberships_Admin::SITE_URL_META_KEY, 'https://hub.example.com' );
+		// Mark as team-owned.
+		update_post_meta( $membership_id, '_team_id', 42 );
+
+		$transfer_event = new Woocommerce_Membership_Updated(
+			'https://hub.example.com',
+			[
+				'email'           => 'teamnew@example.com',
+				'user_id'         => $new_user_id,
+				'plan_network_id' => 'test-team-plan',
+				'membership_id'   => 555,
+				'new_status'      => 'active',
+				'end_date'        => null,
+				'previous_email'  => 'teamold@example.com',
+			],
+			time()
+		);
+
+		$transfer_method = new ReflectionMethod( Woocommerce_Membership_Updated::class, 'transfer_membership' );
+		$transfer_method->setAccessible( true );
+
+		$new_user = get_user_by( 'id', $new_user_id );
+		$transfer_method->invoke( $transfer_event, $new_user, $plan_id, 'teamold@example.com' );
+
+		// post_author must remain unchanged for team-owned memberships.
+		$this->assertEquals( $old_user_id, (int) get_post( $membership_id )->post_author );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Refs [NPPM-2741](https://linear.app/a8c/issue/NPPM-2741).

`Woocommerce_Membership_Updated::transfer_membership()` currently reassigns a user_membership to its new owner by rewriting `post_author` via `wp_update_post`. That's fine for standalone memberships, but for team-owned memberships (those with a `_team_id` meta) ownership doesn't live on `post_author` – it lives on three separate records:

- the team post's `_member_id` (the team owner)
- the linked subscription's `_customer_user`
- team_member user meta (role, added-date)

Rewriting only `post_author` silently desyncs all of those. On the next renewal dispatch, SkyVerge Teams' owner-vs-customer check can then spawn a duplicate team, and the original team/membership pair gets orphaned.

Today this path is hard to hit because SkyVerge Teams does **not** fire `wc_memberships_user_membership_transferred`, so `Events::membership_transferred` never dispatches the network event for team memberships from the node side. But a future Teams version, a manual dispatch, a mis-linked remote membership, or a reconciliation flow could all reach `transfer_membership` with a team-owned local membership, and today that would silently corrupt the data. This PR makes the function skip team-owned memberships and log a note instead.

Cheapest guard: `get_post_meta( $existing_membership_id, '_team_id', true )` – direct meta read, no object instantiation.

### How to test the changes in this Pull Request:

**Unit tests** – a new test `test_transfer_skips_team_owned_membership` is added alongside the existing `TestMembershipTransfer` suite. It sets up a managed user_membership with `_team_id=42` meta, invokes `transfer_membership()` via Reflection, and asserts `post_author` is unchanged.

```
docker exec newspack_dev bash -c '/var/scripts/test-php.sh newspack-network --filter TestMembershipTransfer'
```

Expected: `OK (5 tests, 7 assertions)`.

### Other information:

- [x] New test added (`test_transfer_skips_team_owned_membership`)
- [x] Tests run locally
- [x] PHPCS clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)