### PR TITLE
Fix critical npm dependency alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11409,9 +11409,9 @@
 			}
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -17472,9 +17472,9 @@
 			"license": "MIT"
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
 	},
 	"devDependencies": {
 		"newspack-scripts": "^5.9.8"
+	},
+	"overrides": {
+		"basic-ftp": "5.3.1",
+		"handlebars": "4.7.9"
 	}
 }


### PR DESCRIPTION
## Summary
- Add targeted npm overrides for patched basic-ftp and handlebars releases.
- Refresh package-lock.json so the current Dependabot critical alerts resolve to patched versions.
- Leave the existing high, medium, and low alert backlog for a separate pass.

## Validation
- npm ci
- npm ls handlebars basic-ftp --all
- npm audit --audit-level=critical
- npm run lint
- npm run build
- npm test
- git diff --check

## Notes
- Dependabot alerts are now enabled for this repository.
- Dependabot security updates remain disabled; this PR only addresses the critical alerts found after enabling alerts.