### PR TITLE
fix(woo-memberships): guard membership_deleted against null plan

### DIFF
--- a/includes/woocommerce-memberships/class-events.php
+++ b/includes/woocommerce-memberships/class-events.php
@@ -112,8 +112,13 @@ class Events {
 		if ( ! $user ) {
 			return;
 		}
+		$plan = $user_membership->get_plan();
+		if ( ! $plan ) {
+			// Plan post was already deleted (e.g. via `wp_delete_auto_drafts` cascading into membership deletion).
+			return;
+		}
 		$user_email = $user->user_email;
-		$plan_id    = $user_membership->get_plan()->get_id();
+		$plan_id    = $plan->get_id();
 
 		$plan_network_id = get_post_meta( $plan_id, Admin::NETWORK_ID_META_KEY, true );
 		if ( ! $plan_network_id ) {

--- a/tests/unit-tests/test-membership-deleted-event.php
+++ b/tests/unit-tests/test-membership-deleted-event.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class TestMembershipDeletedEvent
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Woocommerce_Memberships\Events as Memberships_Events;
+
+require_once __DIR__ . '/mock-wc-memberships.php';
+
+/**
+ * Test Events::membership_deleted() handling of a missing parent plan.
+ *
+ * @group membership-deleted-event
+ */
+class TestMembershipDeletedEvent extends WP_UnitTestCase {
+
+	/**
+	 * Calling membership_deleted() with a membership whose plan has been deleted must not fatal.
+	 *
+	 * Reproduces the production fatal observed at v2.20.0 of newspack-network:
+	 *   Uncaught Error: Call to a member function get_id() on false
+	 *   in includes/woocommerce-memberships/class-events.php:116
+	 * Triggered when `wp_delete_auto_drafts` cascades into membership deletion after the
+	 * parent plan post is already gone, so `$user_membership->get_plan()` returns false.
+	 */
+	public function test_does_not_fatal_when_plan_is_null() {
+		$user_id   = $this->factory->user->create( [ 'user_email' => 'stub@example.com' ] );
+		$test_user = get_user_by( 'id', $user_id );
+
+		$membership_stub = new class( $test_user ) {
+			/**
+			 * Backing user returned by get_user().
+			 *
+			 * @var \WP_User
+			 */
+			private $user;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param \WP_User $user Backing user.
+			 */
+			public function __construct( $user ) {
+				$this->user = $user;
+			}
+
+			/**
+			 * Return the backing user.
+			 *
+			 * @return \WP_User
+			 */
+			public function get_user() {
+				return $this->user;
+			}
+
+			/**
+			 * Return false to reproduce the production fatal path.
+			 *
+			 * @return false
+			 */
+			public function get_plan() {
+				return false;
+			}
+
+			/**
+			 * Return the membership id.
+			 *
+			 * @return int
+			 */
+			public function get_id() {
+				return 42;
+			}
+		};
+
+		$result = Memberships_Events::membership_deleted( $membership_stub );
+		$this->assertNull( $result );
+	}
+}

--- a/tests/unit-tests/test-membership-deleted-event.php
+++ b/tests/unit-tests/test-membership-deleted-event.php
@@ -19,13 +19,12 @@ class TestMembershipDeletedEvent extends WP_UnitTestCase {
 	/**
 	 * Calling membership_deleted() with a membership whose plan has been deleted must not fatal.
 	 *
-	 * Reproduces the production fatal observed at v2.20.0 of newspack-network:
+	 * Reproduces the production fatal:
 	 *   Uncaught Error: Call to a member function get_id() on false
-	 *   in includes/woocommerce-memberships/class-events.php:116
 	 * Triggered when `wp_delete_auto_drafts` cascades into membership deletion after the
 	 * parent plan post is already gone, so `$user_membership->get_plan()` returns false.
 	 */
-	public function test_does_not_fatal_when_plan_is_null() {
+	public function test_does_not_fatal_when_plan_is_missing() {
 		$user_id   = $this->factory->user->create( [ 'user_email' => 'stub@example.com' ] );
 		$test_user = get_user_by( 'id', $user_id );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Newspack_Network\Woocommerce_Memberships\Events::membership_deleted()` fatals when the parent plan post has already been deleted. The call chain `$user_membership->get_plan()->get_id()` throws `Uncaught Error: Call to a member function get_id() on false` because `get_plan()` returns `false` once the plan post is gone.

The most common trigger in production is the `wp_delete_auto_drafts` cron: deleting a plan auto-draft cascades through WC Memberships' `delete_related_data`, which fires `wc_memberships_user_membership_deleted` on memberships whose plan no longer exists. The data event being produced has no meaningful `plan_network_id` once the plan is gone, so bailing out is the correct behavior.

This adds a guard mirroring the existing `! $user` early-return.

### How to test the changes in this Pull Request:

1. On a site with WC Memberships active, create a membership plan and assign it to a user.
2. Delete the plan post directly (`wp post delete <plan_id> --force` or via the admin). Confirm no PHP fatal is logged when the cascade fires.
3. Run the included unit test from the plugin directory: `composer test -- --filter test_does_not_fatal_when_plan_is_null`. It must pass; without the fix it errors with `Call to a member function get_id() on false`.
4. Regression: verify normal membership deletion (plan still present) continues to emit the `newspack_network_woo_membership_updated` data event with `new_status: __deleted`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?