### PR TITLE
fix(network): harden the user-sync receive side and sign the Hub pull response

### DIFF
--- a/includes/class-crypto.php
+++ b/includes/class-crypto.php
@@ -23,21 +23,31 @@ class Crypto {
 	}
 
 	/**
+	 * Whether a value is a non-empty, even-length hexadecimal string (i.e. safe for hex2bin()).
+	 *
+	 * @param mixed $value The value to check.
+	 * @return bool
+	 */
+	private static function is_hex( $value ) {
+		return is_string( $value ) && '' !== $value && 0 === strlen( $value ) % 2 && ctype_xdigit( $value );
+	}
+
+	/**
 	 * Decrypts a message
 	 *
-	 * @param string $message The message to be decrypted.
+	 * @param string $message The hex-encoded message to be decrypted.
 	 * @param string $secret_key The secret key to verify the message with.
 	 * @param string $nonce The nonce to verify the message with, generated with Crypto::generate_nonce().
 	 * @return string|false The decrypted message or false if the message could not be decrypted.
 	 */
 	public static function decrypt_message( $message, $secret_key, $nonce ) {
-		if ( ! $secret_key || ! is_string( $secret_key ) || ! $nonce || ! is_string( $nonce ) || ! is_string( $message ) ) {
+		if ( ! self::is_hex( $message ) || ! self::is_hex( $secret_key ) || ! self::is_hex( $nonce ) ) {
 			return false;
 		}
 
 		try {
 			$decrypted = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt( hex2bin( $message ), '', hex2bin( $nonce ), hex2bin( $secret_key ) );
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return false;
 		}
 
@@ -50,17 +60,17 @@ class Crypto {
 	 * @param string $message The message to be encrypted.
 	 * @param string $secret_key The secret key to encrypt the message with.
 	 * @param string $nonce The nonce to verify the message with, generated with Crypto::generate_nonce().
-	 * @return string|WP_Error The encrypted message or WP_Error if the message could not be encrypted.
+	 * @return string|false|WP_Error The encrypted message, false on invalid arguments, or WP_Error if encryption failed.
 	 */
 	public static function encrypt_message( $message, $secret_key, $nonce ) {
-		if ( ! $secret_key || ! is_string( $secret_key ) || ! $nonce || ! is_string( $nonce ) ) {
+		if ( ! is_string( $message ) || ! self::is_hex( $secret_key ) || ! self::is_hex( $nonce ) ) {
 			return false;
 		}
 
 		try {
 			$encrypted = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt( $message, '', hex2bin( $nonce ), hex2bin( $secret_key ) );
 			return bin2hex( $encrypted );
-		} catch ( \Exception $e ) {
+		} catch ( \Throwable $e ) {
 			return new \WP_Error( 'newspack-network-node-webhook-encrypting-error', $e->getMessage() );
 		}
 	}

--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -8,6 +8,7 @@
 namespace Newspack_Network\Hub;
 
 use Newspack_Network\Accepted_Actions;
+use Newspack_Network\Crypto;
 use Newspack_Network\Debugger;
 use Newspack_Network\Hub\Stores\Event_Log;
 use WP_REST_Response;
@@ -72,14 +73,19 @@ class Pull_Endpoint {
 	 * @return WP_REST_Response
 	 */
 	public static function handle_pull( $request ) {
-		$request_error = \Newspack_Network\Utils\Requests::get_request_to_hub_errors( $request );
-		if ( \is_wp_error( $request_error ) ) {
-			return new WP_REST_Response( [ 'error' => $request_error->get_error_message() ], 403 );
+		$verified_params = \Newspack_Network\Utils\Requests::get_request_to_hub_errors( $request );
+		if ( \is_wp_error( $verified_params ) ) {
+			return new WP_REST_Response( [ 'error' => $verified_params->get_error_message() ], 403 );
 		}
 
+		// Read the request parameters from the verified (signed) payload, not the plaintext
+		// copies, so a man-in-the-middle can't tamper with the action list, the cursor, or
+		// the signed-response flag. The plaintext 'site' is fine to use for the Node lookup:
+		// it selected the secret that decrypted the signature, so it identifies the sender.
 		$site              = $request['site'];
-		$last_processed_id = $request['last_processed_id'];
-		$actions           = $request['actions'];
+		$last_processed_id = (int) ( $verified_params['last_processed_id'] ?? 0 );
+		$actions           = (array) ( $verified_params['actions'] ?? [] );
+		$signed_response   = ! empty( $verified_params['signed_response'] );
 
 		Debugger::log( sprintf( 'Pull request received from site %s, with last processed ID %d, for actions: %s.', $site, $last_processed_id, implode( ', ', $actions ) ) );
 
@@ -122,6 +128,25 @@ class Pull_Endpoint {
 			'data'  => $events_formatted,
 			'total' => $total_events,
 		];
+
+		// When the Node asked for a signed response, encrypt the body with the shared secret
+		// so a man-in-the-middle can't inject events into it. Older Nodes don't set the flag
+		// and get the body unencrypted, as before.
+		if ( $signed_response ) {
+			$response_nonce  = Crypto::generate_nonce();
+			$encrypted_body  = Crypto::encrypt_message( wp_json_encode( $response_body ), $node->get_secret_key(), $response_nonce );
+			if ( is_wp_error( $encrypted_body ) || ! is_string( $encrypted_body ) ) {
+				Debugger::log( 'Could not sign the pull response.' );
+				return new WP_REST_Response( [ 'error' => 'Could not sign response.' ], 500 );
+			}
+			return new WP_REST_Response(
+				[
+					'nonce' => $response_nonce,
+					'data'  => $encrypted_body,
+				]
+			);
+		}
+
 		return new WP_REST_Response( $response_body );
 	}
 }

--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -87,6 +87,12 @@ class Pull_Endpoint {
 		$actions           = (array) ( $verified_params['actions'] ?? [] );
 		$signed_response   = ! empty( $verified_params['signed_response'] );
 
+		// Defense-in-depth: cross-check the plaintext 'site' against the signed copy so a
+		// mismatch is rejected even if a future change makes the lookup tolerant of either.
+		if ( isset( $verified_params['site'] ) && $verified_params['site'] !== $site ) {
+			return new WP_REST_Response( [ 'error' => 'Site mismatch.' ], 403 );
+		}
+
 		Debugger::log( sprintf( 'Pull request received from site %s, with last processed ID %d, for actions: %s.', $site, $last_processed_id, implode( ', ', $actions ) ) );
 
 		if ( empty( $actions ) ) {

--- a/includes/hub/class-pull-endpoint.php
+++ b/includes/hub/class-pull-endpoint.php
@@ -73,7 +73,7 @@ class Pull_Endpoint {
 	 * @return WP_REST_Response
 	 */
 	public static function handle_pull( $request ) {
-		$verified_params = \Newspack_Network\Utils\Requests::get_request_to_hub_errors( $request );
+		$verified_params = \Newspack_Network\Utils\Requests::verify_request_to_hub( $request );
 		if ( \is_wp_error( $verified_params ) ) {
 			return new WP_REST_Response( [ 'error' => $verified_params->get_error_message() ], 403 );
 		}
@@ -133,8 +133,13 @@ class Pull_Endpoint {
 		// so a man-in-the-middle can't inject events into it. Older Nodes don't set the flag
 		// and get the body unencrypted, as before.
 		if ( $signed_response ) {
-			$response_nonce  = Crypto::generate_nonce();
-			$encrypted_body  = Crypto::encrypt_message( wp_json_encode( $response_body ), $node->get_secret_key(), $response_nonce );
+			$response_json = wp_json_encode( $response_body );
+			if ( false === $response_json ) {
+				Debugger::log( 'Could not encode the pull response.' );
+				return new WP_REST_Response( [ 'error' => 'Could not encode response.' ], 500 );
+			}
+			$response_nonce = Crypto::generate_nonce();
+			$encrypted_body = Crypto::encrypt_message( $response_json, $node->get_secret_key(), $response_nonce );
 			if ( is_wp_error( $encrypted_body ) || ! is_string( $encrypted_body ) ) {
 				Debugger::log( 'Could not sign the pull response.' );
 				return new WP_REST_Response( [ 'error' => 'Could not sign response.' ], 500 );

--- a/includes/incoming-events/class-user-deleted.php
+++ b/includes/incoming-events/class-user-deleted.php
@@ -39,7 +39,7 @@ class User_Deleted extends Abstract_Incoming_Event {
 	 */
 	public function process_user_deleted() {
 		$email = $this->get_email();
-		Debugger::log( 'Processing user deletion with email: ' . $email );
+		Debugger::log( sprintf( 'Processing user deletion for %s from %s.', $email, $this->get_site() ) );
 		if ( ! $email ) {
 			return;
 		}

--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -44,7 +44,7 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 	 */
 	public function maybe_sync_user() {
 		$email = $this->get_email();
-		Debugger::log( 'Processing user_manually_synced with email: ' . $email );
+		Debugger::log( sprintf( 'Processing user_manually_synced for %s from %s.', $email, $this->get_site() ) );
 		if ( ! $email ) {
 			return;
 		}

--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -104,13 +104,19 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 			}
 		}
 
-		// Loop through user props and update.
+		// Loop through user props and update. Roles are synced above via $data->role; the
+		// props and meta below are restricted to the fixed set of fields the user sync
+		// tracks, so an incoming payload can't write arbitrary props (user_pass, ...) or
+		// meta (_application_passwords, wp_capabilities, ...).
 		if ( isset( $data->prop ) ) {
-			$update_array = [
+			$incoming_props = (array) $data->prop;
+			$update_array   = [
 				'ID' => $user->ID,
 			];
-			foreach ( $data->prop as $prop_key => $prop_value ) {
-				$update_array[ $prop_key ] = $prop_value;
+			foreach ( User_Update_Watcher::$user_props as $prop_key ) {
+				if ( isset( $incoming_props[ $prop_key ] ) ) {
+					$update_array[ $prop_key ] = $incoming_props[ $prop_key ];
+				}
 			}
 			Debugger::log( 'Manually syncing user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			wp_update_user( $update_array );
@@ -118,9 +124,12 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 
 		// Loop through user meta and update.
 		if ( isset( $data->meta ) ) {
-			foreach ( $data->meta as $meta_key => $meta_value ) {
-				Debugger::log( 'Manually syncing user meta: ' . $meta_key );
-				update_user_meta( $user->ID, $meta_key, $meta_value );
+			$incoming_meta = (array) $data->meta;
+			foreach ( User_Update_Watcher::get_writable_meta() as $meta_key ) {
+				if ( isset( $incoming_meta[ $meta_key ] ) ) {
+					Debugger::log( 'Manually syncing user meta: ' . $meta_key );
+					update_user_meta( $user->ID, $meta_key, $incoming_meta[ $meta_key ] );
+				}
 			}
 
 			User_Utils::maybe_sideload_avatar( $user->ID, $data->meta, true );

--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -40,6 +40,14 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 	/**
 	 * Maybe updates a new WP user based on this event
 	 *
+	 * Unlike the background `User_Updated` receiver, this handler intentionally accepts
+	 * `$data->role` (including `administrator`) and `$data->user_login` without sanitization
+	 * or allowlisting. Manual sync is the documented way an admin on one site propagates an
+	 * admin role across the network, and the trust model assumes every Node in the network
+	 * is operated by the same operator. If that model ever changes, both fields must be
+	 * constrained here (sanitize `user_login` via `sanitize_user()`, restrict `role` to a
+	 * safe set).
+	 *
 	 * @return void
 	 */
 	public function maybe_sync_user() {

--- a/includes/incoming-events/class-user-manually-synced.php
+++ b/includes/incoming-events/class-user-manually-synced.php
@@ -118,8 +118,11 @@ class User_Manually_Synced extends Abstract_Incoming_Event {
 					$update_array[ $prop_key ] = $incoming_props[ $prop_key ];
 				}
 			}
-			Debugger::log( 'Manually syncing user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			wp_update_user( $update_array );
+			// Only update if at least one allowed prop is present; $update_array always has 'ID'.
+			if ( count( $update_array ) > 1 ) {
+				Debugger::log( 'Manually syncing user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				wp_update_user( $update_array );
+			}
 		}
 
 		// Loop through user meta and update.

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -58,12 +58,19 @@ class User_Updated extends Abstract_Incoming_Event {
 
 		$data = $this->get_data();
 
+		// Only the fixed set of profile fields and meta keys that the user sync tracks are
+		// applied. The incoming payload is signed by the sending site but not otherwise
+		// validated, so an arbitrary key (e.g. user_pass, role, wp_capabilities,
+		// _application_passwords) must never reach wp_update_user() / update_user_meta().
 		if ( isset( $data->prop ) ) {
-			$update_array = [
+			$incoming_props = (array) $data->prop;
+			$update_array   = [
 				'ID' => $existing_user->ID,
 			];
-			foreach ( $data->prop as $prop_key => $prop_value ) {
-				$update_array[ $prop_key ] = $prop_value;
+			foreach ( User_Update_Watcher::$user_props as $prop_key ) {
+				if ( isset( $incoming_props[ $prop_key ] ) ) {
+					$update_array[ $prop_key ] = $incoming_props[ $prop_key ];
+				}
 			}
 			Debugger::log( 'Updating user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 
@@ -71,9 +78,12 @@ class User_Updated extends Abstract_Incoming_Event {
 		}
 
 		if ( isset( $data->meta ) ) {
-			foreach ( $data->meta as $meta_key => $meta_value ) {
-				Debugger::log( 'Updating user meta: ' . $meta_key );
-				update_user_meta( $existing_user->ID, $meta_key, $meta_value );
+			$incoming_meta = (array) $data->meta;
+			foreach ( User_Update_Watcher::get_writable_meta() as $meta_key ) {
+				if ( isset( $incoming_meta[ $meta_key ] ) ) {
+					Debugger::log( 'Updating user meta: ' . $meta_key );
+					update_user_meta( $existing_user->ID, $meta_key, $incoming_meta[ $meta_key ] );
+				}
 			}
 
 			User_Utils::maybe_sideload_avatar( $existing_user->ID, $data->meta, true );

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -80,9 +80,11 @@ class User_Updated extends Abstract_Incoming_Event {
 				Debugger::log( sprintf( 'Ignoring email change for non-reader user %d via network sync.', $existing_user->ID ) );
 				unset( $update_array['user_email'] );
 			}
-			Debugger::log( 'Updating user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-
-			wp_update_user( $update_array );
+			// Only update if at least one allowed prop is present; $update_array always has 'ID'.
+			if ( count( $update_array ) > 1 ) {
+				Debugger::log( 'Updating user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				wp_update_user( $update_array );
+			}
 		}
 
 		if ( isset( $data->meta ) ) {

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -72,14 +72,6 @@ class User_Updated extends Abstract_Incoming_Event {
 					$update_array[ $prop_key ] = $incoming_props[ $prop_key ];
 				}
 			}
-			// A background sync event must not change the email address of a staff account:
-			// the email is the password-reset target, so a peer site could otherwise take
-			// over the account. Reader emails still sync (email is the reader's identity);
-			// a staff email change can still be pushed via manual sync.
-			if ( isset( $update_array['user_email'] ) && ! \Newspack\Reader_Activation::is_user_reader( $existing_user ) ) {
-				Debugger::log( sprintf( 'Ignoring email change for non-reader user %d via network sync.', $existing_user->ID ) );
-				unset( $update_array['user_email'] );
-			}
 			// Only update if at least one allowed prop is present; $update_array always has 'ID'.
 			if ( count( $update_array ) > 1 ) {
 				Debugger::log( 'Updating user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -43,7 +43,7 @@ class User_Updated extends Abstract_Incoming_Event {
 	 */
 	public function maybe_update_user() {
 		$email = $this->get_email();
-		Debugger::log( 'Processing user_updated with email: ' . $email );
+		Debugger::log( sprintf( 'Processing user_updated for %s from %s.', $email, $this->get_site() ) );
 		if ( ! $email ) {
 			return;
 		}

--- a/includes/incoming-events/class-user-updated.php
+++ b/includes/incoming-events/class-user-updated.php
@@ -72,6 +72,14 @@ class User_Updated extends Abstract_Incoming_Event {
 					$update_array[ $prop_key ] = $incoming_props[ $prop_key ];
 				}
 			}
+			// A background sync event must not change the email address of a staff account:
+			// the email is the password-reset target, so a peer site could otherwise take
+			// over the account. Reader emails still sync (email is the reader's identity);
+			// a staff email change can still be pushed via manual sync.
+			if ( isset( $update_array['user_email'] ) && ! \Newspack\Reader_Activation::is_user_reader( $existing_user ) ) {
+				Debugger::log( sprintf( 'Ignoring email change for non-reader user %d via network sync.', $existing_user->ID ) );
+				unset( $update_array['user_email'] );
+			}
 			Debugger::log( 'Updating user with data: ' . print_r( $update_array, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 
 			wp_update_user( $update_array );

--- a/includes/node/class-pulling.php
+++ b/includes/node/class-pulling.php
@@ -141,6 +141,7 @@ class Pulling {
 			'last_processed_id' => self::get_last_processed_id(),
 			'actions'           => Accepted_Actions::ACTIONS_THAT_NODES_PULL,
 			'site'              => get_bloginfo( 'url' ),
+			'signed_response'   => true,
 		];
 		$response = \Newspack_Network\Utils\Requests::request_to_hub( 'wp-json/newspack-network/v1/pull', $params );
 		if ( is_wp_error( $response ) ) {
@@ -226,7 +227,24 @@ class Pulling {
 			update_option( self::LAST_ERROR_OPTION_NAME, '' );
 		}
 		$response = json_decode( $response, true );
-		if ( ! is_array( $response['data'] ) ) {
+
+		// We always ask the Hub for a signed response (see make_request()), so the body must
+		// be the encrypted envelope: a nonce plus the ciphertext under the shared secret.
+		// Anything else (a plaintext body) is either a Hub that needs updating or a tampered
+		// response, and must not be processed.
+		if ( ! is_array( $response ) || empty( $response['nonce'] ) || ! isset( $response['data'] ) || ! is_string( $response['data'] ) ) {
+			self::handle_error( new \WP_Error( 'newspack-network-node-pull-unsigned-response', __( 'The Hub returned an unsigned pull response. Make sure the Hub is up to date.', 'newspack-network' ) ) );
+			return;
+		}
+
+		$verified = Crypto::decrypt_message( $response['data'], Settings::get_secret_key(), $response['nonce'] );
+		if ( false === $verified ) {
+			self::handle_error( new \WP_Error( 'newspack-network-node-pull-signature', __( 'Could not verify the Hub pull response signature.', 'newspack-network' ) ) );
+			return;
+		}
+
+		$response = json_decode( $verified, true );
+		if ( ! isset( $response['data'] ) || ! is_array( $response['data'] ) ) {
 			return;
 		}
 		self::process_pulled_data( $response['data'] );

--- a/includes/node/class-pulling.php
+++ b/includes/node/class-pulling.php
@@ -185,6 +185,12 @@ class Pulling {
 	 * @param array $events The events to process.
 	 */
 	public static function process_pulled_data( $events ) {
+		// Track the highest ID processed in this batch so the stored cursor only ever moves
+		// forward. AEAD on the pull response prevents forgery, but a previously-captured
+		// envelope can be replayed; clamping the cursor monotonically means a replay can't
+		// roll it backward and force re-fetching old events.
+		$last_processed_id = (int) self::get_last_processed_id();
+		$highest_id        = $last_processed_id;
 		foreach ( $events as $event ) {
 			$action    = $event['action'] ?? false;
 			$site      = $event['site'] ?? false;
@@ -193,6 +199,11 @@ class Pulling {
 			$id        = $event['id'] ?? false;
 
 			if ( ! $action || ! $id || ! $data || ! $timestamp ) {
+				continue;
+			}
+
+			// Skip events the cursor has already passed.
+			if ( (int) $id <= $last_processed_id ) {
 				continue;
 			}
 
@@ -206,7 +217,13 @@ class Pulling {
 
 			$incoming_event->process_in_node();
 
-			self::set_last_processed_id( $id );
+			if ( (int) $id > $highest_id ) {
+				$highest_id = (int) $id;
+			}
+		}
+
+		if ( $highest_id > $last_processed_id ) {
+			self::set_last_processed_id( $highest_id );
 		}
 	}
 
@@ -244,7 +261,8 @@ class Pulling {
 		}
 
 		$response = json_decode( $verified, true );
-		if ( ! isset( $response['data'] ) || ! is_array( $response['data'] ) ) {
+		if ( ! is_array( $response ) || ! isset( $response['data'] ) || ! is_array( $response['data'] ) ) {
+			self::handle_error( new \WP_Error( 'newspack-network-node-pull-malformed-response', __( 'The Hub returned a signed pull response with an unexpected structure.', 'newspack-network' ) ) );
 			return;
 		}
 		self::process_pulled_data( $response['data'] );

--- a/includes/utils/class-requests.php
+++ b/includes/utils/class-requests.php
@@ -52,10 +52,14 @@ class Requests {
 	}
 
 	/**
-	 * Validate a request.
+	 * Validate a request to the Hub and return its authenticated parameters.
+	 *
+	 * The signature is verified against the requesting Node's secret key; on success the
+	 * decrypted request parameters are returned so callers can use those instead of the
+	 * plaintext copies (which a man-in-the-middle could tamper with).
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
-	 * @return bool|WP_Error True if the request is valid, WP_Error otherwise.
+	 * @return array|WP_Error The verified request parameters, or WP_Error if verification failed.
 	 */
 	public static function get_request_to_hub_errors( $request ) {
 		$site      = $request['site'];
@@ -76,13 +80,13 @@ class Requests {
 			return new WP_Error( 'newspack_network_bad_request_node_not_found', __( 'Bad request. Site not registered in this Hub', 'newspack-network' ) );
 		}
 
-		$verified         = $node->decrypt_message( $signature, $nonce );
-		$verified_message = json_decode( $verified );
-		if ( ! $verified || ! is_object( $verified_message ) ) {
+		$verified = $node->decrypt_message( $signature, $nonce );
+		$params   = is_string( $verified ) ? json_decode( $verified, true ) : null;
+		if ( ! is_array( $params ) ) {
 			\Newspack_Network\Debugger::log( 'Signature check failed' );
 			return new WP_Error( 'newspack_network_bad_request_signature', __( 'Bad request. Invalid signature.', 'newspack-network' ) );
 		}
 
-		return true;
+		return $params;
 	}
 }

--- a/includes/utils/class-requests.php
+++ b/includes/utils/class-requests.php
@@ -61,7 +61,7 @@ class Requests {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return array|WP_Error The verified request parameters, or WP_Error if verification failed.
 	 */
-	public static function get_request_to_hub_errors( $request ) {
+	public static function verify_request_to_hub( $request ) {
 		$site      = $request['site'];
 		$signature = $request['signature'];
 		$nonce     = $request['nonce'];

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -131,7 +131,7 @@ class Users {
 			$user_data = (array) $user_data;
 		}
 
-		if ( array_key_exists( $avatar_meta_key, $user_data ) && ! empty( $user_data[ $avatar_meta_key ]['full'] ) ) {
+		if ( array_key_exists( $avatar_meta_key, $user_data ) && is_array( $user_data[ $avatar_meta_key ] ) && ! empty( $user_data[ $avatar_meta_key ]['full'] ) ) {
 			$avatar_url = $user_data[ $avatar_meta_key ]['full'];
 
 			// The avatar URL comes from the network event payload and is fetched server-side

--- a/includes/utils/class-users.php
+++ b/includes/utils/class-users.php
@@ -132,8 +132,18 @@ class Users {
 		}
 
 		if ( array_key_exists( $avatar_meta_key, $user_data ) && ! empty( $user_data[ $avatar_meta_key ]['full'] ) ) {
-			Debugger::log( 'Updating user avatar' );
 			$avatar_url = $user_data[ $avatar_meta_key ]['full'];
+
+			// The avatar URL comes from the network event payload and is fetched server-side
+			// (media_sideload_image -> download_url -> wp_remote_get, which does not block
+			// private/reserved hosts), so a peer could otherwise make this site request an
+			// internal address (SSRF). Reject anything that isn't a valid external URL.
+			if ( ! is_string( $avatar_url ) || ! wp_http_validate_url( $avatar_url ) ) {
+				Debugger::log( 'Avatar URL is not a valid external URL, skipping sideload' );
+				return false;
+			}
+
+			Debugger::log( 'Updating user avatar' );
 
 			if ( ! function_exists( 'media_sideload_image' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/media.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Two pieces of hardening on the Hub/Node sync, neither of which changes what the sync features do (automatic profile/role sync and the "Sync user across network" button — including an admin propagating an admin — all work as before):

- **(a) receive-side robustness on the user-sync event handlers**, and
- **(b) man-in-the-middle hardening of the pull channel.**

Note on scope: a Newspack Network treats all member sites as trusted participants, so this PR is *not* about defending against a malicious Node. It's about (a) not letting a bug or plugin interaction on a Node push fields the sync was never meant to carry, and (b) not letting an attacker *on the wire between a Node and the Hub* (a proxy/CDN/WAF in the path, a TLS misconfig, DNS hijack) inject events — a wire attacker isn't a Node.

**1. Allowlist incoming `prop` / `meta`** (`User_Updated`, `User_Manually_Synced`)

`maybe_update_user()` / `maybe_sync_user()` copied every `data->prop` into `wp_update_user()` and every `data->meta` into `update_user_meta()` with no allowlist — so a malformed/bug-produced payload could write things like `user_pass`, `wp_capabilities`, `_application_passwords`, `np_reader_email_verified`, none of which the sync legitimately emits. Now restricted to `User_Update_Watcher::$user_props` and `User_Update_Watcher::get_writable_meta()` — exactly the keys the legitimate sync produces (`User_Update_Watcher` for `network_user_updated`, `User_Manual_Sync::manual_sync_user()` for `network_manual_sync_user`). This is the allowlist already used by `class-author-ingestion.php` and `class-incoming-post.php`; these two handlers were the only user-writing paths that didn't use it. `wp_update_user()` is also skipped when no allowed prop is present (the array would contain only `ID`). Role propagation and auto-create in `User_Manually_Synced` are untouched.

**2. Avatar sideload is SSRF-guarded** (`Users::maybe_sideload_avatar()`)

The avatar URL comes from the event payload and is fetched server-side (`media_sideload_image()` → `download_url()` → `wp_remote_get()`, which does not block private/reserved hosts). It's now validated with `wp_http_validate_url()` before sideloading. Fixed in the shared util, so the author-ingestion and incoming-post callers are covered too. (Used `wp_http_validate_url()` rather than scoping to the originating host so legitimately CDN'd avatar URLs — e.g. Jetpack Site Accelerator rewrites attachment URLs to `i*.wp.com` — keep working.)

**3. The Hub pull response is signed; request params are authenticated** (`Pull_Endpoint`, `Pulling`, `Requests`)

The Node's pull *request* was signed, but `Pull_Endpoint::handle_pull()` returned the event list in cleartext and read `actions` / `last_processed_id` from the *plaintext* request params (not the signed payload). A man-in-the-middle on the Node↔Hub link could therefore rewrite the response to inject any pullable event (e.g. `network_manual_sync_user` creating an administrator) or tamper with the request. Now:

- `Requests::get_request_to_hub_errors()` returns the decrypted request parameters; `handle_pull()` reads `actions` / `last_processed_id` / the signed-response flag from those, not the spoofable plaintext.
- The Node always asks for a signed response; the Hub encrypts the response body with the shared secret; the Node decrypts it and refuses to process an unsigned or unverifiable response. Older Nodes that don't set the flag still get the plain body, so a freshly-updated Hub doesn't break them.

### How to test the changes in this Pull Request:

1. Set up a Hub + Node (`n setup` on two sites, one hub, one node). Confirm normal sync still works: register a reader on the Node → propagates to the Hub; edit a reader's profile / social link / billing / email → propagates.
2. Edit an admin on the Node and click **Sync user across network** — confirm the user and their role (`administrator`) propagate and the account is created on peers. Also confirm an admin's profile edits (incl. email) propagate via the automatic `network_user_updated` event.
3. Trigger a Node pull (wait for the cron or use the manual pull button); confirm events still flow. Then point the Node's hub URL at something that returns a cleartext `{data:[...],total:N}` body — confirm the Node logs an "unsigned pull response" error and processes nothing.
4. Send a crafted `network_user_updated` webhook to the Hub for an existing user's email with `prop: { user_pass, … }` and `meta: { _application_passwords, np_reader_email_verified, wp_capabilities, … }` — confirm none of those keys are written; the `User_Update_Watcher` profile/meta keys still are.
5. Run `n test-php` in `newspack-network`.

### Other information:

- PHPCS passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)